### PR TITLE
Make proxy cache vote deduplication atomic

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -88,7 +88,7 @@ public abstract class VoteCacheHandler {
 	 * @param server the server name
 	 * @param vote the vote to add
 	 */
-	public void addServerVote(String server, OfflineBungeeVote vote) {
+	public synchronized void addServerVote(String server, OfflineBungeeVote vote) {
 		if (containsServerVote(server, vote.getVoteId())) {
 			debug1("Not caching duplicate vote " + vote.getVoteId() + " for server " + server);
 			return;
@@ -165,7 +165,7 @@ public abstract class VoteCacheHandler {
 	 * @param uuid the player UUID
 	 * @param vote the vote to add
 	 */
-	public void addOnlineVote(String uuid, OfflineBungeeVote vote) {
+	public synchronized void addOnlineVote(String uuid, OfflineBungeeVote vote) {
 		if (containsOnlineVote(uuid, vote.getVoteId())) {
 			debug1("Not caching duplicate online vote " + vote.getVoteId() + " for " + uuid);
 			return;

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -5,12 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +63,30 @@ public class VoteCacheHandlerVoteIdTest {
 
 		assertEquals(1, handler.getOnlineVotes("player-uuid").size());
 		verify(storage).addVoteOnline("player-uuid", 0, handler.getOnlineVotes("player-uuid").get(0));
+	}
+
+	@Test
+	public void concurrentServerDeliveriesReserveVoteIdAtomically() throws Exception {
+		UUID voteId = UUID.randomUUID();
+
+		runConcurrently(() -> handler.addServerVote("server", vote(voteId, 100L)),
+				() -> handler.addServerVote("server", vote(voteId, 101L)));
+
+		assertEquals(1, handler.getVotes("server").size());
+		verify(storage, times(1)).addVote(org.mockito.ArgumentMatchers.eq("server"),
+				org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.any(OfflineBungeeVote.class));
+	}
+
+	@Test
+	public void concurrentOnlineDeliveriesReserveVoteIdAtomically() throws Exception {
+		UUID voteId = UUID.randomUUID();
+
+		runConcurrently(() -> handler.addOnlineVote("player-uuid", vote(voteId, 100L)),
+				() -> handler.addOnlineVote("player-uuid", vote(voteId, 101L)));
+
+		assertEquals(1, handler.getOnlineVotes("player-uuid").size());
+		verify(storage, times(1)).addVoteOnline(org.mockito.ArgumentMatchers.eq("player-uuid"),
+				org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.any(OfflineBungeeVote.class));
 	}
 
 	@Test
@@ -157,6 +186,39 @@ public class VoteCacheHandlerVoteIdTest {
 		when(parent.has(key)).thenReturn(true);
 		when(parent.get(key)).thenReturn(child);
 		when(child.asBoolean()).thenReturn(value);
+	}
+
+	private static void runConcurrently(Runnable first, Runnable second) throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		try {
+			Future<?> firstFuture = executor.submit(() -> {
+				ready.countDown();
+				await(start);
+				first.run();
+			});
+			Future<?> secondFuture = executor.submit(() -> {
+				ready.countDown();
+				await(start);
+				second.run();
+			});
+			ready.await();
+			start.countDown();
+			firstFuture.get();
+			secondFuture.get();
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			latch.await();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(e);
+		}
 	}
 
 	private static OfflineBungeeVote vote(UUID voteId, long time) {


### PR DESCRIPTION
## Summary

- synchronize server-cache vote insertion across the duplicate check, in-memory add, and persistence
- synchronize online-cache vote insertion across the same operation
- add concurrent regression tests for both cache paths

## Why

The existing `contains`-then-`add` flow was correct for sequential delivery but was not atomic. Two simultaneous deliveries with the same `voteId` could both pass the duplicate check and be cached/persisted twice.

## Impact

Duplicate reservation is now atomic per `VoteCacheHandler` instance. The synchronized sections are short and vote traffic is low-volume, so contention should be negligible.

## Validation

The new tests start two delivery threads behind a latch and assert that only one cache entry and one persistence call are produced for server and online caches.