### PR TITLE
Substitute %player% into vote site URLs.

### DIFF
--- a/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/Commands/Commands.java
+++ b/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/Commands/Commands.java
@@ -834,6 +834,7 @@ public class Commands {
 				msg = StringUtils.getInstance().replaceIgnoreCase(msg, "%num%", Integer.toString(counter));
 				msg = StringUtils.getInstance().replaceIgnoreCase(msg, "%url%", voteURL);
 				msg = StringUtils.getInstance().replaceIgnoreCase(msg, "%SiteName%", voteSite.getDisplayName());
+				msg = StringUtils.getInstance().replaceIgnoreCase(msg, "%player%", user.getPlayerName());
 				sites.add(msg);
 			}
 		}


### PR DESCRIPTION
Substitute `%player%` into the `VoteSites.<id>.VoteURL` setting
from `VoteSites.yml` to support pre-fill of player name in
`/vote` command output.

Example `VoteSites.yml`:

    VoteURL: some-voting-site.com/server/123456/vote/?username=%player%

Side note: (I'm not currently using it, but...) commands like `/vote next` would probably benefit from the same sort of treatment - of being able to show the site URL with the player name substituted in.