### PR TITLE
Preserve vote identity through proxy time queues

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -1342,7 +1342,7 @@ public abstract class VotingPluginProxy {
 	public void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
 			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().remove();
-			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null);
+			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote.getVoteId());
 		}
 	}
 
@@ -1597,7 +1597,19 @@ public abstract class VotingPluginProxy {
 
 	public synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
 			VoteTotalsSnapshot text, String uuid) {
+		vote(player, service, realVote, timeQueue, queueTime, text, uuid, null);
+	}
+
+	private synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
+			VoteTotalsSnapshot text, String uuid, UUID existingVoteId) {
 		try {
+			UUID voteId = existingVoteId;
+			if (voteId == null && text != null) {
+				voteId = text.getVoteUUID();
+			}
+			if (voteId == null) {
+				voteId = UUID.randomUUID();
+			}
 			if (player == null || player.isEmpty()) {
 				log("No name from vote on " + service);
 				return;
@@ -1608,7 +1620,7 @@ public abstract class VotingPluginProxy {
 				if (getGlobalDataHandler().isTimeChangedHappened()) {
 					getGlobalDataHandler().checkForFinishedTimeChanges();
 					if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
-						getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(player, service,
+						getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(voteId, player, service,
 								LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
 						log("Caching vote from " + player + "/" + service
 								+ " because time change is happening right now");
@@ -1683,8 +1695,6 @@ public abstract class VotingPluginProxy {
 			// Cache online state/server once (IMPORTANT for broadcast logic correctness)
 			final boolean playerOnline = isPlayerOnline(player);
 			final String playerServer = playerOnline ? getCurrentPlayerServer(player) : null;
-
-			final UUID voteId = UUID.randomUUID();
 
 			addVoteParty();
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
@@ -2,6 +2,7 @@
 package com.bencodez.votingplugin.proxy;
 
 import java.util.Map;
+import java.util.UUID;
 
 import com.bencodez.simpleapi.servercomm.codec.JsonEnvelope;
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -40,6 +40,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setString(path + ".Name", voteTimedQueue.getName());
 		setString(path + ".Service", voteTimedQueue.getService());
 		setLong(path + ".Time", voteTimedQueue.getTime());
+		setString(path + ".VoteId", voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString());
 	}
 
 	public void addVote(String server, int num, OfflineBungeeVote voteData) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import com.bencodez.simpleapi.sql.mysql.AbstractSqlTable;
 import com.bencodez.simpleapi.sql.mysql.DbType;
@@ -30,7 +31,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 					+ qi("id") + " BIGSERIAL PRIMARY KEY, "
 					+ qi("playerName") + " VARCHAR(100), "
 					+ qi("service") + " VARCHAR(100), "
-					+ qi("time") + " BIGINT"
+					+ qi("time") + " BIGINT, "
+					+ qi("voteId") + " VARCHAR(36)"
 					+ ");";
 		}
 
@@ -39,6 +41,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				+ qi("playerName") + " VARCHAR(100),"
 				+ qi("service") + " VARCHAR(100),"
 				+ qi("time") + " BIGINT,"
+				+ qi("voteId") + " VARCHAR(36),"
 				+ "INDEX idx_time (" + qi("time") + ")"
 				+ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
 	}
@@ -62,6 +65,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		super((tablePrefix != null ? tablePrefix : "") + "votingplugin_timedvotecache",
 				existingMysql,
 				debug);
+		ensureVoteIdColumn();
 		ensureIndexes();
 	}
 
@@ -72,7 +76,17 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 */
 	public ProxyTimedVoteCacheTable(MysqlConfig config, boolean debug) {
 		super("votingplugin_timedvotecache", config, debug);
+		ensureVoteIdColumn();
 		ensureIndexes();
+	}
+
+	private void ensureVoteIdColumn() {
+		try {
+			new Query(mysql, "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN IF NOT EXISTS " + qi("voteId")
+					+ " VARCHAR(36);").executeUpdate();
+		} catch (SQLException e) {
+			debug(e);
+		}
 	}
 
 	private void ensureIndexes() {
@@ -89,18 +103,20 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	// --- INSERT ---
 	/**
 	 * Inserts a timed vote.
+	 * @param voteId unique vote identifier
 	 * @param playerName the player name
 	 * @param service the voting service
 	 * @param time the vote time
 	 */
-	public void insertTimedVote(String playerName, String service, long time) {
+	public void insertTimedVote(UUID voteId, String playerName, String service, long time) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
-				+ qi("time") + ") VALUES (?, ?, ?);";
+				+ qi("time") + ", " + qi("voteId") + ") VALUES (?, ?, ?, ?);";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setString(1, playerName);
 			ps.setString(2, service);
 			ps.setLong(3, time);
+			ps.setString(4, voteId == null ? null : voteId.toString());
 			ps.executeUpdate();
 		} catch (SQLException e) {
 			debug(e);
@@ -189,7 +205,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 							rs.getInt("id"),
 							rs.getString("playerName"),
 							rs.getString("service"),
-							rs.getLong("time")
+							rs.getLong("time"),
+							parseUuid(rs.getString("voteId"))
 					));
 				}
 			}
@@ -197,6 +214,17 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			debug(e);
 		}
 		return list;
+	}
+
+	private UUID parseUuid(String value) {
+		if (value == null || value.isEmpty()) {
+			return null;
+		}
+		try {
+			return UUID.fromString(value);
+		} catch (IllegalArgumentException ignored) {
+			return null;
+		}
 	}
 
 	/**
@@ -207,6 +235,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		private final String playerName;
 		private final String service;
 		private final long time;
+		private final UUID voteId;
 
 		/**
 		 * Constructor for TimedVoteRow.
@@ -214,12 +243,14 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 * @param playerName the player name
 		 * @param service the voting service
 		 * @param time the vote time
+		 * @param voteId unique vote identifier
 		 */
-		public TimedVoteRow(int id, String playerName, String service, long time) {
+		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId) {
 			this.id = id;
 			this.playerName = playerName;
 			this.service = service;
 			this.time = time;
+			this.voteId = voteId;
 		}
 
 		/**
@@ -252,6 +283,15 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 */
 		public long getTime() {
 			return time;
+		}
+
+		/**
+		 * Gets the vote identifier.
+		 *
+		 * @return vote identifier or null
+		 */
+		public UUID getVoteId() {
+			return voteId;
 		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -81,8 +81,17 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	}
 
 	private void ensureVoteIdColumn() {
+		String probeSql = "SELECT " + qi("voteId") + " FROM " + qi(getTableName()) + " WHERE 1 = 0;";
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(probeSql)) {
+			ps.executeQuery();
+			return;
+		} catch (SQLException ignored) {
+			// Column does not exist yet.
+		}
+
 		try {
-			new Query(mysql, "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN IF NOT EXISTS " + qi("voteId")
+			new Query(mysql, "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("voteId")
 					+ " VARCHAR(36);").executeUpdate();
 		} catch (SQLException e) {
 			debug(e);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -292,6 +292,28 @@ public abstract class VoteCacheHandler {
 	}
 
 	/**
+	 * Reads an optional UUID from cached data.
+	 *
+	 * @param data cached data
+	 * @param key value key
+	 * @return parsed UUID or null
+	 */
+	private UUID readUuid(DataNode data, String key) {
+		if (!data.has(key)) {
+			return null;
+		}
+		String value = data.get(key).asString();
+		if (value == null || value.isEmpty()) {
+			return null;
+		}
+		try {
+			return UUID.fromString(value);
+		} catch (IllegalArgumentException ignored) {
+			return null;
+		}
+	}
+
+	/**
 	 * Saves the vote cache to storage.
 	 */
 	public void saveVoteCache() {
@@ -299,7 +321,7 @@ public abstract class VoteCacheHandler {
 
 			if (!getTimeChangeQueue().isEmpty()) {
 				for (VoteTimeQueue vote : getTimeChangeQueue()) {
-					timedVoteCacheTable.insertTimedVote(vote.getName(), vote.getService(), vote.getTime());
+					timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(), vote.getTime());
 				}
 			}
 		} else {
@@ -351,8 +373,8 @@ public abstract class VoteCacheHandler {
 			// Load timed votes from MySQL
 			ArrayList<VoteTimeQueue> timedVotes = new ArrayList<>();
 			timedVoteCacheTable.getAllVotes().forEach(timedVoteRow -> {
-				VoteTimeQueue voteTimeQueue = new VoteTimeQueue(timedVoteRow.getPlayerName(), timedVoteRow.getService(),
-						timedVoteRow.getTime());
+				VoteTimeQueue voteTimeQueue = new VoteTimeQueue(timedVoteRow.getVoteId(), timedVoteRow.getPlayerName(),
+						timedVoteRow.getService(), timedVoteRow.getTime());
 				timedVotes.add(voteTimeQueue);
 			});
 			timeChangeQueue.addAll(timedVotes);
@@ -368,8 +390,9 @@ public abstract class VoteCacheHandler {
 						String name = data.has("Name") ? data.get("Name").asString() : "";
 						String service = data.has("Service") ? data.get("Service").asString() : "";
 						long time = data.has("Time") ? data.get("Time").asLong() : 0L;
+						UUID voteId = readUuid(data, "VoteId");
 
-						getTimeChangeQueue().add(new VoteTimeQueue(name, service, time));
+						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time));
 					}
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -28,6 +28,8 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteTimedQueue.getName(), "TimedVoteCache", String.valueOf(num), "Name");
 		setPath(voteTimedQueue.getService(), "TimedVoteCache", String.valueOf(num), "Service");
 		setPath(voteTimedQueue.getTime(), "TimedVoteCache", String.valueOf(num), "Time");
+		setPath(voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString(), "TimedVoteCache",
+				String.valueOf(num), "VoteId");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -5,6 +5,9 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Represents a vote delayed while a proxy time change is active.
+ */
 public class VoteTimeQueue {
 	@Getter
 	@Setter
@@ -19,10 +22,25 @@ public class VoteTimeQueue {
 	@Setter
 	private UUID voteId;
 
+	/**
+	 * Creates a legacy-compatible queued vote without an identifier.
+	 *
+	 * @param name player name
+	 * @param service service site
+	 * @param time vote timestamp
+	 */
 	public VoteTimeQueue(String name, String service, long time) {
 		this(null, name, service, time);
 	}
 
+	/**
+	 * Creates a queued vote with its original identifier.
+	 *
+	 * @param voteId unique vote identifier
+	 * @param name player name
+	 * @param service service site
+	 * @param time vote timestamp
+	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
 		this.voteId = voteId;
 		this.name = name;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -1,5 +1,7 @@
 package com.bencodez.votingplugin.timequeue;
 
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,8 +15,16 @@ public class VoteTimeQueue {
 	@Getter
 	@Setter
 	private long time;
+	@Getter
+	@Setter
+	private UUID voteId;
 
 	public VoteTimeQueue(String name, String service, long time) {
+		this(null, name, service, time);
+	}
+
+	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
+		this.voteId = voteId;
 		this.name = name;
 		this.service = service;
 		this.time = time;


### PR DESCRIPTION
## What changed

- assigns a vote ID before a vote can enter the proxy time-change queue
- restores the same ID when the queue is processed
- preserves an incoming multiproxy snapshot ID instead of generating a replacement
- stores optional time-queue vote IDs in Bungee and Velocity JSON caches
- adds an optional `voteId` column to MySQL/PostgreSQL timed-vote cache storage
- loads older queue entries without an ID as compatible legacy entries

## Why

Votes delayed during a global time change previously received a new identity when replayed. That prevented the backend idempotency layer from recognizing a replay of the original accepted vote.

## Database compatibility

The timed-vote cache table creates or adds a nullable `VARCHAR(36)` vote ID column. Existing rows remain valid and load with a null ID.

## Dependency

This PR is stacked on #1528, which is stacked on #1527. Merge them in order, then retarget the next PR to `master`.

## Validation

Constructor, persistence, and replay call sites were checked across proxy, JSON, and SQL implementations through the GitHub connector. Maven and database integration tests could not be run because this workspace has no local checkout.