### PR TITLE
Add VoteStreaks reset command

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -85,6 +85,7 @@ import com.bencodez.votingplugin.presets.VoteSitePreset;
 import com.bencodez.votingplugin.presets.VoteSitePresetSetupHandler;
 import com.bencodez.votingplugin.specialrewards.votemilestones.VoteMilestonesManager;
 import com.bencodez.votingplugin.specialrewards.votestreak.VoteStreakDefinition;
+import com.bencodez.votingplugin.specialrewards.votestreak.VoteStreakType;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.user.VotingPluginUser;
 import com.bencodez.votingplugin.votesites.VoteSite;
@@ -903,6 +904,46 @@ public class CommandLoader {
 				sender.sendMessage(MessageAPI.colorize("&cSet votestreak month for '" + args[1] + "' to " + args[4]));
 			}
 		});
+
+		plugin.getAdminVoteCommand()
+				.add(new CommandHandler(plugin, new String[] { "User", "(player)", "ResetVoteStreaks" },
+						"VotingPlugin.Commands.AdminVote.ResetVoteStreaks|" + adminPerm,
+						"Reset configured VoteStreaks state for player") {
+
+					@Override
+					public void execute(CommandSender sender, String[] args) {
+						VotingPluginUser user = plugin.getVotingPluginUserManager().getVotingPluginUser(args[1]);
+						int reset = plugin.getVoteStreakHandler().resetVoteStreaks(user);
+						sendMessage(sender, "&cReset " + reset + " VoteStreaks for '" + args[1] + "'");
+					}
+				});
+
+		plugin.getAdminVoteCommand()
+				.add(new CommandHandler(plugin, new String[] { "User", "(player)", "ResetVoteStreaks", "(votestreak)" },
+						"VotingPlugin.Commands.AdminVote.ResetVoteStreaks|" + adminPerm,
+						"Reset configured VoteStreaks state for player by type or id") {
+
+					@Override
+					public void execute(CommandSender sender, String[] args) {
+						VotingPluginUser user = plugin.getVotingPluginUserManager().getVotingPluginUser(args[1]);
+						String target = args[3];
+
+						try {
+							VoteStreakType type = VoteStreakType.from(target);
+							int reset = plugin.getVoteStreakHandler().resetVoteStreaks(user, type);
+							sendMessage(sender,
+									"&cReset " + reset + " " + type.name() + " VoteStreaks for '" + args[1] + "'");
+							return;
+						} catch (Exception ignored) {
+						}
+
+						if (plugin.getVoteStreakHandler().resetVoteStreak(user, target)) {
+							sendMessage(sender, "&cReset VoteStreak '" + target + "' for '" + args[1] + "'");
+						} else {
+							sendMessage(sender, "&cVoteStreak not found: &e" + target);
+						}
+					}
+				});
 
 		for (final TopVoter top : TopVoter.values()) {
 			plugin.getAdminVoteCommand()

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -451,6 +451,48 @@ public class VoteStreakHandler {
 		return true;
 	}
 
+	public int resetVoteStreaks(VotingPluginUser user) {
+		if (user == null) {
+			return 0;
+		}
+
+		int reset = 0;
+		for (VoteStreakDefinition def : ordered) {
+			writeStateString(user, getColumnName(def), "");
+			reset++;
+		}
+		return reset;
+	}
+
+	public int resetVoteStreaks(VotingPluginUser user, VoteStreakType type) {
+		if (user == null || type == null) {
+			return 0;
+		}
+
+		int reset = 0;
+		for (VoteStreakDefinition def : ordered) {
+			if (def.getType() == type) {
+				writeStateString(user, getColumnName(def), "");
+				reset++;
+			}
+		}
+		return reset;
+	}
+
+	public boolean resetVoteStreak(VotingPluginUser user, String id) {
+		if (user == null || id == null || id.trim().isEmpty()) {
+			return false;
+		}
+
+		VoteStreakDefinition def = getDefinition(id);
+		if (def == null) {
+			return false;
+		}
+
+		writeStateString(user, getColumnName(def), "");
+		return true;
+	}
+
 	private void giveRewards(VotingPluginUser user, VoteStreakDefinition def, UUID voteUUID, int streakCount) {
 		PlayerSpecialRewardEvent event = new PlayerSpecialRewardEvent(user,
 				SpecialRewardType.VOTESTREAKS.setType(def.getType().toString()).setAmount(def.getVotesRequired()),

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -152,6 +152,31 @@ class VoteStreakHandlerTest {
 		return root;
 	}
 
+	private static MemoryConfiguration rootWithThreeStreaks() {
+		MemoryConfiguration root = new MemoryConfiguration();
+		ConfigurationSection voteStreaks = root.createSection("VoteStreaks");
+
+		addStreak(voteStreaks, "Daily3", "DAILY", true, 3, 1, 1, 7);
+		addStreak(voteStreaks, "Daily7", "DAILY", true, 7, 1, 1, 7);
+		addStreak(voteStreaks, "Weekly2", "WEEKLY", true, 2, 1, 0, 0);
+
+		return root;
+	}
+
+	private static void addStreak(ConfigurationSection voteStreaks, String id, String type, boolean enabled,
+			int intervalAmount, int votesRequired, int allowMissedAmount, int allowMissedPeriod) {
+		ConfigurationSection def = voteStreaks.createSection(id);
+		def.set("Type", type);
+		def.set("Enabled", enabled);
+
+		ConfigurationSection req = def.createSection("Requirements");
+		req.set("Amount", intervalAmount);
+		req.set("VotesRequired", votesRequired);
+
+		def.set("AllowMissedAmount", allowMissedAmount);
+		def.set("AllowMissedPeriod", allowMissedPeriod);
+	}
+
 	/**
 	 * periodKey|streakCount|votesThisPeriod|countedThisPeriod|missWindowStartKey|missesUsed
 	 *
@@ -263,6 +288,74 @@ class VoteStreakHandlerTest {
 		assertFalse(shouldReward(recurring, 2));
 		assertTrue(shouldReward(recurring, 3));
 		assertTrue(shouldReward(recurring, 6));
+	}
+
+	@Test
+	void resetVoteStreaks_resetsAllConfiguredDefinitions() {
+		loadFromRoot(rootWithThreeStreaks());
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		for (VoteStreakDefinition def : handler.getDefinitions()) {
+			backing.put(handler.getColumnName(def), "2026-01-10|5|1|true||0");
+		}
+
+		int reset = handler.resetVoteStreaks(user);
+
+		assertEquals(3, reset);
+		for (VoteStreakDefinition def : handler.getDefinitions()) {
+			assertEquals("", backing.get(handler.getColumnName(def)));
+		}
+	}
+
+	@Test
+	void resetVoteStreaks_byTypeResetsOnlyMatchingDefinitions() {
+		loadFromRoot(rootWithThreeStreaks());
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		VoteStreakDefinition daily3 = handler.getDefinition("Daily3");
+		VoteStreakDefinition daily7 = handler.getDefinition("Daily7");
+		VoteStreakDefinition weekly2 = handler.getDefinition("Weekly2");
+
+		backing.put(handler.getColumnName(daily3), "2026-01-10|3|1|true||0");
+		backing.put(handler.getColumnName(daily7), "2026-01-10|7|1|true||0");
+		backing.put(handler.getColumnName(weekly2), "2026-W02|2|1|true||0");
+
+		int reset = handler.resetVoteStreaks(user, VoteStreakType.DAILY);
+
+		assertEquals(2, reset);
+		assertEquals("", backing.get(handler.getColumnName(daily3)));
+		assertEquals("", backing.get(handler.getColumnName(daily7)));
+		assertEquals("2026-W02|2|1|true||0", backing.get(handler.getColumnName(weekly2)));
+	}
+
+	@Test
+	void resetVoteStreak_byIdResetsOnlyMatchingDefinition() {
+		loadFromRoot(rootWithThreeStreaks());
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		VoteStreakDefinition daily3 = handler.getDefinition("Daily3");
+		VoteStreakDefinition weekly2 = handler.getDefinition("Weekly2");
+
+		backing.put(handler.getColumnName(daily3), "2026-01-10|3|1|true||0");
+		backing.put(handler.getColumnName(weekly2), "2026-W02|2|1|true||0");
+
+		assertTrue(handler.resetVoteStreak(user, "daily3"));
+		assertEquals("", backing.get(handler.getColumnName(daily3)));
+		assertEquals("2026-W02|2|1|true||0", backing.get(handler.getColumnName(weekly2)));
+	}
+
+	@Test
+	void resetVoteStreak_unknownIdReturnsFalse() {
+		loadFromRoot(rootWithThreeStreaks());
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+
+		assertFalse(handler.resetVoteStreak(user, "missing"));
+		assertTrue(backing.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Adds an admin command/API to reset the new VoteStreaks state for a player.

```
/av User <player> ResetVoteStreaks
/av User <player> ResetVoteStreaks <DAILY|WEEKLY|MONTHLY>
/av User <player> ResetVoteStreaks <votestreak id>
```

This only resets the new VoteStreaks state columns, not the old legacy DayVoteStreak, WeekVoteStreak, or MonthVoteStreak values.
