### PR TITLE
Support recurring vote-streak rewards and migrate legacy streak config/state

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakDefinition.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakDefinition.java
@@ -20,9 +20,11 @@ public final class VoteStreakDefinition {
 
 	@Getter
 	private final int votesRequired;
+	@Getter
+	private final boolean recurring;
 
 	public VoteStreakDefinition(String id, VoteStreakType type, boolean enabled, int requiredAmount, int votesRequired,
-			int allowMissedAmount, int allowMissedPeriod) {
+			int allowMissedAmount, int allowMissedPeriod, boolean recurring) {
 		this.id = id;
 		this.type = type;
 		this.enabled = enabled;
@@ -30,6 +32,7 @@ public final class VoteStreakDefinition {
 		this.allowMissedAmount = Math.max(0, allowMissedAmount);
 		this.allowMissedPeriod = Math.max(0, allowMissedPeriod);
 		this.votesRequired = Math.max(1, votesRequired);
+		this.recurring = recurring;
 	}
 
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -548,14 +548,21 @@ public class VoteStreakHandler {
 			if (legacy == null) {
 				return false;
 			}
+			ConfigurationSection voteStreaks = root.getConfigurationSection("VoteStreaks");
+			if (voteStreaks == null) {
+				voteStreaks = root.createSection("VoteStreaks");
+			}
 			boolean any = false;
-			any |= loadLegacyType(legacy, "Day", VoteStreakType.DAILY);
-			any |= loadLegacyType(legacy, "Week", VoteStreakType.WEEKLY);
-			any |= loadLegacyType(legacy, "Month", VoteStreakType.MONTHLY);
+			any |= loadLegacyType(voteStreaks, legacy, "Day", VoteStreakType.DAILY);
+			any |= loadLegacyType(voteStreaks, legacy, "Week", VoteStreakType.WEEKLY);
+			any |= loadLegacyType(voteStreaks, legacy, "Month", VoteStreakType.MONTHLY);
+			if (any) {
+				plugin.getSpecialRewardsConfig().saveData();
+			}
 			return any;
 		}
 
-		private boolean loadLegacyType(ConfigurationSection legacy, String key, VoteStreakType type) {
+		private boolean loadLegacyType(ConfigurationSection voteStreaks, ConfigurationSection legacy, String key, VoteStreakType type) {
 			ConfigurationSection sec = legacy.getConfigurationSection(key);
 			if (sec == null) return false;
 			boolean any = false;
@@ -570,6 +577,20 @@ public class VoteStreakHandler {
 				boolean enabled = defSec.getBoolean("Enabled", true);
 				defSec.set("Enabled", false);
 				String id = "Legacy" + type.name() + amount + (recurring ? "Recurring" : "OneTime");
+				if (voteStreaks.getConfigurationSection(id) == null) {
+					ConfigurationSection migrated = voteStreaks.createSection(id);
+					migrated.set("Type", type.name());
+					migrated.set("Enabled", enabled);
+					migrated.set("Recurring", recurring);
+					ConfigurationSection req = migrated.createSection("Requirements");
+					req.set("Amount", amount);
+					req.set("VotesRequired", 1);
+					migrated.set("AllowMissedAmount", 0);
+					migrated.set("AllowMissedPeriod", 0);
+					if (defSec.getConfigurationSection("Rewards") != null) {
+						migrated.set("Rewards", defSec.getConfigurationSection("Rewards").getValues(true));
+					}
+				}
 				VoteStreakDefinition def = new VoteStreakDefinition(id, type, enabled, amount, 1, 0, 0, recurring);
 				plugin.getUserManager().getDataManager()
 						.addKey(new UserDataKeyString(getColumnName(def)).setColumnType("MEDIUMTEXT"));
@@ -635,7 +656,6 @@ public class VoteStreakHandler {
 				}
 
 				boolean enabled = defSec.getBoolean("Enabled", true);
-				defSec.set("Enabled", false);
 
 				int amountInterval = 0;
 				int votesRequired = 1;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -100,6 +100,38 @@ public class VoteStreakHandler {
 		}
 	}
 
+
+	private int getLegacyStreakProgress(VotingPluginUser user, VoteStreakType type) {
+		switch (type) {
+		case DAILY:
+			return Math.max(0, user.getDayVoteStreak());
+		case WEEKLY:
+			return Math.max(0, user.getWeekVoteStreak());
+		case MONTHLY:
+			return Math.max(0, user.getMonthVoteStreak());
+		default:
+			return 0;
+		}
+	}
+
+	private void migrateLegacyProgressIfNeeded(VotingPluginUser user, VoteStreakDefinition def, StreakState state,
+			String currentPeriodKey) {
+		if (state.periodKey != null && !state.periodKey.isEmpty()) {
+			return;
+		}
+		int legacyProgress = getLegacyStreakProgress(user, def.getType());
+		if (legacyProgress <= 0) {
+			return;
+		}
+		state.periodKey = currentPeriodKey;
+		state.streakCount = legacyProgress;
+		state.votesThisPeriod = 0;
+		state.countedThisPeriod = false;
+		state.missWindowStartKey = "";
+		state.missesUsed = 0;
+		plugin.extraDebug("[VoteStreak] migrated legacy progress for " + def.getId() + ": " + legacyProgress);
+	}
+
 	private void processVoteForDefinition(VotingPluginUser user, VoteStreakDefinition def, long voteTimeMillis,
 			UUID voteUUID) {
 		final String col = getColumnName(def);
@@ -107,6 +139,7 @@ public class VoteStreakHandler {
 		StreakState state = StreakState.deserialize(rawBefore);
 
 		final String currentPeriodKey = periodKey(def.getType(), voteTimeMillis);
+		migrateLegacyProgressIfNeeded(user, def, state, currentPeriodKey);
 
 		plugin.extraDebug("[VoteStreak] def=" + def.getId() + " idKey=" + def.getId() + " type=" + def.getType()
 				+ " col=" + col + " period=" + currentPeriodKey + " votesReq=" + def.getVotesRequired() + " interval="
@@ -146,7 +179,9 @@ public class VoteStreakHandler {
 				state.streakCount++;
 
 				int interval = Math.max(1, def.getRequiredAmount());
-				boolean shouldReward = state.streakCount > 0 && (state.streakCount % interval) == 0;
+				boolean shouldReward = def.isRecurring() ?
+						(state.streakCount > 0 && (state.streakCount % interval) == 0)
+						: (state.streakCount == interval);
 
 				plugin.extraDebug("[VoteStreak] period satisfied: streakCount=" + state.streakCount + " interval="
 						+ interval + " shouldReward=" + shouldReward);
@@ -507,6 +542,43 @@ public class VoteStreakHandler {
 
 	public final class VoteStreakConfigLoader {
 
+
+		private boolean loadLegacy(ConfigurationSection root) {
+			ConfigurationSection legacy = root.getConfigurationSection("VoteStreak");
+			if (legacy == null) {
+				return false;
+			}
+			boolean any = false;
+			any |= loadLegacyType(legacy, "Day", VoteStreakType.DAILY);
+			any |= loadLegacyType(legacy, "Week", VoteStreakType.WEEKLY);
+			any |= loadLegacyType(legacy, "Month", VoteStreakType.MONTHLY);
+			return any;
+		}
+
+		private boolean loadLegacyType(ConfigurationSection legacy, String key, VoteStreakType type) {
+			ConfigurationSection sec = legacy.getConfigurationSection(key);
+			if (sec == null) return false;
+			boolean any = false;
+			for (String streakKey : sec.getKeys(false)) {
+				ConfigurationSection defSec = sec.getConfigurationSection(streakKey);
+				if (defSec == null) continue;
+				String normalized = streakKey.replace("-", "");
+				if (!MessageAPI.isInt(normalized)) continue;
+				int amount = Integer.parseInt(normalized);
+				if (amount <= 0) continue;
+				boolean recurring = streakKey.contains("-");
+				boolean enabled = defSec.getBoolean("Enabled", true);
+				defSec.set("Enabled", false);
+				String id = "Legacy" + type.name() + amount + (recurring ? "Recurring" : "OneTime");
+				VoteStreakDefinition def = new VoteStreakDefinition(id, type, enabled, amount, 1, 0, 0, recurring);
+				plugin.getUserManager().getDataManager()
+						.addKey(new UserDataKeyString(getColumnName(def)).setColumnType("MEDIUMTEXT"));
+				byId.put(id, def);
+				ordered.add(def);
+				any = true;
+			}
+			return any;
+		}
 		private final Pattern idPattern = Pattern.compile("^[A-Za-z0-9_\\-]+$"); // no spaces
 
 		public void load(ConfigurationSection root) {
@@ -516,7 +588,11 @@ public class VoteStreakHandler {
 			}
 
 			ConfigurationSection voteStreaks = root.getConfigurationSection("VoteStreaks");
-			if (voteStreaks == null) {
+			if (voteStreaks == null || voteStreaks.getKeys(false).isEmpty()) {
+				if (loadLegacy(root)) {
+					plugin.getLogger().info("Loaded " + ordered.size() + " VoteStreak definitions from legacy VoteStreak section.");
+					return;
+				}
 				plugin.getLogger().warning("VoteStreaks is missing or not a section; no streaks loaded.");
 				return;
 			}
@@ -559,6 +635,7 @@ public class VoteStreakHandler {
 				}
 
 				boolean enabled = defSec.getBoolean("Enabled", true);
+				defSec.set("Enabled", false);
 
 				int amountInterval = 0;
 				int votesRequired = 1;
@@ -579,11 +656,10 @@ public class VoteStreakHandler {
 
 				int allowMissedAmount = Math.max(0, defSec.getInt("AllowMissedAmount", 0));
 				int allowMissedPeriod = Math.max(0, defSec.getInt("AllowMissedPeriod", 0));
-
-				// ConfigurationSection editableTarget = getOrCreateVoteStreakSection(id);
+				boolean recurring = defSec.getBoolean("Recurring", true);
 
 				VoteStreakDefinition def = new VoteStreakDefinition(id, type, enabled, amountInterval, votesRequired,
-						allowMissedAmount, allowMissedPeriod);
+						allowMissedAmount, allowMissedPeriod, recurring);
 
 				plugin.getUserManager().getDataManager()
 						.addKey(new UserDataKeyString(getColumnName(def)).setColumnType("MEDIUMTEXT"));

--- a/VotingPlugin/src/main/resources/SpecialRewards.yml
+++ b/VotingPlugin/src/main/resources/SpecialRewards.yml
@@ -193,6 +193,8 @@ VoteStreaks:
       VotesRequired: 3
     AllowMissedAmount: 1
     AllowMissedPeriod: 7
+    # true = reward every N streak completions, false = reward only once at N
+    Recurring: true
     Rewards:
       Commands:
       - say test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -30,7 +30,6 @@ import com.bencodez.votingplugin.specialrewards.votestreak.VoteStreakType;
 import com.bencodez.votingplugin.user.VotingPluginUser;
 
 class VoteStreakHandlerTest {
-
 	private VotingPluginMain plugin;
 	private TimeChecker timeChecker;
 	private VoteStreakHandler handler;
@@ -39,13 +38,9 @@ class VoteStreakHandlerTest {
 	void setup() {
 		plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
 		timeChecker = mock(TimeChecker.class);
-
 		when(plugin.getTimeChecker()).thenReturn(timeChecker);
 		when(timeChecker.getTime()).thenReturn(LocalDateTime.of(2026, 1, 10, 12, 0));
-		when(plugin.getLogger()).thenReturn(Logger.getLogger("VoteStreakHandlerTest"));
-		
 		when(plugin.getLogger()).thenReturn(silentLogger());
-
 		handler = new VoteStreakHandler(plugin);
 	}
 
@@ -53,53 +48,39 @@ class VoteStreakHandlerTest {
 		VotingPluginUser user = mock(VotingPluginUser.class);
 		when(user.getJavaUUID()).thenReturn(uuid);
 		when(user.getPlayerName()).thenReturn(name);
-
 		when(user.getVoteStreakState(anyString())).thenAnswer(inv -> backing.get(inv.getArgument(0, String.class)));
-
 		doAnswer(inv -> {
 			backing.put(inv.getArgument(0, String.class), inv.getArgument(1, String.class));
 			return null;
 		}).when(user).setVoteStreakState(anyString(), anyString());
-
 		return user;
 	}
-	
 
 	private static Logger silentLogger() {
-	    Logger l = Logger.getLogger("silent-test-logger");
-	    l.setUseParentHandlers(false);   // <- key: stops ConsoleHandler printing
-	    l.setLevel(Level.OFF);           // or Level.WARNING if you want warnings
-	    // also remove any handlers that might already be attached
-	    java.util.logging.Handler[] hs = l.getHandlers();
-	    for (java.util.logging.Handler h : hs) {
-	        l.removeHandler(h);
-	    }
-	    return l;
+		Logger l = Logger.getLogger("silent-test-logger");
+		l.setUseParentHandlers(false);
+		l.setLevel(Level.OFF);
+		for (java.util.logging.Handler h : l.getHandlers()) {
+			l.removeHandler(h);
+		}
+		return l;
 	}
 
-
 	private static MemoryConfiguration rootWithOneStreak(String id, String type, boolean enabled, int intervalAmount,
-			int votesRequired, int allowMissedAmount, int allowMissedPeriod) {
-
+			int votesRequired, int allowMissedAmount, int allowMissedPeriod, boolean recurring) {
 		MemoryConfiguration root = new MemoryConfiguration();
-
 		ConfigurationSection def = root.createSection("VoteStreaks").createSection(id);
 		def.set("Type", type);
 		def.set("Enabled", enabled);
-
 		ConfigurationSection req = def.createSection("Requirements");
 		req.set("Amount", intervalAmount);
 		req.set("VotesRequired", votesRequired);
-
 		def.set("AllowMissedAmount", allowMissedAmount);
 		def.set("AllowMissedPeriod", allowMissedPeriod);
-
+		def.set("Recurring", recurring);
 		return root;
 	}
 
-	/**
-	 * periodKey|streakCount|votesThisPeriod|countedThisPeriod|missWindowStartKey|missesUsed
-	 */
 	private static String[] parseState(String raw) {
 		assertNotNull(raw);
 		assertFalse(raw.isEmpty());
@@ -109,20 +90,15 @@ class VoteStreakHandlerTest {
 	}
 
 	private void loadFromRoot(ConfigurationSection root) {
-		// IMPORTANT: no plugin.getSpecialRewardsConfig() involved.
 		handler.new VoteStreakConfigLoader().load(root);
 	}
 
 	@Test
 	void configLoader_loadsDefinition_andGetDefinitionWorks() {
-		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 2, 0, 0);
+		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 2, 0, 0, true);
 		loadFromRoot(root);
-
-		// getDefinition() is broken due to key casing mismatch in handler: byId.put(id)
-		// vs lookup lowercased
 		VoteStreakDefinition def = handler.getById().get("DailyStreak");
 		assertNotNull(def);
-
 		assertEquals("DailyStreak", def.getId());
 		assertEquals(VoteStreakType.DAILY, def.getType());
 		assertTrue(def.isEnabled());
@@ -132,50 +108,59 @@ class VoteStreakHandlerTest {
 
 	@Test
 	void processVote_whenAlreadyCountedThisPeriod_doesNotIncrementStreakAgain() {
-		MemoryConfiguration root = rootWithOneStreak("test", "DAILY", true, 9999, 2, 0, 0);
+		MemoryConfiguration root = rootWithOneStreak("test", "DAILY", true, 9999, 2, 0, 0, true);
 		loadFromRoot(root);
-
 		VoteStreakDefinition def = handler.getById().get("test");
-		assertNotNull(def);
-
 		String col = handler.getColumnName(def);
-
 		Map<String, String> backing = new HashMap<>();
 		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
-
 		backing.put(col, "2026-01-10|5|1|true||0");
-
 		handler.processVote(user, System.currentTimeMillis(), UUID.randomUUID());
-
 		String[] p = parseState(handler.readStateString(user, col));
-		assertEquals("5", p[1], "streakCount must not increment again when already counted");
-		assertEquals("1", p[2], "votesThisPeriod should NOT increment once already countedThisPeriod=true");
+		assertEquals("5", p[1]);
+		assertEquals("1", p[2]);
 		assertEquals("true", p[3]);
 	}
 
 	@Test
 	void processVote_acceptsOldFiveFieldFormat_andUpgradesState() {
-		MemoryConfiguration root = rootWithOneStreak("test", "DAILY", true, 9999, 2, 0, 0);
+		MemoryConfiguration root = rootWithOneStreak("test", "DAILY", true, 9999, 2, 0, 0, true);
 		loadFromRoot(root);
-
 		VoteStreakDefinition def = handler.getById().get("test");
-		assertNotNull(def);
-
 		String col = handler.getColumnName(def);
-
 		Map<String, String> backing = new HashMap<>();
 		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
-
 		backing.put(col, "2026-01-10|5|true||2");
-
 		handler.processVote(user, System.currentTimeMillis(), UUID.randomUUID());
-
 		String[] p = parseState(handler.readStateString(user, col));
 		assertEquals("2026-01-10", p[0]);
-		assertEquals("5", p[1], "streakCount should not increment (already counted)");
-		assertEquals("1", p[2], "votesThisPeriod upgraded-from-old (counted=true => 1) and ignored on vote");
+		assertEquals("5", p[1]);
+		assertEquals("1", p[2]);
 		assertEquals("true", p[3]);
-		assertEquals("2", p[5], "missesUsed preserved");
+		assertEquals("2", p[5]);
 	}
 
+	@Test
+	void processVote_migratesLegacyProgressIntoNewState() {
+		MemoryConfiguration root = rootWithOneStreak("daily", "DAILY", true, 99, 1, 0, 0, true);
+		loadFromRoot(root);
+		VoteStreakDefinition def = handler.getById().get("daily");
+		String col = handler.getColumnName(def);
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		when(user.getDayVoteStreak()).thenReturn(7);
+		handler.processVote(user, System.currentTimeMillis(), UUID.randomUUID());
+		String[] p = parseState(handler.readStateString(user, col));
+		assertEquals("8", p[1]);
+	}
+
+	@Test
+	void configLoader_migratesLegacyVoteStreakSection() {
+		MemoryConfiguration root = new MemoryConfiguration();
+		ConfigurationSection day = root.createSection("VoteStreak").createSection("Day");
+		day.createSection("2").set("Enabled", true);
+		day.createSection("-3").set("Enabled", true);
+		loadFromRoot(root);
+		assertEquals(2, handler.getDefinitions().size());
+	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -162,5 +162,9 @@ class VoteStreakHandlerTest {
 		day.createSection("-3").set("Enabled", true);
 		loadFromRoot(root);
 		assertEquals(2, handler.getDefinitions().size());
+		assertNotNull(root.getConfigurationSection("VoteStreaks.LegacyDAILY2OneTime"));
+		assertNotNull(root.getConfigurationSection("VoteStreaks.LegacyDAILY3Recurring"));
+		assertFalse(root.getBoolean("VoteStreak.Day.2.Enabled"));
+		assertFalse(root.getBoolean("VoteStreak.Day.-3.Enabled"));
 	}
 }


### PR DESCRIPTION
### Motivation

- Add support for recurring vote-streak rewards (reward every N completions) in addition to one-time rewards at N. 
- Smooth upgrade path for users upgrading from older plugin versions by migrating legacy per-user streak fields and the deprecated `VoteStreak` config section into the new `VoteStreaks` format.

### Description

- Added a `recurring` boolean to `VoteStreakDefinition` and updated its constructor and usages to carry the new option. 
- Updated reward logic in `VoteStreakHandler.processVoteForDefinition` to honor `recurring` (reward every N completions when true, otherwise reward only once at N). 
- Implemented legacy migration helpers `getLegacyStreakProgress` and `migrateLegacyProgressIfNeeded` to import old per-user streak counters into the new serialized streak state on first use. 
- Added legacy config loader methods `loadLegacy` and `loadLegacyType` to ingest the deprecated `VoteStreak` -> `Day|Week|Month` sections, create `VoteStreakDefinition` entries, and disable the old config nodes; also added `Recurring` support to the example `SpecialRewards.yml`.

### Testing

- Ran the unit tests in `VoteStreakHandlerTest`, including `configLoader_loadsDefinition_andGetDefinitionWorks`, `processVote_whenAlreadyCountedThisPeriod_doesNotIncrementStreakAgain`, `processVote_acceptsOldFiveFieldFormat_andUpgradesState`, `processVote_migratesLegacyProgressIntoNewState`, and `configLoader_migratesLegacyVoteStreakSection`. 
- All unit tests passed (no failing assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5562e29ac83279b3fc02d4ae0941b)