### PR TITLE
Prevent clients from sending plugin messages

### DIFF
--- a/VotingPlugin/src/com/bencodez/votingplugin/bungee/VotingPluginBungee.java
+++ b/VotingPlugin/src/com/bencodez/votingplugin/bungee/VotingPluginBungee.java
@@ -36,6 +36,7 @@ import lombok.Getter;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.event.PostLoginEvent;
 import net.md_5.bungee.api.event.ServerConnectedEvent;

--- a/VotingPlugin/src/com/bencodez/votingplugin/bungee/VotingPluginBungee.java
+++ b/VotingPlugin/src/com/bencodez/votingplugin/bungee/VotingPluginBungee.java
@@ -379,6 +379,12 @@ public class VotingPluginBungee extends Plugin implements net.md_5.bungee.api.pl
 		if (!ev.getTag().equals("vp:vp".toLowerCase())) {
 			return;
 		}
+		
+		ev.setCancelled(true);
+		
+		if (!(ev.getSender() instanceof Server))
+			return;
+		
 		ByteArrayInputStream instream = new ByteArrayInputStream(ev.getData());
 		DataInputStream in = new DataInputStream(instream);
 		try {


### PR DESCRIPTION
Clients can send data over the plugin message channels the same way servers can. Canceling the event and returning if the message was not sent by the Server fixes the issue.
In the worst-case scenario, the server will crash if the client sends invalid data, due to how this plugin attempts to continually load the message.
In the best-case scenario, the user could fake anyone's voting data and whatever else this plugin uses messaging channels for.

Here is a quick gif of me sending a custom payload to exploit this issue. (Cut to the most important parts).
![exploit](https://media.giphy.com/media/ywB8RrKoZJ5tlcWQh5/giphy.gif)

Close up of the stacktrace, since I just noticed the gif is tiny and unreadable.
![close-up](https://i.imgur.com/166apKI.png)

If you need help in reproducing the issue for yourself, feel free to contact me.