### PR TITLE
Fix issue with RedisHandler initialization utilizing wrong parameters

### DIFF
--- a/VotingPlugin/src/com/bencodez/votingplugin/BungeeHandler.java
+++ b/VotingPlugin/src/com/bencodez/votingplugin/BungeeHandler.java
@@ -598,7 +598,7 @@ public class BungeeHandler implements Listener {
 			plugin.registerBungeeChannels("vp:vp");
 		} else if (method.equals(BungeeMethod.REDIS)) {
 			redisHandler = new RedisHandler(plugin.getBungeeSettings().getRedisHost(),
-					plugin.getBungeeSettings().getRedisPort(), plugin.getBungeeSettings().getRedisPassword(),
+					plugin.getBungeeSettings().getRedisPort(), plugin.getBungeeSettings().getRedisUsername(),
 					plugin.getBungeeSettings().getRedisPassword()) {
 
 				@Override


### PR DESCRIPTION
Currently the password is being used instead of the username parameter, simple fix!