### PR TITLE
added option "DisableLineBreaking" to prevent that items are corruped

### DIFF
--- a/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/Objects/VoteSite.java
+++ b/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/Objects/VoteSite.java
@@ -175,7 +175,11 @@ public class VoteSite {
 			return new ItemBuilder(Material.STONE, 1).setName("&cInvalid item for site: " + key)
 					.setLore("&cInvalid item for site: " + key);
 		} else {
-			return new ItemBuilder(item);
+			ItemBuilder builder = new ItemBuilder(item);
+			if(item.getBoolean("DisableLineBreaking")) {
+				builder.dontCheckLoreLength();
+			}
+			return builder;
 		}
 	}
 


### PR DESCRIPTION
Our item, that is given to the player is a little bit more complex. We check with other plugins, if the item equals a specific item. The line breaking of the lore, beak this compare. In reason of that, i added a option, to siable this line beaking.

I am sure, there are other options to solve this problem, but i prefere this. It would be nice, to have this solution in the plugin, to solve this problem.