### PR TITLE
Deduplicate proxy vote cache entries

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
@@ -2,6 +2,7 @@
 package com.bencodez.votingplugin.proxy;
 
 import java.util.Map;
+import java.util.UUID;
 
 import com.bencodez.simpleapi.servercomm.codec.JsonEnvelope;
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -50,7 +50,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setLong(path + ".Time", voteData.getTime());
 		setBoolean(path + ".Real", voteData.isRealVote());
 		setString(path + ".Text", voteData.getText());
-		setString(path + ".VoteID", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
+		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
 	}
 
 	public void addVoteOnline(String player, int num, OfflineBungeeVote voteData) {
@@ -61,7 +61,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setLong(path + ".Time", voteData.getTime());
 		setBoolean(path + ".Real", voteData.isRealVote());
 		setString(path + ".Text", voteData.getText());
-		setString(path + ".VoteID", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
+		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
 	}
 
 	public void clearData() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -88,6 +89,11 @@ public abstract class VoteCacheHandler {
 	 * @param vote the vote to add
 	 */
 	public void addServerVote(String server, OfflineBungeeVote vote) {
+		if (containsServerVote(server, vote.getVoteId())) {
+			debug1("Not caching duplicate vote " + vote.getVoteId() + " for server " + server);
+			return;
+		}
+
 		cachedVotes.putIfAbsent(server, new ArrayList<>());
 		cachedVotes.get(server).add(vote);
 
@@ -160,6 +166,11 @@ public abstract class VoteCacheHandler {
 	 * @param vote the vote to add
 	 */
 	public void addOnlineVote(String uuid, OfflineBungeeVote vote) {
+		if (containsOnlineVote(uuid, vote.getVoteId())) {
+			debug1("Not caching duplicate online vote " + vote.getVoteId() + " for " + uuid);
+			return;
+		}
+
 		cachedOnlineVotes.putIfAbsent(uuid, new ArrayList<>());
 		cachedOnlineVotes.get(uuid).add(vote);
 
@@ -224,6 +235,60 @@ public abstract class VoteCacheHandler {
 		for (String server : cachedVotes.keySet()) {
 			removeServerVotes(server, expiredServerVotes);
 		}
+	}
+
+	/**
+	 * Checks whether a vote is already cached for a server.
+	 *
+	 * @param server target server
+	 * @param voteId unique vote identifier
+	 * @return true if the vote is already cached for the server
+	 */
+	private boolean containsServerVote(String server, UUID voteId) {
+		if (voteId == null) {
+			return false;
+		}
+		for (OfflineBungeeVote vote : getVotes(server)) {
+			if (voteId.equals(vote.getVoteId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether a vote is already cached for an online player.
+	 *
+	 * @param uuid player UUID
+	 * @param voteId unique vote identifier
+	 * @return true if the vote is already cached for the player
+	 */
+	private boolean containsOnlineVote(String uuid, UUID voteId) {
+		if (voteId == null) {
+			return false;
+		}
+		for (OfflineBungeeVote vote : getOnlineVotes(uuid)) {
+			if (voteId.equals(vote.getVoteId())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Reads a vote identifier using the current key and the legacy key.
+	 *
+	 * @param data cached vote data
+	 * @return stored vote identifier or an empty string
+	 */
+	private String readVoteId(DataNode data) {
+		if (data.has("VoteId")) {
+			return data.get("VoteId").asString();
+		}
+		if (data.has("VoteID")) {
+			return data.get("VoteID").asString();
+		}
+		return "";
 	}
 
 	/**
@@ -326,7 +391,7 @@ public abstract class VoteCacheHandler {
 							long time = data.has("Time") ? data.get("Time").asLong() : 0L;
 							boolean real = data.has("Real") && data.get("Real").asBoolean();
 							String text = data.has("Text") ? data.get("Text").asString() : "";
-							String voteId = data.has("VoteId") ? data.get("VoteId").asString() : "";
+							String voteId = readVoteId(data);
 
 							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text));
 						}
@@ -351,7 +416,7 @@ public abstract class VoteCacheHandler {
 							long time = data.has("Time") ? data.get("Time").asLong() : 0L;
 							boolean real = data.has("Real") && data.get("Real").asBoolean();
 							String text = data.has("Text") ? data.get("Text").asString() : "";
-							String voteId = data.has("VoteId") ? data.get("VoteId").asString() : "";
+							String voteId = readVoteId(data);
 
 							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text));
 						}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -38,7 +38,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.getTime(), "VoteCache", server, String.valueOf(num), "Time");
 		setPath(voteData.isRealVote(), "VoteCache", server, String.valueOf(num), "Real");
 		setPath(voteData.getText(), "VoteCache", server, String.valueOf(num), "Text");
-		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "VoteCache", server, String.valueOf(num), "VoteID");
+		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "VoteCache", server, String.valueOf(num), "VoteId");
 	}
 
 	@Override
@@ -49,7 +49,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.getTime(), "OnlineCache", player, String.valueOf(num), "Time");
 		setPath(voteData.isRealVote(), "OnlineCache", player, String.valueOf(num), "Real");
 		setPath(voteData.getText(), "OnlineCache", player, String.valueOf(num), "Text");
-		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "OnlineCache", player, String.valueOf(num), "VoteID");
+		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "OnlineCache", player, String.valueOf(num), "VoteId");
 	}
 
 	@Override


### PR DESCRIPTION
## What changed

- rejects duplicate server-cache entries by `voteId` within each target server
- rejects duplicate online-cache entries by `voteId` within each player queue
- standardizes new Bungee and Velocity JSON writes on `VoteId`
- reads both `VoteId` and legacy `VoteID` keys when loading cached votes
- retains legacy behavior for entries without an ID

## Why

A vote can be queued more than once before delivery. Cache-level dedup avoids scheduling repeated delivery while preserving the valid case where one vote is intentionally queued once per backend server.

The JSON writer and loader previously used different capitalization, causing the explicit cached ID to be lost after a JSON reload.

## Dependency

This PR is stacked on #1527 so cached delivery can propagate the explicit ID through the wire. Merge #1527 first, then retarget this PR to `master`.

## Validation

Code-level storage-key and cache-scope checks were completed through the GitHub connector. Maven tests could not be run because no local checkout is available in this workspace.