### PR TITLE
Fix queued proxy votes being rejected by vote delay

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
@@ -145,7 +145,9 @@ public class PlayerVoteListener implements Listener {
 			}
 		}
 
-		if (voteSite.isWaitUntilVoteDelay() && !user.canVoteSite(voteSite)) {
+		boolean queuedProxyVoteAlreadyRecorded = ProxyVoteDelayCheck.isQueuedVoteAlreadyRecorded(event.isBungee(),
+				event.getTime(), user.getTime(voteSite));
+		if (voteSite.isWaitUntilVoteDelay() && !queuedProxyVoteAlreadyRecorded && !user.canVoteSite(voteSite)) {
 			if (!event.isRealVote()) {
 				plugin.getLogger().info(user.getPlayerName() + " did a not real vote, bypassing WaitUntilVoteDelay");
 			} else {
@@ -156,6 +158,10 @@ public class PlayerVoteListener implements Listener {
 				plugin.getLogger()
 						.info(user.getPlayerName() + " has bypass permission for WaitUntilVoteDelay, bypassing");
 			}
+		}
+		if (queuedProxyVoteAlreadyRecorded) {
+			plugin.debug("Allowing queued proxy vote for " + user.getPlayerName() + " on " + voteSite.getKey()
+					+ "; proxy vote time already matches LastVotes: " + event.getTime());
 		}
 
 		UUID voteUUID = UUID.randomUUID();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/ProxyVoteDelayCheck.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/ProxyVoteDelayCheck.java
@@ -1,0 +1,24 @@
+package com.bencodez.votingplugin.listeners;
+
+/**
+ * Handles the WaitUntilVoteDelay exception for votes queued by a proxy.
+ */
+public final class ProxyVoteDelayCheck {
+
+	private ProxyVoteDelayCheck() {
+	}
+
+	/**
+	 * A proxy stores the real vote timestamp before its queued message reaches the
+	 * backend. The backend must accept that one delivery when the stored timestamp
+	 * is the same timestamp carried by the message.
+	 *
+	 * @param proxyVote true when the vote was forwarded by VotingPlugin's proxy
+	 * @param messageVoteTime real vote time included in the proxy message
+	 * @param storedVoteTime current backend last-vote time for the site
+	 * @return true when the delay check should allow the queued delivery
+	 */
+	public static boolean isQueuedVoteAlreadyRecorded(boolean proxyVote, long messageVoteTime, long storedVoteTime) {
+		return proxyVote && messageVoteTime > 0L && messageVoteTime == storedVoteTime;
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyVoteDelayCheckTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyVoteDelayCheckTest.java
@@ -1,0 +1,23 @@
+package com.bencodez.votingplugin.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.listeners.ProxyVoteDelayCheck;
+
+class ProxyVoteDelayCheckTest {
+
+	@Test
+	void acceptsQueuedProxyVoteWhenTheProxyTimestampIsAlreadyStored() {
+		assertTrue(ProxyVoteDelayCheck.isQueuedVoteAlreadyRecorded(true, 12345L, 12345L));
+	}
+
+	@Test
+	void doesNotBypassTheDelayForDirectOrStaleProxyVotes() {
+		assertFalse(ProxyVoteDelayCheck.isQueuedVoteAlreadyRecorded(false, 12345L, 12345L));
+		assertFalse(ProxyVoteDelayCheck.isQueuedVoteAlreadyRecorded(true, 12344L, 12345L));
+		assertFalse(ProxyVoteDelayCheck.isQueuedVoteAlreadyRecorded(true, 0L, 0L));
+	}
+}


### PR DESCRIPTION
## Summary

- allow a queued VotingPlugin proxy vote when its forwarded vote timestamp already matches the backend's stored `LastVotes` timestamp
- retain `WaitUntilVoteDelay` enforcement for direct votes and stale proxy timestamps
- add a focused regression test for the timestamp match

## Root cause

The proxy writes the real vote time before a queued offline vote reaches the backend. The backend then reads that same value from `LastVotes` and incorrectly treats the queued delivery as a vote that is still on cooldown, skipping rewards and milestone evaluation.

## Validation

- Added `ProxyVoteDelayCheckTest` covering the accepted queued-proxy case and rejected direct/stale cases.
- Maven is not installed in this environment, so the test suite could not be executed locally.