### PR TITLE
Added variable %sitename% to placeholders of Commands.Vote.Today.Line

### DIFF
--- a/VotingPlugin/src/com/bencodez/votingplugin/commands/gui/player/VoteToday.java
+++ b/VotingPlugin/src/com/bencodez/votingplugin/commands/gui/player/VoteToday.java
@@ -155,6 +155,7 @@ public class VoteToday extends GUIHandler {
 				HashMap<String, String> placeholders = new HashMap<>();
 				placeholders.put("player", user.getPlayerName());
 				placeholders.put("votesite", voteSite.getKey());
+                                placeholders.put("sitename", voteSite.getDisplayName());
 				placeholders.put("time", timeString);
 				msg.add(PlaceholderUtils.replacePlaceHolder(plugin.getConfigFile().getFormatCommandsVoteTodayLine(),
 						placeholders));
@@ -184,6 +185,7 @@ public class VoteToday extends GUIHandler {
 				HashMap<String, String> placeholders = new HashMap<>();
 				placeholders.put("player", user.getPlayerName());
 				placeholders.put("votesite", mostRecentSite.getKey());
+                                placeholders.put("sitename", mostRecentSite.getDisplayName());
 				placeholders.put("time", timeString);
 				msg.add(PlaceholderUtils.replacePlaceHolder(plugin.getConfigFile().getFormatCommandsVoteTodayLine(),
 						placeholders));


### PR DESCRIPTION
Greetings!

While configuring the UI to look visually appealing, I noticed how the key `Commands.Vote.Today.Line` only supported the placeholder `%votesite%`, which represents the config-key of the corresponding vote-site, but not its displayname; as to unify the appearance, I added another placeholder called `%sitename%` (as commonly called in various other locations), which resolves to the desired value.

I hope we can get this little change merged, so that I do not need to maintain my own fork.

Best Regards,
BlvckBytes