### PR TITLE
Preserve validated vote identities

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
@@ -75,11 +75,28 @@ public class PlayerVoteListener implements Listener {
 			return;
 		}
 
-		// Resolve Bedrock/Java + add prefix only when appropriate AFTER validation
-		BedrockNameResolver.Result rn = plugin.getBedrockHandle().resolve(properName);
-		String creditedName = rn.finalName;
+		String creditedName;
+		String resolutionRationale;
+		if (validationResult.isValid()) {
+			// Validation checks exact online and stored identities before attempting a
+			// prefixed Bedrock fallback. Keep that decision authoritative so a second
+			// resolver pass cannot redirect an offline Java vote to an online Bedrock
+			// account with the same base name.
+			creditedName = validationResult.getNormalizedName();
+			if (creditedName == null || creditedName.isEmpty()) {
+				creditedName = properName;
+			}
+			resolutionRationale = "validation-"
+					+ validationResult.getSource().toString().toLowerCase(java.util.Locale.ROOT);
+		} else {
+			// Invalid users only reach this point when AllowUnjoined is enabled. Preserve
+			// the existing resolver behavior for those otherwise unknown identities.
+			BedrockNameResolver.Result rn = plugin.getBedrockHandle().resolve(properName);
+			creditedName = rn.finalName;
+			resolutionRationale = rn.rationale;
+		}
 
-		plugin.debug("Vote name resolved: " + properName + " -> " + creditedName + " (" + rn.rationale + ")");
+		plugin.debug("Vote name resolved: " + properName + " -> " + creditedName + " (" + resolutionRationale + ")");
 
 		// If we get here, use the resolved/possibly-prefixed name going forward
 		playerName = creditedName;


### PR DESCRIPTION
## Summary

- treat a successful `VotePlayerValidator` result as the authoritative player identity
- avoid running a second Bedrock-name resolution pass that can redirect an exact stored Java name to an online prefixed Bedrock player
- retain the existing resolver path for invalid-but-allowed unjoined votes
- include the validation source in debug output

## Why this is needed

Validation already checks exact online, cached, and stored identities before prefixed Bedrock fallbacks. The listener then discarded that decision and resolved the normalized name again. During a Java/Bedrock same-name collision, that second pass could select the online prefixed account and award it the Java account's vote.

This is a defensive companion to [AdvancedCore#281](https://github.com/BenCodez/AdvancedCore/pull/281), which fixes the shared resolver ordering itself.

## Behavior after this change

- Unprefixed votes validated as an exact Java identity stay attached to that Java identity.
- Explicitly prefixed incoming votes retain their Bedrock identity.
- Unique Bedrock fallback continues to be decided by validation.
- `AllowUnjoined` keeps its previous general-resolution behavior when validation cannot establish an identity.

## Validation

- `git diff --check`
- Maven and a JDK were unavailable in the local execution environment, so compilation and test execution are left to GitHub CI.

## AI disclosure

Created with assistance from OpenAI Codex.
