### PR TITLE
Allow to hide top-voters which have not played before

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/Config.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/Config.java
@@ -491,6 +491,10 @@ public class Config extends YMLFile {
 	@Getter
 	private int MaxiumNumberOfTopVotersToLoad = 1000;
 
+	@ConfigDataBoolean(path = "HideTopVoterIfNotPlayedBefore")
+	@Getter
+	private boolean HideTopVoterIfNotPlayedBefore = false;
+
 	@ConfigDataBoolean(path = "OverrideVersionDisable")
 	@Getter
 	private boolean overrideVersionDisable = false;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterHandler.java
@@ -765,7 +765,7 @@ public class TopVoterHandler implements Listener {
 
 		if (plugin.getConfigFile().isHideTopVoterIfNotPlayedBefore()) {
 			list.removeIf(entry -> {
-				var playerId = entry.getKey().getUser().getJavaUUID();
+				UUID playerId = entry.getKey().getUser().getJavaUUID();
 				OfflinePlayer player = Bukkit.getOfflinePlayer(playerId);
 
 				return !player.hasPlayedBefore();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterHandler.java
@@ -763,6 +763,15 @@ public class TopVoterHandler implements Listener {
 
 		List<Entry<TopVoterPlayer, Integer>> list = new LinkedList<>(map.entrySet());
 
+		if (plugin.getConfigFile().isHideTopVoterIfNotPlayedBefore()) {
+			list.removeIf(entry -> {
+				var playerId = entry.getKey().getUser().getJavaUUID();
+				OfflinePlayer player = Bukkit.getOfflinePlayer(playerId);
+
+				return !player.hasPlayedBefore();
+			});
+		}
+
 		// Sorting the list based on values
 		Collections.sort(list, new Comparator<Entry<TopVoterPlayer, Integer>>() {
 			@Override

--- a/VotingPlugin/src/main/resources/Config.yml
+++ b/VotingPlugin/src/main/resources/Config.yml
@@ -467,6 +467,9 @@ LoadTopVoter:
 # Set to -1 for no limit
 MaxiumNumberOfTopVotersToLoad: 1000
 
+# Whether to remove voters from the top-list if they have not joined the server yet
+HideTopVoterIfNotPlayedBefore: false
+
 # When top voter awards are given (even if there are none listed) it will store top voters
 # Files will created in TopVoters folder.
 # Monthly top voters are always saved by default now


### PR DESCRIPTION
Hey!

We've recently set up a hologram displaying the names of the top 10 voters per month and ran into the issue that even mistyped names show up on there, which is rather undesirable. This probably doesn't happen on large and active servers, as typo vote-counts are tiny in comparison and fall to the very bottom, but with smaller communities, these votes will show up sooner or later.

Since I'm not familiar with the code-base much, I chose a simple solution, namely to hide entries right before sorting the top-list if the flag is enabled and they have not joined the server before. To keep behaviour unchanged relative to prior builds, the flag is default-false.

Looking forward to feedback of any kind if applicable and would be happy if we can get a feature like this in.