### PR TITLE
More reminding options

### DIFF
--- a/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/VoteReminding/VoteReminding.java
+++ b/VotingPlugin/src/com/Ben12345rocks/VotingPlugin/VoteReminding/VoteReminding.java
@@ -58,7 +58,7 @@ public class VoteReminding {
 
 		if (PlayerUtils.getInstance().hasServerPermission(playerName, "VotingPlugin.Login.RemindVotes")
 				|| PlayerUtils.getInstance().hasServerPermission(playerName, "VotingPlugin.Player")) {
-			if (user.canVoteAll()) {
+			if (user.canVoteAll() || (user.canVoteAny() && user.hasPermission("VotingPlugin.Login.RemindVotes.Any"))) {
 				Player player = Bukkit.getPlayer(playerName);
 				if (player != null) {
 					if (!Config.getInstance().getVoteRemindingRemindOnlyOnce()) {


### PR DESCRIPTION
With this change, players with the votingplugin.login.remindvotes.any permission will be reminded to vote as long as they can vote on any of their voting sites.

Previously, players would only be reminded if they could vote on ALL sites.