### PR TITLE
Correct spelling in user-facing source text

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -1544,7 +1544,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			}
 			if (!contains && !getConfigFile().isDisableNoServiceSiteMessage()) {
 				issues = false;
-				plugin.getLogger().warning("No vote has been recieved from " + site.getServiceSite()
+				plugin.getLogger().warning("No vote has been received from " + site.getServiceSite()
 						+ ", may be an invalid service site. Please read: https://github.com/BenCodez/VotingPlugin/wiki/Votifier-Troubleshooting");
 			}
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -651,7 +651,7 @@ public class CommandLoader {
 		plugin.getAdminVoteCommand()
 				.add(new CommandHandler(plugin, new String[] { "Perms", "(Number)", "(Player)" },
 						"VotingPlugin.Commands.AdminVote.Perms.Other|" + adminPerm,
-						"List permissions from the plugin the specificed player has") {
+						"List permissions from the plugin the specified player has") {
 
 					@Override
 					public void execute(CommandSender sender, String[] args) {
@@ -1418,7 +1418,7 @@ public class CommandLoader {
 
 		plugin.getAdminVoteCommand()
 				.add(new CommandHandler(plugin, new String[] { "VoteSite", "(sitename)", "SetServiceSite", "(string)" },
-						"VotingPlugin.Commands.AdminVote.VoteSite.Edit|" + adminPerm, "Set VoteSite SerivceSite") {
+						"VotingPlugin.Commands.AdminVote.VoteSite.Edit|" + adminPerm, "Set VoteSite ServiceSite") {
 
 					@Override
 					public void execute(CommandSender sender, String[] args) {
@@ -1565,7 +1565,7 @@ public class CommandLoader {
 						sender.sendMessage(MessageAPI.colorize("&aServiceSite is properly setup"));
 					} else {
 						sender.sendMessage(
-								MessageAPI.colorize("&cService may not be valid, haven't recieved a vote from "
+								MessageAPI.colorize("&cService may not be valid, haven't received a vote from "
 										+ service + ", see /av servicesites"));
 					}
 
@@ -3246,7 +3246,7 @@ public class CommandLoader {
 		plugin.getVoteCommand()
 				.add(new CommandHandler(plugin, new String[] { "ToggleBroadcast" },
 						"VotingPlugin.Commands.Vote.ToggleBroadcast|" + playerPerm,
-						"Toggle whether or not you will recieve vote broadcasts", false) {
+						"Toggle whether or not you will receive vote broadcasts", false) {
 
 					@Override
 					public void execute(CommandSender sender, String[] args) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/PlayerVoteListener.java
@@ -115,7 +115,7 @@ public class PlayerVoteListener implements Listener {
 					new ProxyVotifierEvent().send(plugin, event);
 				} catch (NoClassDefFoundError ex) {
 					plugin.getLogger().severe(
-							"Failed to trigger Votifier event for proxy vote. Either install votiifer or disable tirgger votiifer event");
+							"Failed to trigger Votifier event for proxy vote. Either install Votifier or disable triggering the Votifier event");
 					plugin.getLogger().severe("Error: " + ex.getMessage());
 					plugin.debug(ex);
 				}

--- a/VotingPlugin/src/main/resources/BungeeSettings.yml
+++ b/VotingPlugin/src/main/resources/BungeeSettings.yml
@@ -88,7 +88,7 @@ MQTT:
   BrokerURL: "tcp://localhost:1883"
   Username: ''
   Password: ''
-  # Set a prefix from an entire proxy network if using mutli-proxy setup below
+  # Set a prefix from an entire proxy network if using multi-proxy setup below
   Prefix: ''
 
 # Enables more debug messages for communication between servers

--- a/VotingPlugin/src/main/resources/bungeeconfig.yml
+++ b/VotingPlugin/src/main/resources/bungeeconfig.yml
@@ -279,7 +279,7 @@ Redis:
   Port: 6379
   Username: ''
   Password: ''
-  # Set a prefix from an entire proxy network if using mutli-proxy setup below
+  # Set a prefix from an entire proxy network if using multi-proxy setup below
   Prefix: ''
   #Db-Index: 0
 
@@ -300,7 +300,7 @@ MQTT:
   BrokerURL: "tcp://localhost:1883"
   Username: ''
   Password: ''
-  # Set a prefix from an entire proxy network if using mutli-proxy setup below
+  # Set a prefix from an entire proxy network if using multi-proxy setup below
   Prefix: ''
 
 ######################################################################################


### PR DESCRIPTION
## What changed

- correct spelling in generated command descriptions
- correct spelling in two user-facing warning messages
- clarify the Votifier event failure warning
- correct `multi-proxy` spelling in bundled configuration comments

## Why

Wiki pull request BenCodez/Wiki#8 corrects copies of several of these strings. Fixing their source prevents generated documentation and default configuration examples from reintroducing the mistakes.

## Impact

This is a text-only change. It does not rename commands, permissions, configuration keys, Java identifiers, or change runtime control flow.

## Validation

- compared the branch against `master`
- confirmed only three Java files and two YAML resource files changed
- verified every change is limited to string or comment text
- verified the branch is based on the current `master` commit

> **AI disclosure:** This pull request was created by ChatGPT/Codex at the maintainer's request. It should receive normal maintainer review before merge.