### PR TITLE
Validate vote service site names

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
@@ -44,6 +44,7 @@ import com.bencodez.votingplugin.proxy.BungeeMethod;
 import com.bencodez.votingplugin.proxy.VoteTotalsSnapshot;
 import com.bencodez.votingplugin.proxy.VotingPluginWire;
 import com.bencodez.votingplugin.user.VotingPluginUser;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
 import com.bencodez.votingplugin.votesites.VoteSite;
 
 import lombok.Getter;
@@ -619,6 +620,11 @@ public class BungeeHandler implements Listener {
 		String service = v.service;
 
 		if (uuidStr == null || uuidStr.isEmpty()) {
+			return;
+		}
+		if (!ServiceSiteValidator.isValid(service)) {
+			plugin.getLogger().warning("Rejected proxy vote with invalid service site '"
+					+ ServiceSiteValidator.sanitizeForLog(service) + "'");
 			return;
 		}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -1388,8 +1388,12 @@ public class CommandLoader {
 			public void execute(CommandSender sender, String[] args) {
 				sender.sendMessage(MessageAPI.colorize("&cCreating VoteSite..." + args[1]));
 
-				plugin.getConfigVoteSites().generateVoteSite(args[1]);
-				sender.sendMessage(MessageAPI.colorize("&cCreated VoteSite: &c&l" + args[1]));
+				if (plugin.getConfigVoteSites().tryGenerateVoteSite(args[1])) {
+					sender.sendMessage(MessageAPI.colorize("&cCreated VoteSite: &c&l" + args[1]));
+				} else {
+					sender.sendMessage(MessageAPI.colorize(
+							"&cUnable to create VoteSite: unsupported name or AutoCreateVoteSites is disabled"));
+				}
 
 			}
 		});

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/AdminGUI.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/AdminGUI.java
@@ -68,10 +68,19 @@ public class AdminGUI {
 
 						@Override
 						public void onInput(Player player, String value) {
-							plugin.getConfigVoteSites().generateVoteSite(value);
+							if (!plugin.getConfigVoteSites().tryGenerateVoteSite(value)) {
+								player.sendMessage(
+										"Unable to generate site: unsupported name or AutoCreateVoteSites is disabled");
+								return;
+							}
 							player.sendMessage("Generated site");
 							plugin.reload();
-							openAdminGUIVoteSiteSite(player, plugin.getVoteSiteManager().getVoteSite(value, true));
+							VoteSite generatedSite = plugin.getVoteSiteManager().getVoteSite(value, true);
+							if (generatedSite == null) {
+								player.sendMessage("Site was generated but could not be loaded");
+								return;
+							}
+							openAdminGUIVoteSiteSite(player, generatedSite);
 						}
 					});
 				} else {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ConfigVoteSites.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ConfigVoteSites.java
@@ -20,6 +20,7 @@ import com.bencodez.simpleapi.file.YMLFile;
 import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.simpleapi.time.ParsedDuration;
 import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
 import com.bencodez.votingplugin.votesites.VoteSite;
 
 // TODO: Auto-generated Javadoc
@@ -48,6 +49,11 @@ public class ConfigVoteSites extends YMLFile {
 	 */
 	public void generateVoteSite(String siteName) {
 		if (plugin.getConfigFile().isAutoCreateVoteSites()) {
+			if (!ServiceSiteValidator.isValid(siteName)) {
+				plugin.getLogger().warning("Unable to generate vote site with unsupported name '"
+						+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
+				return;
+			}
 			String org = siteName;
 			siteName = siteName.replaceAll("[\\.\\s]+", "_");
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ConfigVoteSites.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ConfigVoteSites.java
@@ -48,11 +48,21 @@ public class ConfigVoteSites extends YMLFile {
 	 * @param siteName the site name
 	 */
 	public void generateVoteSite(String siteName) {
+		tryGenerateVoteSite(siteName);
+	}
+
+	/**
+	 * Attempts to generate a vote site.
+	 *
+	 * @param siteName the site name
+	 * @return {@code true} if the site was generated
+	 */
+	public boolean tryGenerateVoteSite(String siteName) {
 		if (plugin.getConfigFile().isAutoCreateVoteSites()) {
 			if (!ServiceSiteValidator.isValid(siteName)) {
 				plugin.getLogger().warning("Unable to generate vote site with unsupported name '"
 						+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
-				return;
+				return false;
 			}
 			String org = siteName;
 			siteName = siteName.replaceAll("[\\.\\s]+", "_");
@@ -147,7 +157,9 @@ public class ConfigVoteSites extends YMLFile {
 							+ ", please check console for details"));
 				}
 			}
+			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
@@ -99,10 +99,13 @@ public class VotiferEvent implements Listener {
 					if (plugin.getConfigFile().isAutoCreateVoteSites() && createSite) {
 						plugin.getLogger().warning("VoteSite with service site '" + voteSiteNameStr
 								+ "' does not exist, attempting to generate...");
-						plugin.getConfigVoteSites().generateVoteSite(voteSiteNameStr);
-
-						plugin.getLogger().info("Current known service sites: "
-								+ ArrayUtils.makeStringList(plugin.getServerData().getServiceSites()));
+						if (plugin.getConfigVoteSites().tryGenerateVoteSite(voteSiteNameStr)) {
+							plugin.getLogger().info("Current known service sites: "
+									+ ArrayUtils.makeStringList(plugin.getServerData().getServiceSites()));
+						} else {
+							plugin.getLogger().warning("Unable to generate VoteSite for service site '"
+									+ ServiceSiteValidator.sanitizeForLog(voteSiteNameStr) + "'");
+						}
 					}
 
 					if (plugin.getTimeChecker().isActiveProcessing()

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
@@ -9,6 +9,7 @@ import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
 import com.bencodez.votingplugin.proxy.BungeeMethod;
 import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
 import com.vexsoftware.votifier.model.Vote;
 import com.vexsoftware.votifier.model.VotifierEvent;
 
@@ -38,13 +39,18 @@ public class VotiferEvent implements Listener {
 
 		Vote vote = event.getVote();
 		String str = vote.getServiceName();
-		if (str.isEmpty()) {
+		if (str == null || str.isEmpty()) {
 			str = "Empty";
 		}
 		final String voteSite = str;
 		final String IP = vote.getAddress();
 		final String voteUsername = vote.getUsername();
 		if (IP.equals("VotingPlugin")) {
+			return;
+		}
+		if (!ServiceSiteValidator.isValid(voteSite)) {
+			plugin.getLogger().warning("Rejected vote with invalid service site '"
+					+ ServiceSiteValidator.sanitizeForLog(voteSite) + "'");
 			return;
 		}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -65,6 +65,7 @@ import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyServerSocketConfigur
 import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable.VoteLogStatus;
 import com.google.gson.JsonElement;
@@ -1615,6 +1616,10 @@ public abstract class VotingPluginProxy {
 	private synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
 			VoteTotalsSnapshot text, String uuid, UUID existingVoteId) {
 		try {
+			if (!ServiceSiteValidator.isValid(service)) {
+				warn("Rejected vote with invalid service site '" + ServiceSiteValidator.sanitizeForLog(service) + "'");
+				return;
+			}
 			if (!MinecraftUsernameValidator.isValid(player, getConfig().getBedrockPlayerPrefix())) {
 				warn("Rejected vote with invalid Minecraft username '"
 						+ MinecraftUsernameValidator.sanitizeForLog(player) + "' from service '"

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
@@ -18,18 +18,22 @@ public final class ServiceSiteValidator {
 	 *         contain unsupported delimiters
 	 */
 	public static boolean isValid(String serviceSite) {
-		if (serviceSite == null || serviceSite.isBlank() || serviceSite.length() > MAX_LENGTH) {
+		if (serviceSite == null || serviceSite.length() > MAX_LENGTH) {
 			return false;
 		}
 
+		boolean hasVisibleCharacter = false;
 		for (int offset = 0; offset < serviceSite.length();) {
 			int codePoint = serviceSite.codePointAt(offset);
 			if (isDisallowed(codePoint)) {
 				return false;
 			}
+			if (!Character.isWhitespace(codePoint) && !Character.isSpaceChar(codePoint)) {
+				hasVisibleCharacter = true;
+			}
 			offset += Character.charCount(codePoint);
 		}
-		return true;
+		return hasVisibleCharacter;
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
@@ -1,14 +1,11 @@
 package com.bencodez.votingplugin.util;
 
-import java.util.regex.Pattern;
-
 /**
  * Validates service-site names received from vote sources.
  */
 public final class ServiceSiteValidator {
-	private static final int MAX_LENGTH = 128;
-	private static final Pattern VALID_SERVICE_SITE = Pattern
-			.compile("[A-Za-z0-9][A-Za-z0-9 ._:/-]{0," + (MAX_LENGTH - 1) + "}");
+	private static final int MAX_LENGTH = 2048;
+	private static final int MAX_LOG_LENGTH = 128;
 
 	private ServiceSiteValidator() {
 	}
@@ -17,11 +14,22 @@ public final class ServiceSiteValidator {
 	 * Tests whether a service-site name contains only supported characters.
 	 *
 	 * @param serviceSite service-site name supplied by a vote source
-	 * @return {@code true} for a bounded service-site name using supported ASCII
-	 *         characters
+	 * @return {@code true} for a bounded, visible service-site name that does not
+	 *         contain unsupported delimiters
 	 */
 	public static boolean isValid(String serviceSite) {
-		return serviceSite != null && VALID_SERVICE_SITE.matcher(serviceSite).matches();
+		if (serviceSite == null || serviceSite.isBlank() || serviceSite.length() > MAX_LENGTH) {
+			return false;
+		}
+
+		for (int offset = 0; offset < serviceSite.length();) {
+			int codePoint = serviceSite.codePointAt(offset);
+			if (isDisallowed(codePoint)) {
+				return false;
+			}
+			offset += Character.charCount(codePoint);
+		}
+		return true;
 	}
 
 	/**
@@ -35,21 +43,31 @@ public final class ServiceSiteValidator {
 			return "<null>";
 		}
 
-		StringBuilder sanitized = new StringBuilder(Math.min(value.length(), MAX_LENGTH));
-		int length = Math.min(value.length(), MAX_LENGTH);
-		for (int i = 0; i < length; i++) {
-			char character = value.charAt(i);
-			if ((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
-					|| (character >= '0' && character <= '9') || character == ' ' || character == '.'
-					|| character == '_' || character == ':' || character == '/' || character == '-') {
-				sanitized.append(character);
-			} else {
+		StringBuilder sanitized = new StringBuilder(Math.min(value.length(), MAX_LOG_LENGTH));
+		int offset = 0;
+		while (offset < value.length() && sanitized.length() < MAX_LOG_LENGTH) {
+			int codePoint = value.codePointAt(offset);
+			if (isDisallowed(codePoint)) {
 				sanitized.append('?');
+			} else {
+				sanitized.appendCodePoint(codePoint);
 			}
+			offset += Character.charCount(codePoint);
 		}
-		if (value.length() > MAX_LENGTH) {
+		if (offset < value.length()) {
 			sanitized.append("...");
 		}
 		return sanitized.toString();
+	}
+
+	private static boolean isDisallowed(int codePoint) {
+		if (codePoint == '[' || codePoint == ']' || codePoint == '\'' || codePoint == '"' || codePoint == '`'
+				|| codePoint == '\\') {
+			return true;
+		}
+
+		int type = Character.getType(codePoint);
+		return type == Character.CONTROL || type == Character.FORMAT || type == Character.LINE_SEPARATOR
+				|| type == Character.PARAGRAPH_SEPARATOR || type == Character.SURROGATE;
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
@@ -1,0 +1,55 @@
+package com.bencodez.votingplugin.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validates service-site names received from vote sources.
+ */
+public final class ServiceSiteValidator {
+	private static final int MAX_LENGTH = 128;
+	private static final Pattern VALID_SERVICE_SITE = Pattern
+			.compile("[A-Za-z0-9][A-Za-z0-9 ._:/-]{0," + (MAX_LENGTH - 1) + "}");
+
+	private ServiceSiteValidator() {
+	}
+
+	/**
+	 * Tests whether a service-site name contains only supported characters.
+	 *
+	 * @param serviceSite service-site name supplied by a vote source
+	 * @return {@code true} for a bounded service-site name using supported ASCII
+	 *         characters
+	 */
+	public static boolean isValid(String serviceSite) {
+		return serviceSite != null && VALID_SERVICE_SITE.matcher(serviceSite).matches();
+	}
+
+	/**
+	 * Produces a bounded, single-line representation safe to include in logs.
+	 *
+	 * @param value untrusted external value
+	 * @return sanitized value
+	 */
+	public static String sanitizeForLog(String value) {
+		if (value == null) {
+			return "<null>";
+		}
+
+		StringBuilder sanitized = new StringBuilder(Math.min(value.length(), MAX_LENGTH));
+		int length = Math.min(value.length(), MAX_LENGTH);
+		for (int i = 0; i < length; i++) {
+			char character = value.charAt(i);
+			if ((character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
+					|| (character >= '0' && character <= '9') || character == ' ' || character == '.'
+					|| character == '_' || character == ':' || character == '/' || character == '-') {
+				sanitized.append(character);
+			} else {
+				sanitized.append('?');
+			}
+		}
+		if (value.length() > MAX_LENGTH) {
+			sanitized.append("...");
+		}
+		return sanitized.toString();
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
@@ -76,12 +76,28 @@ public final class ServiceSiteValidator {
 	}
 
 	private static boolean isVisibleBaseCharacter(int codePoint) {
-		if (Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint)) {
+		if (Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint)
+				|| isDefaultIgnorable(codePoint)) {
 			return false;
 		}
 
 		int type = Character.getType(codePoint);
 		return type != Character.NON_SPACING_MARK && type != Character.COMBINING_SPACING_MARK
 				&& type != Character.ENCLOSING_MARK;
+	}
+
+	private static boolean isDefaultIgnorable(int codePoint) {
+		return codePoint == 0x00AD || codePoint == 0x034F || codePoint == 0x061C
+				|| (codePoint >= 0x115F && codePoint <= 0x1160)
+				|| (codePoint >= 0x17B4 && codePoint <= 0x17B5)
+				|| (codePoint >= 0x180B && codePoint <= 0x180F)
+				|| (codePoint >= 0x200B && codePoint <= 0x200F)
+				|| (codePoint >= 0x202A && codePoint <= 0x202E)
+				|| (codePoint >= 0x2060 && codePoint <= 0x206F) || codePoint == 0x3164
+				|| (codePoint >= 0xFE00 && codePoint <= 0xFE0F) || codePoint == 0xFEFF
+				|| codePoint == 0xFFA0 || (codePoint >= 0xFFF0 && codePoint <= 0xFFF8)
+				|| (codePoint >= 0x1BCA0 && codePoint <= 0x1BCA3)
+				|| (codePoint >= 0x1D173 && codePoint <= 0x1D17A)
+				|| (codePoint >= 0xE0000 && codePoint <= 0xE0FFF);
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ServiceSiteValidator.java
@@ -28,7 +28,7 @@ public final class ServiceSiteValidator {
 			if (isDisallowed(codePoint)) {
 				return false;
 			}
-			if (!Character.isWhitespace(codePoint) && !Character.isSpaceChar(codePoint)) {
+			if (isVisibleBaseCharacter(codePoint)) {
 				hasVisibleCharacter = true;
 			}
 			offset += Character.charCount(codePoint);
@@ -73,5 +73,15 @@ public final class ServiceSiteValidator {
 		int type = Character.getType(codePoint);
 		return type == Character.CONTROL || type == Character.FORMAT || type == Character.LINE_SEPARATOR
 				|| type == Character.PARAGRAPH_SEPARATOR || type == Character.SURROGATE;
+	}
+
+	private static boolean isVisibleBaseCharacter(int codePoint) {
+		if (Character.isWhitespace(codePoint) || Character.isSpaceChar(codePoint)) {
+			return false;
+		}
+
+		int type = Character.getType(codePoint);
+		return type != Character.NON_SPACING_MARK && type != Character.COMBINING_SPACING_MARK
+				&& type != Character.ENCLOSING_MARK;
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
@@ -153,7 +153,9 @@ public class VoteSiteManager {
 						+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
 				return null;
 			}
-			plugin.getConfigVoteSites().generateVoteSite(siteName);
+			if (!plugin.getConfigVoteSites().tryGenerateVoteSite(siteName)) {
+				return null;
+			}
 			return new VoteSite(plugin, normalizeVoteSiteKey(siteName));
 		}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -147,6 +148,11 @@ public class VoteSiteManager {
 		}
 
 		if (plugin.getConfigFile().isAutoCreateVoteSites() && !hasVoteSite(siteName)) {
+			if (!ServiceSiteValidator.isValid(siteName)) {
+				plugin.getLogger().warning("Unable to auto-create vote site with unsupported name '"
+						+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
+				return null;
+			}
 			plugin.getConfigVoteSites().generateVoteSite(siteName);
 			return new VoteSite(plugin, normalizeVoteSiteKey(siteName));
 		}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
@@ -1,0 +1,37 @@
+package com.bencodez.votingplugin.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
+
+class ServiceSiteValidatorTest {
+
+	@Test
+	void acceptsCommonServiceSiteNames() {
+		for (String serviceSite : new String[] { "PlanetMinecraft.com", "Minecraft Server List", "Crafty.gg",
+				"https://example.com/vote", "site_name-2" }) {
+			assertTrue(ServiceSiteValidator.isValid(serviceSite), serviceSite);
+		}
+	}
+
+	@Test
+	void rejectsUnsupportedCharacters() {
+		for (String serviceSite : new String[] { "[Javascript=1]", "Site's", "\"Site\"", "Site%player%",
+				"Site,Other", "Site;Other", "Site#Comment", "Site`Name", "Site\\Name", "Site\nName",
+				"Site\tName" }) {
+			assertFalse(ServiceSiteValidator.isValid(serviceSite), serviceSite);
+		}
+	}
+
+	@Test
+	void rejectsMissingAndOversizedNames() {
+		assertFalse(ServiceSiteValidator.isValid(null));
+		assertFalse(ServiceSiteValidator.isValid(""));
+		assertFalse(ServiceSiteValidator.isValid(" "));
+		assertFalse(ServiceSiteValidator.isValid("A".repeat(129)));
+		assertTrue(ServiceSiteValidator.isValid("A".repeat(128)));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
@@ -14,7 +14,7 @@ class ServiceSiteValidatorTest {
 		for (String serviceSite : new String[] { "PlanetMinecraft.com", "Minecraft Server List", "Crafty.gg",
 				"https://example.com/vote", "https://list.example/vote?id=1&source=proxy#top",
 				"https://example.com/search?q=site%20name+network", "site_name-2", "Site, Other; Network!",
-				"Serviço de votação" }) {
+				"Serviço de votação", "Site\u00A0Name" }) {
 			assertTrue(ServiceSiteValidator.isValid(serviceSite), serviceSite);
 		}
 	}
@@ -32,6 +32,10 @@ class ServiceSiteValidatorTest {
 		assertFalse(ServiceSiteValidator.isValid(null));
 		assertFalse(ServiceSiteValidator.isValid(""));
 		assertFalse(ServiceSiteValidator.isValid(" "));
+		assertFalse(ServiceSiteValidator.isValid("\u00A0"));
+		assertFalse(ServiceSiteValidator.isValid("\u2007"));
+		assertFalse(ServiceSiteValidator.isValid("\u202F"));
+		assertFalse(ServiceSiteValidator.isValid(" \u00A0\u2007\u202F "));
 		assertFalse(ServiceSiteValidator.isValid("A".repeat(2049)));
 		assertTrue(ServiceSiteValidator.isValid("A".repeat(2048)));
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
@@ -14,7 +14,7 @@ class ServiceSiteValidatorTest {
 		for (String serviceSite : new String[] { "PlanetMinecraft.com", "Minecraft Server List", "Crafty.gg",
 				"https://example.com/vote", "https://list.example/vote?id=1&source=proxy#top",
 				"https://example.com/search?q=site%20name+network", "site_name-2", "Site, Other; Network!",
-				"Serviço de votação", "Site\u00A0Name" }) {
+				"Serviço de votação", "Site\u00A0Name", "Site\uFE0F", "Cafe\u0301" }) {
 			assertTrue(ServiceSiteValidator.isValid(serviceSite), serviceSite);
 		}
 	}
@@ -36,6 +36,10 @@ class ServiceSiteValidatorTest {
 		assertFalse(ServiceSiteValidator.isValid("\u2007"));
 		assertFalse(ServiceSiteValidator.isValid("\u202F"));
 		assertFalse(ServiceSiteValidator.isValid(" \u00A0\u2007\u202F "));
+		assertFalse(ServiceSiteValidator.isValid("\uFE0F"));
+		assertFalse(ServiceSiteValidator.isValid("\u034F"));
+		assertFalse(ServiceSiteValidator.isValid("\u0301"));
+		assertFalse(ServiceSiteValidator.isValid("\uFE0F\u034F\u0301"));
 		assertFalse(ServiceSiteValidator.isValid("A".repeat(2049)));
 		assertTrue(ServiceSiteValidator.isValid("A".repeat(2048)));
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
@@ -12,16 +12,17 @@ class ServiceSiteValidatorTest {
 	@Test
 	void acceptsCommonServiceSiteNames() {
 		for (String serviceSite : new String[] { "PlanetMinecraft.com", "Minecraft Server List", "Crafty.gg",
-				"https://example.com/vote", "site_name-2" }) {
+				"https://example.com/vote", "https://list.example/vote?id=1&source=proxy#top",
+				"https://example.com/search?q=site%20name+network", "site_name-2", "Site, Other; Network!",
+				"Serviço de votação" }) {
 			assertTrue(ServiceSiteValidator.isValid(serviceSite), serviceSite);
 		}
 	}
 
 	@Test
 	void rejectsUnsupportedCharacters() {
-		for (String serviceSite : new String[] { "[Javascript=1]", "Site's", "\"Site\"", "Site%player%",
-				"Site,Other", "Site;Other", "Site#Comment", "Site`Name", "Site\\Name", "Site\nName",
-				"Site\tName" }) {
+		for (String serviceSite : new String[] { "[Javascript=1]", "Site's", "\"Site\"", "Site`Name",
+				"Site\\Name", "Site\nName", "Site\tName", "Site\u0000Name", "Site\u200BName" }) {
 			assertFalse(ServiceSiteValidator.isValid(serviceSite), serviceSite);
 		}
 	}
@@ -31,7 +32,7 @@ class ServiceSiteValidatorTest {
 		assertFalse(ServiceSiteValidator.isValid(null));
 		assertFalse(ServiceSiteValidator.isValid(""));
 		assertFalse(ServiceSiteValidator.isValid(" "));
-		assertFalse(ServiceSiteValidator.isValid("A".repeat(129)));
-		assertTrue(ServiceSiteValidator.isValid("A".repeat(128)));
+		assertFalse(ServiceSiteValidator.isValid("A".repeat(2049)));
+		assertTrue(ServiceSiteValidator.isValid("A".repeat(2048)));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ServiceSiteValidatorTest.java
@@ -14,7 +14,7 @@ class ServiceSiteValidatorTest {
 		for (String serviceSite : new String[] { "PlanetMinecraft.com", "Minecraft Server List", "Crafty.gg",
 				"https://example.com/vote", "https://list.example/vote?id=1&source=proxy#top",
 				"https://example.com/search?q=site%20name+network", "site_name-2", "Site, Other; Network!",
-				"Serviço de votação", "Site\u00A0Name", "Site\uFE0F", "Cafe\u0301" }) {
+				"Serviço de votação", "Site\u00A0Name", "Site\uFE0F", "Cafe\u0301", "Site\u3164Name" }) {
 			assertTrue(ServiceSiteValidator.isValid(serviceSite), serviceSite);
 		}
 	}
@@ -40,6 +40,12 @@ class ServiceSiteValidatorTest {
 		assertFalse(ServiceSiteValidator.isValid("\u034F"));
 		assertFalse(ServiceSiteValidator.isValid("\u0301"));
 		assertFalse(ServiceSiteValidator.isValid("\uFE0F\u034F\u0301"));
+		assertFalse(ServiceSiteValidator.isValid("\u115F"));
+		assertFalse(ServiceSiteValidator.isValid("\u1160"));
+		assertFalse(ServiceSiteValidator.isValid("\u3164"));
+		assertFalse(ServiceSiteValidator.isValid("\uFFA0"));
+		assertFalse(ServiceSiteValidator.isValid("\uFFF0"));
+		assertFalse(ServiceSiteValidator.isValid(new String(Character.toChars(0xE0001))));
 		assertFalse(ServiceSiteValidator.isValid("A".repeat(2049)));
 		assertTrue(ServiceSiteValidator.isValid("A".repeat(2048)));
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -152,6 +153,16 @@ public class VoteSiteManagerTest {
 
 		assertEquals("new_site", created.getKey());
 		verify(voteSitesConfig).generateVoteSite("new.site");
+	}
+
+	@Test
+	public void testGetVoteSiteDoesNotAutoCreateUnsupportedName() {
+		when(configFile.isAutoCreateVoteSites()).thenReturn(true);
+
+		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>()));
+
+		assertNull(manager.getVoteSite("[Unsupported]", false));
+		verify(voteSitesConfig, never()).generateVoteSite(anyString());
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
@@ -145,6 +145,7 @@ public class VoteSiteManagerTest {
 	@Test
 	public void testGetVoteSiteAutoCreatesWhenEnabledAndNotPresentInConfig() {
 		when(configFile.isAutoCreateVoteSites()).thenReturn(true);
+		when(voteSitesConfig.tryGenerateVoteSite("new.site")).thenReturn(true);
 
 		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>()));
 
@@ -152,7 +153,18 @@ public class VoteSiteManagerTest {
 		assertNotNull(created, "Should auto-create VoteSite when enabled and not configured");
 
 		assertEquals("new_site", created.getKey());
-		verify(voteSitesConfig).generateVoteSite("new.site");
+		verify(voteSitesConfig).tryGenerateVoteSite("new.site");
+	}
+
+	@Test
+	public void testGetVoteSiteReturnsNullWhenGenerationFails() {
+		when(configFile.isAutoCreateVoteSites()).thenReturn(true);
+		when(voteSitesConfig.tryGenerateVoteSite("new.site")).thenReturn(false);
+
+		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>()));
+
+		assertNull(manager.getVoteSite("new.site", false));
+		verify(voteSitesConfig).tryGenerateVoteSite("new.site");
 	}
 
 	@Test
@@ -162,7 +174,7 @@ public class VoteSiteManagerTest {
 		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>()));
 
 		assertNull(manager.getVoteSite("[Unsupported]", false));
-		verify(voteSitesConfig, never()).generateVoteSite(anyString());
+		verify(voteSitesConfig, never()).tryGenerateVoteSite(anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- add a shared validator for external service-site names
- accept ordinary names, Unicode, domains, and complete URLs with query strings and fragments
- reject square brackets, ASCII quotes, backticks, backslashes, and invisible or control characters
- apply validation to standalone, proxy, backend-wire, and automatic-site creation paths
- report rejected site creation to GUI, command, listener, and manager callers without breaking the existing public method signature
- add unit and manager-level coverage

## Why
Service-site names are used in matching, storage, logging, and generated configuration paths. A targeted validation rule prevents malformed entries without rejecting legitimate service names or URLs already used by vote sources. Explicit generation results prevent callers from reporting success or opening an editor when no site was created.

## Accepted format
Non-blank service-site names up to 2,048 characters. Normal URL punctuation is supported, including `:`, `/`, `?`, `=`, `&`, `%`, `+`, and `#`. For example: `https://list.example/vote?id=1&source=proxy#top`.

Square brackets, single and double ASCII quotes, backticks, backslashes, and invisible/control characters are rejected.

## Validation
- parsed all changed Java sources successfully
- added focused JUnit coverage for full URLs, URL-encoded values, Unicode names, rejected delimiters, controls, length bounds, and generation failure propagation
- full Maven validation will run in GitHub Actions because the local environment does not include Maven or a Java 21 compiler