### PR TITLE
Fix VoteStreak one-time rewards and legacy list migration

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -186,7 +186,7 @@ public class VoteStreakHandler {
 				state.streakCount++;
 
 				int interval = Math.max(1, def.getRequiredAmount());
-				boolean shouldReward = state.streakCount > 0 && (state.streakCount % interval) == 0;
+				boolean shouldReward = shouldReward(def, state.streakCount);
 
 				plugin.extraDebug("[VoteStreak] period satisfied: streakCount=" + state.streakCount + " interval="
 						+ interval + " shouldReward=" + shouldReward);
@@ -209,6 +209,18 @@ public class VoteStreakHandler {
 		final String readBack = readStateString(user, col);
 		plugin.extraDebug("[VoteStreak] read-back col=" + col + " raw='" + readBack + "' (writtenLen="
 				+ rawAfter.length() + " readLen=" + readBack.length() + ")");
+	}
+
+	private boolean shouldReward(VoteStreakDefinition def, int streakCount) {
+		if (streakCount <= 0) {
+			return false;
+		}
+
+		int interval = Math.max(1, def.getRequiredAmount());
+		if (def.isRecurring()) {
+			return (streakCount % interval) == 0;
+		}
+		return streakCount == interval;
 	}
 
 	/**
@@ -626,6 +638,8 @@ public class VoteStreakHandler {
 					ConfigurationSection rewards = defSec.getConfigurationSection("Rewards");
 					if (rewards != null) {
 						migrated.createSection("Rewards", rewards.getValues(false));
+					} else if (defSec.isList("Rewards")) {
+						migrated.set("Rewards", defSec.getList("Rewards"));
 					}
 
 					migratedAny = true;

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -11,8 +11,11 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -135,6 +138,20 @@ class VoteStreakHandlerTest {
 		return root;
 	}
 
+	private static YamlConfiguration rootWithLegacyListRewards() {
+		YamlConfiguration root = new YamlConfiguration();
+
+		ConfigurationSection legacy = root.createSection("VoteStreak");
+		ConfigurationSection day = legacy.createSection("Day");
+		day.set("Enabled", true);
+
+		ConfigurationSection enabledOneTime = day.createSection("3");
+		enabledOneTime.set("Enabled", true);
+		enabledOneTime.set("Rewards", Arrays.asList("VoteSteak_3_Rewards_Online", "VoteSteak_3_Rewards_Offline"));
+
+		return root;
+	}
+
 	/**
 	 * periodKey|streakCount|votesThisPeriod|countedThisPeriod|missWindowStartKey|missesUsed
 	 *
@@ -157,6 +174,12 @@ class VoteStreakHandlerTest {
 
 	private void setSpecialRewardsRoot(FileConfiguration root) {
 		when(plugin.getSpecialRewardsConfig().getData()).thenReturn(root);
+	}
+
+	private boolean shouldReward(VoteStreakDefinition def, int streakCount) throws Exception {
+		Method m = VoteStreakHandler.class.getDeclaredMethod("shouldReward", VoteStreakDefinition.class, int.class);
+		m.setAccessible(true);
+		return (boolean) m.invoke(handler, def, streakCount);
 	}
 
 	@Test
@@ -220,6 +243,22 @@ class VoteStreakHandlerTest {
 		assertEquals("1", p[2], "votesThisPeriod upgraded from old counted=true state and ignored on vote");
 		assertEquals("true", p[3]);
 		assertEquals("2", p[5], "missesUsed preserved");
+	}
+
+	@Test
+	void shouldReward_respectsRecurringFlag() throws Exception {
+		VoteStreakDefinition oneTime = new VoteStreakDefinition("oneTime", VoteStreakType.DAILY, true, 3, 1, 0, 0,
+				false);
+		VoteStreakDefinition recurring = new VoteStreakDefinition("recurring", VoteStreakType.DAILY, true, 3, 1, 0, 0,
+				true);
+
+		assertFalse(shouldReward(oneTime, 2));
+		assertTrue(shouldReward(oneTime, 3));
+		assertFalse(shouldReward(oneTime, 6));
+
+		assertFalse(shouldReward(recurring, 2));
+		assertTrue(shouldReward(recurring, 3));
+		assertTrue(shouldReward(recurring, 6));
 	}
 
 	@Test
@@ -297,6 +336,22 @@ class VoteStreakHandlerTest {
 		assertTrue(rewards.getKeys(false).contains("Messages"));
 		assertFalse(rewards.getKeys(false).contains("Messages.Player"),
 				"Rewards should not contain flattened Messages.Player key");
+	}
+
+	@Test
+	void migrateLegacyConfigManually_copiesListBasedRewards() {
+		YamlConfiguration root = rootWithLegacyListRewards();
+		setSpecialRewardsRoot(root);
+
+		handler.migrateLegacyConfigManually();
+
+		ConfigurationSection migrated = root.getConfigurationSection("VoteStreaks.LegacyDAILY3OneTime");
+		assertNotNull(migrated);
+
+		List<String> rewards = migrated.getStringList("Rewards");
+		assertEquals(Arrays.asList("VoteSteak_3_Rewards_Online", "VoteSteak_3_Rewards_Offline"), rewards);
+		assertFalse(migrated.isConfigurationSection("Rewards"),
+				"list-based reward references should remain list-based");
 	}
 
 }


### PR DESCRIPTION
This builds on the legacy VoteStreak migration added in [a74a7e3](https://github.com/BenCodez/VotingPlugin/commit/a74a7e35b81e46d21eb3594d4b82bed43500ef27)

Changes:
- Makes `Recurring: false` reward only when `streakCount == Requirements.Amount`.
- Keeps `Recurring: true` using the existing modulo behavior.
- Preserves legacy list-based reward references during migration, for configs like:
```yaml
Rewards:
- VoteSteak_3_Rewards_Online
- VoteSteak_3_Rewards_Offline
```
- Adds tests for one-time vs recurring reward checks and list-based legacy reward migration.