### PR TITLE
Reject invalid usernames from Votifier votes

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
@@ -8,6 +8,7 @@ import com.bencodez.simpleapi.array.ArrayUtils;
 import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
 import com.bencodez.votingplugin.proxy.BungeeMethod;
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
 import com.vexsoftware.votifier.model.Vote;
 import com.vexsoftware.votifier.model.VotifierEvent;
 
@@ -42,13 +43,15 @@ public class VotiferEvent implements Listener {
 		}
 		final String voteSite = str;
 		final String IP = vote.getAddress();
-		final String voteUsername = vote.getUsername().trim();
+		final String voteUsername = vote.getUsername();
 		if (IP.equals("VotingPlugin")) {
 			return;
 		}
 
-		if (voteUsername.length() == 0) {
-			plugin.getLogger().warning("No name from vote on " + voteSite);
+		if (!MinecraftUsernameValidator.isValid(voteUsername)) {
+			plugin.getLogger().warning("Rejected vote with invalid Minecraft username '"
+					+ MinecraftUsernameValidator.sanitizeForLog(voteUsername) + "' from service '"
+					+ MinecraftUsernameValidator.sanitizeForLog(voteSite) + "'");
 			return;
 		}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -64,6 +64,7 @@ import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyServerSocketConfigur
 import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyServerSocketConfigurationBungee;
 import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 import com.bencodez.votingplugin.topvoter.TopVoter;
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable.VoteLogStatus;
 import com.google.gson.JsonElement;
@@ -1603,13 +1604,16 @@ public abstract class VotingPluginProxy {
 	private synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
 			VoteTotalsSnapshot text, String uuid, UUID existingVoteId) {
 		try {
+			if (!MinecraftUsernameValidator.isValid(player)) {
+				warn("Rejected vote with invalid Minecraft username '"
+						+ MinecraftUsernameValidator.sanitizeForLog(player) + "' from service '"
+						+ MinecraftUsernameValidator.sanitizeForLog(service) + "'");
+				return;
+			}
+
 			UUID voteId = existingVoteId;
 			if (voteId == null) {
 				voteId = UUID.randomUUID();
-			}
-			if (player == null || player.isEmpty()) {
-				log("No name from vote on " + service);
-				return;
 			}
 
 			// Handle time change queue

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VoteEventBungee.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VoteEventBungee.java
@@ -1,5 +1,6 @@
 package com.bencodez.votingplugin.proxy.bungee;
 
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
 import com.vexsoftware.votifier.bungee.events.VotifierEvent;
 import com.vexsoftware.votifier.model.Vote;
 
@@ -32,7 +33,8 @@ public class VoteEventBungee implements net.md_5.bungee.api.plugin.Listener {
 			public void run() {
 				Vote vote = event.getVote();
 				String serviceSite = vote.getServiceName();
-				plugin.getLogger().info("Vote received " + vote.getUsername() + " from service site " + serviceSite);
+				plugin.getLogger().info("Vote received " + MinecraftUsernameValidator.sanitizeForLog(vote.getUsername())
+						+ " from service site " + MinecraftUsernameValidator.sanitizeForLog(serviceSite));
 
 				if (serviceSite.isEmpty()) {
 					serviceSite = "Empty";

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VoteEventVelocity.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VoteEventVelocity.java
@@ -1,5 +1,6 @@
 package com.bencodez.votingplugin.proxy.velocity;
 
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
 import com.velocitypowered.api.event.Subscribe;
 import com.vexsoftware.votifier.velocity.event.VotifierEvent;
 
@@ -30,7 +31,8 @@ public class VoteEventVelocity {
 			@Override
 			public void run() {
 				String serviceSite = serviceSiteVote;
-				plugin.getLogger().info("Vote received " + name + " from service site " + serviceSite);
+				plugin.getLogger().info("Vote received " + MinecraftUsernameValidator.sanitizeForLog(name)
+						+ " from service site " + MinecraftUsernameValidator.sanitizeForLog(serviceSite));
 				if (serviceSite.isEmpty()) {
 					serviceSite = "Empty";
 				}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/MinecraftUsernameValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/MinecraftUsernameValidator.java
@@ -1,0 +1,53 @@
+package com.bencodez.votingplugin.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validates Java Edition player names received from external vote sources.
+ */
+public final class MinecraftUsernameValidator {
+	private static final int MAX_LENGTH = 16;
+	private static final int MAX_LOG_LENGTH = 32;
+	private static final Pattern VALID_USERNAME = Pattern.compile("[A-Za-z0-9_]{1," + MAX_LENGTH + "}");
+
+	private MinecraftUsernameValidator() {
+	}
+
+	/**
+	 * Tests whether a value uses the Minecraft Java username syntax.
+	 *
+	 * @param username username supplied by an external source
+	 * @return {@code true} for a 1-16 character ASCII letter, digit, or underscore
+	 */
+	public static boolean isValid(String username) {
+		return username != null && VALID_USERNAME.matcher(username).matches();
+	}
+
+	/**
+	 * Produces a bounded, single-line representation safe to include in logs.
+	 *
+	 * @param value untrusted external value
+	 * @return sanitized value
+	 */
+	public static String sanitizeForLog(String value) {
+		if (value == null) {
+			return "<null>";
+		}
+
+		StringBuilder sanitized = new StringBuilder(Math.min(value.length(), MAX_LOG_LENGTH));
+		int length = Math.min(value.length(), MAX_LOG_LENGTH);
+		for (int i = 0; i < length; i++) {
+			char character = value.charAt(i);
+			if ((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
+					|| (character >= '0' && character <= '9') || character == '_') {
+				sanitized.append(character);
+			} else {
+				sanitized.append('?');
+			}
+		}
+		if (value.length() > MAX_LOG_LENGTH) {
+			sanitized.append("...");
+		}
+		return sanitized.toString();
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/MinecraftUsernameValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/MinecraftUsernameValidatorTest.java
@@ -1,0 +1,25 @@
+package com.bencodez.votingplugin.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
+
+class MinecraftUsernameValidatorTest {
+
+	@ParameterizedTest
+	@ValueSource(strings = { "MchtName15Chars", "MchtNameOver16xx", "Player_123" })
+	void acceptsValidMinecraftUsernames(String username) {
+		assertTrue(MinecraftUsernameValidator.isValid(username));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash", "Mcht Space",
+			"Mcht\tTab", "Mcht\nLine", "Mcht\u0000Control", "Mcht- punctuation", "Mcht\u00E9Unicode", "\uD800" })
+	void rejectsInvalidMinecraftUsernames(String username) {
+		assertFalse(MinecraftUsernameValidator.isValid(username));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/MinecraftUsernameValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/MinecraftUsernameValidatorTest.java
@@ -3,23 +3,25 @@ package com.bencodez.votingplugin.tests;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 
 import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
 
 class MinecraftUsernameValidatorTest {
 
-	@ParameterizedTest
-	@ValueSource(strings = { "MchtName15Chars", "MchtNameOver16xx", "Player_123" })
-	void acceptsValidMinecraftUsernames(String username) {
-		assertTrue(MinecraftUsernameValidator.isValid(username));
+	@Test
+	void acceptsValidMinecraftUsernames() {
+		for (String username : new String[] { "MchtName15Chars", "MchtNameOver16xx", "Player_123" }) {
+			assertTrue(MinecraftUsernameValidator.isValid(username), username);
+		}
 	}
 
-	@ParameterizedTest
-	@ValueSource(strings = { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash", "Mcht Space",
-			"Mcht\tTab", "Mcht\nLine", "Mcht\u0000Control", "Mcht- punctuation", "Mcht\u00E9Unicode", "\uD800" })
-	void rejectsInvalidMinecraftUsernames(String username) {
-		assertFalse(MinecraftUsernameValidator.isValid(username));
+	@Test
+	void rejectsInvalidMinecraftUsernames() {
+		for (String username : new String[] { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash",
+				"Mcht Space", "Mcht\tTab", "Mcht\nLine", "Mcht\u0000Control", "Mcht- punctuation",
+				"Mcht\u00E9Unicode", "\uD800" }) {
+			assertFalse(MinecraftUsernameValidator.isValid(username), username);
+		}
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -88,7 +88,7 @@ public class VotingPluginProxyTest {
 	void invalidVoteStopsBeforeAnyPersistentRewardCacheOrForwardingState() {
 		for (String username : new String[] { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash",
 				"Mcht Space", "Mcht\tTab", "Mcht\u00E9Unicode" }) {
-			VotingPluginProxy spyProxy = Mockito.spy(votingPluginProxy);
+			VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
 
 			spyProxy.vote(username, "MCHT", true, true, 0, null, null);
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -2,11 +2,16 @@
 package com.bencodez.votingplugin.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -81,5 +86,23 @@ public class VotingPluginProxyTest {
 		// Add 2 more votes
 		votingPluginProxy.addCurrentVotePartyVotes(2);
 		assertEquals(5, votingPluginProxy.getVotePartyVotes());
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash", "Mcht Space",
+			"Mcht\tTab", "Mcht\u00E9Unicode" })
+	void invalidVoteStopsBeforeAnyPersistentRewardCacheOrForwardingState(String username) {
+		VotingPluginProxy spyProxy = Mockito.spy(votingPluginProxy);
+
+		spyProxy.vote(username, "MCHT", true, true, 0, null, null);
+
+		verify(spyProxy, never()).getUUID(Mockito.anyString());
+		verify(spyProxy, never()).addVoteParty();
+		verify(spyProxy, never()).getVoteCacheHandler();
+		verify(spyProxy, never()).getGlobalMessageProxyHandler();
+		verify(proxyMySQL, never()).containsKeyQuery(Mockito.anyString());
+		verify(multiProxyHandler, never()).sendMultiProxyEnvelope(Mockito.any());
+		assertEquals(0, spyProxy.getVotePartyVotes());
+		assertTrue(spyProxy.getWarnings().stream().anyMatch(warning -> warning.contains("Rejected vote")));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -72,8 +70,6 @@ public class VotingPluginProxyTest {
 		assertEquals(1, spyProxy.getVotePartyVotes());
 	}
 
-
-
 	@Test
 	void testAddCurrentVotePartyVotes() {
 		// Initial votePartyVotes should be 0
@@ -88,21 +84,22 @@ public class VotingPluginProxyTest {
 		assertEquals(5, votingPluginProxy.getVotePartyVotes());
 	}
 
-	@ParameterizedTest
-	@ValueSource(strings = { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash", "Mcht Space",
-			"Mcht\tTab", "Mcht\u00E9Unicode" })
-	void invalidVoteStopsBeforeAnyPersistentRewardCacheOrForwardingState(String username) {
-		VotingPluginProxy spyProxy = Mockito.spy(votingPluginProxy);
+	@Test
+	void invalidVoteStopsBeforeAnyPersistentRewardCacheOrForwardingState() {
+		for (String username : new String[] { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash",
+				"Mcht Space", "Mcht\tTab", "Mcht\u00E9Unicode" }) {
+			VotingPluginProxy spyProxy = Mockito.spy(votingPluginProxy);
 
-		spyProxy.vote(username, "MCHT", true, true, 0, null, null);
+			spyProxy.vote(username, "MCHT", true, true, 0, null, null);
 
-		verify(spyProxy, never()).getUUID(Mockito.anyString());
-		verify(spyProxy, never()).addVoteParty();
-		verify(spyProxy, never()).getVoteCacheHandler();
-		verify(spyProxy, never()).getGlobalMessageProxyHandler();
-		verify(proxyMySQL, never()).containsKeyQuery(Mockito.anyString());
-		verify(multiProxyHandler, never()).sendMultiProxyEnvelope(Mockito.any());
-		assertEquals(0, spyProxy.getVotePartyVotes());
-		assertTrue(spyProxy.getWarnings().stream().anyMatch(warning -> warning.contains("Rejected vote")));
+			verify(spyProxy, never()).getUUID(Mockito.anyString());
+			verify(spyProxy, never()).addVoteParty();
+			verify(spyProxy, never()).getVoteCacheHandler();
+			verify(spyProxy, never()).getGlobalMessageProxyHandler();
+			verify(proxyMySQL, never()).containsKeyQuery(Mockito.anyString());
+			verify(multiProxyHandler, never()).sendMultiProxyEnvelope(Mockito.any());
+			assertEquals(0, spyProxy.getVotePartyVotes(), username);
+			assertTrue(spyProxy.getWarnings().stream().anyMatch(warning -> warning.contains("Rejected vote")), username);
+		}
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -1,8 +1,10 @@
 package com.bencodez.votingplugin.tests;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ScheduledExecutorService;
@@ -14,6 +16,11 @@ import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
 
 public class VotingPluginProxyTestImpl extends VotingPluginProxy {
+	private final List<String> warnings = new ArrayList<>();
+
+	public List<String> getWarnings() {
+		return warnings;
+	}
 
 	@Override
 	public void addNonVotedPlayer(String uuid, String playerName) {
@@ -144,8 +151,7 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 
 	@Override
 	public void warn(String message) {
-		// For testing, simply print the warning message
-		System.err.println("WARNING: " + message);
+		warnings.add(message);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Reject invalid Minecraft usernames at the earliest VotingPlugin vote-ingress boundaries before any UUID generation or state mutation.

Valid Java Edition-style usernames continue to accept 1-16 ASCII letters, digits, and underscores, including previously unknown offline players and the exact 16-character value `MchtNameOver16xx`.

## Root cause

Proxy offline mode resolved an offline UUID before validating the externally supplied Votifier username. Values containing traversal syntax, slashes, whitespace, punctuation, Unicode, controls, or more than 16 characters could therefore reach MySQL totals, vote caches, rewards, and backend/proxy forwarding.

## Changes

- Add a central `MinecraftUsernameValidator` using `[A-Za-z0-9_]{1,16}`.
- Validate at the shared `VotingPluginProxy.vote(...)` boundary used by BungeeCord, Velocity, and multi-proxy vote replay.
- Validate standalone Bukkit Votifier events before service-site, queue, or `PlayerVoteEvent` processing.
- Sanitize and bound all rejected username/service values before logging.
- Sanitize the informational BungeeCord and Velocity Votifier receipt logs.
- Add regression coverage for invalid names and verify rejection happens before UUID lookup, totals/database access, vote-party/reward state, vote-cache access, backend messaging, or multi-proxy envelopes.
- Cover the 15-, 16-, and 17-character boundaries explicitly.

## Validation

- `git diff --check` — passed.
- Validator compiled directly and smoke tests passed for valid 15/16-character names and invalid 17-character, traversal, slash, whitespace, Unicode, and control-character values.
- Full Maven tests could not be run in the available workspace because Maven and JDK 21 were unavailable.

## MCHT follow-up

The MCHT harness is maintained outside this repository. Its invalid-length fixture must change from the valid 16-character `MchtNameOver16xx` to the genuine 17-character `MchtNameOver16xxx` before the next MCHT run.