### PR TITLE
Broadcast proxy votes immediately in FORWARD mode

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
@@ -355,8 +355,9 @@ public class BungeeHandler implements Listener {
 				// New fields (May use later)
 				@SuppressWarnings("unused")
 				final long time = readLongSafe(f.get(VotingPluginWire.K_TIME), 0L);
-				@SuppressWarnings("unused")
-				final String totals = nvl(f.get(VotingPluginWire.K_TOTALS));
+				final String totalsRaw = nvl(f.get(VotingPluginWire.K_TOTALS));
+				final VoteTotalsSnapshot totals = totalsRaw.isEmpty() ? null
+						: VoteTotalsSnapshot.parseStorage(totalsRaw);
 
 				VoteSite voteSite = plugin.getVoteSiteManager()
 						.getVoteSite(plugin.getVoteSiteManager().getVoteSiteName(true, service), true);
@@ -394,7 +395,7 @@ public class BungeeHandler implements Listener {
 						? Boolean.parseBoolean(f.get(VotingPluginWire.K_WAS_ONLINE))
 						: user.isOnline();
 				plugin.getBroadcastHandler().broadcastVote(user.getJavaUUID(), user.getPlayerName(),
-						voteSite.getDisplayName(), online);
+						voteSite.getDisplayName(), online, totals);
 			}
 		});
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/BungeeHandler.java
@@ -388,7 +388,11 @@ public class BungeeHandler implements Listener {
 					return;
 				}
 
-				final boolean online = user.isOnline(); // same behavior as non-bungee vote path
+				// New proxies preserve the state sampled when the vote arrived. Fall back to
+				// the legacy delivery-time behavior for envelopes from older proxies.
+				final boolean online = f.containsKey(VotingPluginWire.K_WAS_ONLINE)
+						? Boolean.parseBoolean(f.get(VotingPluginWire.K_WAS_ONLINE))
+						: user.isOnline();
 				plugin.getBroadcastHandler().broadcastVote(user.getJavaUUID(), user.getPlayerName(),
 						voteSite.getDisplayName(), online);
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
@@ -181,7 +181,9 @@ public final class BroadcastHandler {
 		OfflinePlayer votedPlayer = votedPlayerUuid == null ? null : Bukkit.getOfflinePlayer(votedPlayerUuid);
 
 		for (String line : lines) {
-			String totalsLine = totals == null ? line : totals.applyBroadcastPlaceholders(line);
+			String totalsLine = totals == null ? line
+					: totals.applyBroadcastPlaceholders(line,
+							plugin.getConfigFile().isUseMonthDateTotalsAsPrimaryTotal());
 			String parsedLine = PlaceholderUtils.replacePlaceHolders(votedPlayer, totalsLine);
 			broadcastToEligiblePlayers(parsedLine);
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
@@ -261,6 +261,8 @@ public final class BroadcastHandler {
 			VoteTotalsSnapshot totals) {
 		if (totals != null) {
 			pendingTotals.put(uuid, totals);
+		} else {
+			pendingTotals.remove(uuid);
 		}
 		if (siteName != null && !siteName.isEmpty()) {
 			LinkedHashSet<String> sites = pendingSites.get(uuid);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/broadcast/BroadcastHandler.java
@@ -25,6 +25,7 @@ import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.simpleapi.player.PlayerUtils;
 import com.bencodez.simpleapi.time.ParsedDuration;
 import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.proxy.VoteTotalsSnapshot;
 import com.bencodez.votingplugin.user.VotingPluginUser;
 
 /**
@@ -49,6 +50,7 @@ public final class BroadcastHandler {
 	private final ConcurrentHashMap<UUID, Instant> lastBroadcastAt = new ConcurrentHashMap<UUID, Instant>();
 
 	private final ConcurrentHashMap<UUID, LinkedHashSet<String>> pendingSites = new ConcurrentHashMap<UUID, LinkedHashSet<String>>();
+	private final ConcurrentHashMap<UUID, VoteTotalsSnapshot> pendingTotals = new ConcurrentHashMap<UUID, VoteTotalsSnapshot>();
 	private final ConcurrentHashMap<UUID, BukkitTask> pendingFlush = new ConcurrentHashMap<UUID, BukkitTask>();
 
 	private final ConcurrentHashMap<UUID, LocalDate> firstVoteDay = new ConcurrentHashMap<UUID, LocalDate>();
@@ -91,6 +93,20 @@ public final class BroadcastHandler {
 	 * @param wasOnline whether the voted player was online when the vote was received
 	 */
 	public void broadcastVote(UUID uuid, String playerName, String siteName, boolean wasOnline) {
+		broadcastVote(uuid, playerName, siteName, wasOnline, null);
+	}
+
+	/**
+	 * Handles a received vote with an optional proxy-projected totals snapshot.
+	 *
+	 * @param uuid the voted player's UUID
+	 * @param playerName the player name, or null to resolve it from Bukkit
+	 * @param siteName the vote site display name
+	 * @param wasOnline whether the voted player was online when the vote was received
+	 * @param totals projected totals for this broadcast, or null to use stored values
+	 */
+	public void broadcastVote(UUID uuid, String playerName, String siteName, boolean wasOnline,
+			VoteTotalsSnapshot totals) {
 		BroadcastSettings currentSettings = settings;
 		if (currentSettings == null || currentSettings.isDisabled()) {
 			return;
@@ -105,21 +121,21 @@ public final class BroadcastHandler {
 			if (!wasOnline) {
 				return;
 			}
-			broadcastNow(uuid, name, single(siteName), "vote_online_only", null);
+			broadcastNow(uuid, name, single(siteName), "vote_online_only", null, totals);
 			return;
 		}
 
 		if (type == VoteBroadcastType.EVERY_VOTE) {
-			broadcastNow(uuid, name, single(siteName), "vote", null);
+			broadcastNow(uuid, name, single(siteName), "vote", null, totals);
 		} else if (type == VoteBroadcastType.COOLDOWN_PER_PLAYER) {
 			if (checkAndMarkCooldown(uuid, currentSettings.getDuration())) {
-				broadcastNow(uuid, name, single(siteName), "cooldown", null);
+				broadcastNow(uuid, name, single(siteName), "cooldown", null, totals);
 			}
 		} else if (type == VoteBroadcastType.BATCH_WINDOW_PER_PLAYER) {
-			bufferBatch(uuid, name, siteName, currentSettings.getDuration());
+			bufferBatch(uuid, name, siteName, currentSettings.getDuration(), totals);
 		} else if (type == VoteBroadcastType.FIRST_VOTE_OF_DAY) {
 			if (markFirstVoteOfDay(uuid)) {
-				broadcastNow(uuid, name, single(siteName), "first_day", null);
+				broadcastNow(uuid, name, single(siteName), "first_day", null, totals);
 			}
 		} else if (type == VoteBroadcastType.INTERVAL_SUMMARY_GLOBAL) {
 			// Handled by the scheduled interval task.
@@ -139,7 +155,7 @@ public final class BroadcastHandler {
 	 * @param extraContext additional format context, or null
 	 */
 	private void broadcastNow(UUID votedPlayerUuid, String playerName, List<String> sites, String reason,
-			Map<String, String> extraContext) {
+			Map<String, String> extraContext, VoteTotalsSnapshot totals) {
 		BroadcastSettings currentSettings = settings;
 		if (currentSettings == null || currentSettings.isDisabled()) {
 			return;
@@ -165,7 +181,8 @@ public final class BroadcastHandler {
 		OfflinePlayer votedPlayer = votedPlayerUuid == null ? null : Bukkit.getOfflinePlayer(votedPlayerUuid);
 
 		for (String line : lines) {
-			String parsedLine = PlaceholderUtils.replacePlaceHolders(votedPlayer, line);
+			String totalsLine = totals == null ? line : totals.applyBroadcastPlaceholders(line);
+			String parsedLine = PlaceholderUtils.replacePlaceHolders(votedPlayer, totalsLine);
 			broadcastToEligiblePlayers(parsedLine);
 		}
 	}
@@ -238,7 +255,11 @@ public final class BroadcastHandler {
 	 * @param siteName the vote site
 	 * @param window the batch window
 	 */
-	private void bufferBatch(UUID uuid, String playerName, String siteName, ParsedDuration window) {
+	private void bufferBatch(UUID uuid, String playerName, String siteName, ParsedDuration window,
+			VoteTotalsSnapshot totals) {
+		if (totals != null) {
+			pendingTotals.put(uuid, totals);
+		}
 		if (siteName != null && !siteName.isEmpty()) {
 			LinkedHashSet<String> sites = pendingSites.get(uuid);
 			if (sites == null) {
@@ -295,6 +316,7 @@ public final class BroadcastHandler {
 	 */
 	private void flushBatch(UUID uuid, String playerName) {
 		Set<String> sites = pendingSites.remove(uuid);
+		VoteTotalsSnapshot totals = pendingTotals.remove(uuid);
 		if (sites == null || sites.isEmpty()) {
 			return;
 		}
@@ -304,7 +326,7 @@ public final class BroadcastHandler {
 			siteList = new ArrayList<String>(sites);
 		}
 
-		broadcastNow(uuid, playerName, siteList, "batch", null);
+		broadcastNow(uuid, playerName, siteList, "batch", null, totals);
 	}
 
 	/**
@@ -442,7 +464,7 @@ public final class BroadcastHandler {
 		context.put("sites", sitesCsv);
 		context.put("numberofsites", String.valueOf(uniqueSites.size()));
 
-		broadcastNow(null, "Server", entries, "interval", context);
+		broadcastNow(null, "Server", entries, "interval", context, null);
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
@@ -43,6 +43,9 @@ public class OfflineBungeeVote {
 	@Getter
 	@Setter
 	private boolean rewardDelivered;
+	@Getter
+	@Setter
+	private boolean deliveryStateDirty;
 
 	/**
 	 * Constructor with UUID voteId.

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
@@ -25,6 +25,8 @@ public class OfflineBungeeVote {
 	private String uuid;
 	@Getter
 	private UUID voteId;
+	@Getter
+	private boolean broadcastForwarded;
 
 	/**
 	 * Constructor with UUID voteId.
@@ -38,6 +40,22 @@ public class OfflineBungeeVote {
 	 */
 	public OfflineBungeeVote(UUID voteId, String playerName, String uuid, String service, long time, boolean realVote,
 			String text) {
+		this(voteId, playerName, uuid, service, time, realVote, text, false);
+	}
+
+	/**
+	 * Constructor with UUID voteId and proxy broadcast delivery state.
+	 * @param voteId the vote ID
+	 * @param playerName the player name
+	 * @param uuid the player UUID
+	 * @param service the vote service
+	 * @param time the vote time
+	 * @param realVote whether this is a real vote
+	 * @param text additional text
+	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+	 */
+	public OfflineBungeeVote(UUID voteId, String playerName, String uuid, String service, long time, boolean realVote,
+			String text, boolean broadcastForwarded) {
 		this.playerName = playerName;
 		this.uuid = uuid;
 		this.service = service;
@@ -45,6 +63,7 @@ public class OfflineBungeeVote {
 		this.realVote = realVote;
 		this.text = text;
 		this.voteId = voteId;
+		this.broadcastForwarded = broadcastForwarded;
 	}
 	
 	/**
@@ -59,12 +78,29 @@ public class OfflineBungeeVote {
 	 */
 	public OfflineBungeeVote(String voteId, String playerName, String uuid, String service, long time, boolean realVote,
 			String text) {
+		this(voteId, playerName, uuid, service, time, realVote, text, false);
+	}
+
+	/**
+	 * Constructor with String voteId and proxy broadcast delivery state.
+	 * @param voteId the vote ID as string
+	 * @param playerName the player name
+	 * @param uuid the player UUID
+	 * @param service the vote service
+	 * @param time the vote time
+	 * @param realVote whether this is a real vote
+	 * @param text additional text
+	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+	 */
+	public OfflineBungeeVote(String voteId, String playerName, String uuid, String service, long time, boolean realVote,
+			String text, boolean broadcastForwarded) {
 		this.playerName = playerName;
 		this.uuid = uuid;
 		this.service = service;
 		this.time = time;
 		this.realVote = realVote;
 		this.text = text;
+		this.broadcastForwarded = broadcastForwarded;
 		if (voteId != null && !voteId.isEmpty()) {
 			this.voteId = UUID.fromString(voteId);
 		} else {
@@ -75,7 +111,7 @@ public class OfflineBungeeVote {
 	@Override
 	public String toString() {
 		return "VoteCache:" + playerName + "/" + uuid + "/" + service + "/" + time + "/" + realVote + "/" + text + "/"
-				+ voteId;
+				+ voteId + "/" + broadcastForwarded;
 	}
 
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/OfflineBungeeVote.java
@@ -1,6 +1,11 @@
 package com.bencodez.votingplugin.proxy;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.UUID;
+
+import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -26,7 +31,18 @@ public class OfflineBungeeVote {
 	@Getter
 	private UUID voteId;
 	@Getter
+	@Setter
 	private boolean broadcastForwarded;
+	@Getter
+	@Setter
+	private boolean proxyBroadcastHandled;
+	@Getter
+	private Set<String> broadcastTargets;
+	@Getter
+	private Set<String> broadcastForwardedServers;
+	@Getter
+	@Setter
+	private boolean rewardDelivered;
 
 	/**
 	 * Constructor with UUID voteId.
@@ -56,6 +72,28 @@ public class OfflineBungeeVote {
 	 */
 	public OfflineBungeeVote(UUID voteId, String playerName, String uuid, String service, long time, boolean realVote,
 			String text, boolean broadcastForwarded) {
+		this(voteId, playerName, uuid, service, time, realVote, text, broadcastForwarded, false,
+				Collections.emptySet(), Collections.emptySet(), false);
+	}
+
+	/**
+	 * Constructor with full proxy broadcast delivery state.
+	 * @param voteId the vote ID
+	 * @param playerName the player name
+	 * @param uuid the player UUID
+	 * @param service the vote service
+	 * @param time the vote time
+	 * @param realVote whether this is a real vote
+	 * @param text additional text
+	 * @param broadcastForwarded legacy aggregate forwarded state
+	 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+	 * @param broadcastTargets original standalone broadcast targets
+	 * @param broadcastForwardedServers targets that accepted standalone delivery
+	 * @param rewardDelivered whether the cached reward vote was already delivered
+	 */
+	public OfflineBungeeVote(UUID voteId, String playerName, String uuid, String service, long time, boolean realVote,
+			String text, boolean broadcastForwarded, boolean proxyBroadcastHandled, Set<String> broadcastTargets,
+			Set<String> broadcastForwardedServers, boolean rewardDelivered) {
 		this.playerName = playerName;
 		this.uuid = uuid;
 		this.service = service;
@@ -64,6 +102,10 @@ public class OfflineBungeeVote {
 		this.text = text;
 		this.voteId = voteId;
 		this.broadcastForwarded = broadcastForwarded;
+		this.proxyBroadcastHandled = proxyBroadcastHandled;
+		setBroadcastTargets(broadcastTargets);
+		setBroadcastForwardedServers(broadcastForwardedServers);
+		this.rewardDelivered = rewardDelivered;
 	}
 	
 	/**
@@ -94,24 +136,93 @@ public class OfflineBungeeVote {
 	 */
 	public OfflineBungeeVote(String voteId, String playerName, String uuid, String service, long time, boolean realVote,
 			String text, boolean broadcastForwarded) {
-		this.playerName = playerName;
-		this.uuid = uuid;
-		this.service = service;
-		this.time = time;
-		this.realVote = realVote;
-		this.text = text;
-		this.broadcastForwarded = broadcastForwarded;
-		if (voteId != null && !voteId.isEmpty()) {
-			this.voteId = UUID.fromString(voteId);
-		} else {
-			this.voteId = null;
+		this(parseVoteId(voteId), playerName, uuid, service, time, realVote, text, broadcastForwarded);
+	}
+
+	/**
+	 * Constructor with String voteId and full proxy broadcast delivery state.
+	 * @param voteId the vote ID as string
+	 * @param playerName the player name
+	 * @param uuid the player UUID
+	 * @param service the vote service
+	 * @param time the vote time
+	 * @param realVote whether this is a real vote
+	 * @param text additional text
+	 * @param broadcastForwarded legacy aggregate forwarded state
+	 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+	 * @param broadcastTargets original standalone broadcast targets
+	 * @param broadcastForwardedServers targets that accepted standalone delivery
+	 * @param rewardDelivered whether the cached reward vote was already delivered
+	 */
+	public OfflineBungeeVote(String voteId, String playerName, String uuid, String service, long time, boolean realVote,
+			String text, boolean broadcastForwarded, boolean proxyBroadcastHandled, Set<String> broadcastTargets,
+			Set<String> broadcastForwardedServers, boolean rewardDelivered) {
+		this(parseVoteId(voteId), playerName, uuid, service, time, realVote, text, broadcastForwarded,
+				proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers, rewardDelivered);
+	}
+
+	private static UUID parseVoteId(String voteId) {
+		return voteId == null || voteId.isEmpty() ? null : UUID.fromString(voteId);
+	}
+
+	/**
+	 * Replaces the original standalone broadcast targets.
+	 * @param targets target servers
+	 */
+	public void setBroadcastTargets(Set<String> targets) {
+		broadcastTargets = targets == null ? new LinkedHashSet<>() : new LinkedHashSet<>(targets);
+	}
+
+	/**
+	 * Replaces the targets that accepted standalone broadcast delivery.
+	 * @param forwardedServers delivered target servers
+	 */
+	public void setBroadcastForwardedServers(Set<String> forwardedServers) {
+		broadcastForwardedServers = forwardedServers == null ? new LinkedHashSet<>()
+				: new LinkedHashSet<>(forwardedServers);
+	}
+
+	/**
+	 * Checks whether every original standalone target accepted delivery.
+	 * @return true when standalone routing is complete
+	 */
+	public boolean isProxyBroadcastComplete() {
+		return proxyBroadcastHandled && broadcastForwardedServers.containsAll(broadcastTargets);
+	}
+
+	/**
+	 * Checks whether this cached vote still needs to broadcast on a server.
+	 * @param server backend server receiving the cached vote
+	 * @return true when this server is an original undelivered target
+	 */
+	public boolean needsBroadcastOn(String server) {
+		if (!proxyBroadcastHandled) {
+			return !broadcastForwarded;
 		}
+		return server != null && broadcastTargets.contains(server) && !broadcastForwardedServers.contains(server);
+	}
+
+	/**
+	 * Encodes the original broadcast targets for cache storage.
+	 * @return encoded target set
+	 */
+	public String encodeBroadcastTargets() {
+		return VoteTimeQueue.encodeBroadcastServers(broadcastTargets);
+	}
+
+	/**
+	 * Encodes delivered broadcast targets for cache storage.
+	 * @return encoded delivered target set
+	 */
+	public String encodeBroadcastForwardedServers() {
+		return VoteTimeQueue.encodeBroadcastServers(broadcastForwardedServers);
 	}
 
 	@Override
 	public String toString() {
 		return "VoteCache:" + playerName + "/" + uuid + "/" + service + "/" + time + "/" + realVote + "/" + text + "/"
-				+ voteId + "/" + broadcastForwarded;
+				+ voteId + "/" + broadcastForwarded + "/" + proxyBroadcastHandled + "/" + broadcastTargets + "/"
+				+ broadcastForwardedServers + "/" + rewardDelivered;
 	}
 
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
@@ -171,6 +171,10 @@ public class VoteTotalsSnapshot {
 		placeholders.put("VotingPlugin_total_daily", Integer.toString(dailyTotal));
 		placeholders.put("VotingPlugin_points", Integer.toString(points));
 		placeholders.put("VotingPlugin_points_format", numberFormat.format(points));
+		placeholders.put("VotingPlugin_BungeeVotePartyVotesCurrent", Integer.toString(votePartyCurrent));
+		placeholders.put("VotingPlugin_BungeeVotePartyVotesNeeded",
+				Integer.toString(votePartyRequired - votePartyCurrent));
+		placeholders.put("VotingPlugin_BungeeVotePartyVotesRequired", Integer.toString(votePartyRequired));
 
 		String output = input;
 		for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
@@ -1,5 +1,9 @@
 package com.bencodez.votingplugin.proxy;
 
+import java.text.NumberFormat;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -122,6 +126,46 @@ public class VoteTotalsSnapshot {
 	@Override
 	public String toString() {
 		return toStorageString();
+	}
+
+	/**
+	 * Applies this snapshot to total placeholders used in a vote broadcast.
+	 *
+	 * The backend may receive a standalone broadcast before rollover totals are
+	 * committed. Replacing these placeholders before PlaceholderAPI runs lets that
+	 * one message use the proxy's projected values without mutating player storage.
+	 *
+	 * @param input broadcast line
+	 * @return line with VotingPlugin total placeholders replaced
+	 */
+	public String applyBroadcastPlaceholders(String input) {
+		if (input == null || input.isEmpty()) {
+			return input;
+		}
+
+		NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
+		Map<String, String> placeholders = new LinkedHashMap<>();
+		placeholders.put("AllTimeTotal", Integer.toString(allTimeTotal));
+		placeholders.put("MonthTotal", Integer.toString(monthTotal));
+		placeholders.put("WeeklyTotal", Integer.toString(weeklyTotal));
+		placeholders.put("DailyTotal", Integer.toString(dailyTotal));
+		placeholders.put("Points", Integer.toString(points));
+		placeholders.put("Points_Format", numberFormat.format(points));
+		placeholders.put("VotingPlugin_alltimetotal", Integer.toString(allTimeTotal));
+		placeholders.put("VotingPlugin_total", Integer.toString(monthTotal));
+		placeholders.put("VotingPlugin_total_alltime", Integer.toString(allTimeTotal));
+		placeholders.put("VotingPlugin_total_monthly", Integer.toString(monthTotal));
+		placeholders.put("VotingPlugin_total_weekly", Integer.toString(weeklyTotal));
+		placeholders.put("VotingPlugin_total_daily", Integer.toString(dailyTotal));
+		placeholders.put("VotingPlugin_points", Integer.toString(points));
+		placeholders.put("VotingPlugin_points_format", numberFormat.format(points));
+
+		String output = input;
+		for (Map.Entry<String, String> placeholder : placeholders.entrySet()) {
+			output = output.replaceAll("(?i)" + Pattern.quote("%" + placeholder.getKey() + "%"),
+					java.util.regex.Matcher.quoteReplacement(placeholder.getValue()));
+		}
+		return output;
 	}
 
 	// Legacy (milestoneCount exists, but ignored)

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VoteTotalsSnapshot.java
@@ -139,11 +139,23 @@ public class VoteTotalsSnapshot {
 	 * @return line with VotingPlugin total placeholders replaced
 	 */
 	public String applyBroadcastPlaceholders(String input) {
+		return applyBroadcastPlaceholders(input, false);
+	}
+
+	/**
+	 * Applies this snapshot using the configured primary monthly total.
+	 *
+	 * @param input broadcast line
+	 * @param useDateMonthTotal whether dated monthly totals are primary
+	 * @return line with VotingPlugin total placeholders replaced
+	 */
+	public String applyBroadcastPlaceholders(String input, boolean useDateMonthTotal) {
 		if (input == null || input.isEmpty()) {
 			return input;
 		}
 
 		NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
+		int primaryMonthTotal = useDateMonthTotal && dateMonthTotal >= 0 ? dateMonthTotal : monthTotal;
 		Map<String, String> placeholders = new LinkedHashMap<>();
 		placeholders.put("AllTimeTotal", Integer.toString(allTimeTotal));
 		placeholders.put("MonthTotal", Integer.toString(monthTotal));
@@ -152,9 +164,9 @@ public class VoteTotalsSnapshot {
 		placeholders.put("Points", Integer.toString(points));
 		placeholders.put("Points_Format", numberFormat.format(points));
 		placeholders.put("VotingPlugin_alltimetotal", Integer.toString(allTimeTotal));
-		placeholders.put("VotingPlugin_total", Integer.toString(monthTotal));
+		placeholders.put("VotingPlugin_total", Integer.toString(primaryMonthTotal));
 		placeholders.put("VotingPlugin_total_alltime", Integer.toString(allTimeTotal));
-		placeholders.put("VotingPlugin_total_monthly", Integer.toString(monthTotal));
+		placeholders.put("VotingPlugin_total_monthly", Integer.toString(primaryMonthTotal));
 		placeholders.put("VotingPlugin_total_weekly", Integer.toString(weeklyTotal));
 		placeholders.put("VotingPlugin_total_daily", Integer.toString(dailyTotal));
 		placeholders.put("VotingPlugin_points", Integer.toString(points));

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -903,8 +903,12 @@ public abstract class VotingPluginProxy {
 		boolean resetWeek = timeChanges.contains(TimeType.WEEK);
 		boolean resetDay = timeChanges.contains(TimeType.DAY);
 		int acceptedQueuedVotes = 0;
+		int acceptedGlobalQueuedVotes = 0;
 		for (VoteTimeQueue queued : getVoteCacheHandler().getTimeChangeQueue()) {
-			if (queued.getName() != null && queued.getName().equalsIgnoreCase(player)) {
+			if (!queued.isProcessed()) {
+				acceptedGlobalQueuedVotes++;
+			}
+			if (!queued.isProcessed() && queued.getName() != null && queued.getName().equalsIgnoreCase(player)) {
 				acceptedQueuedVotes++;
 			}
 		}
@@ -937,8 +941,27 @@ public abstract class VotingPluginProxy {
 			}
 		}
 
-		return new VoteTotalsSnapshot(allTimeTotal, monthTotal, weeklyTotal, dailyTotal, points, votePartyVotes,
-				currentVotePartyVotesRequired, dateMonthTotal);
+		int[] projectedVoteParty = getProjectedVotePartyState(acceptedGlobalQueuedVotes + 1);
+		return new VoteTotalsSnapshot(allTimeTotal, monthTotal, weeklyTotal, dailyTotal, points,
+				projectedVoteParty[0], projectedVoteParty[1], dateMonthTotal);
+	}
+
+	protected int[] getProjectedVotePartyState(int acceptedVotes) {
+		int current = votePartyVotes;
+		int required = currentVotePartyVotesRequired;
+		if (!getConfig().getVotePartyEnabled()) {
+			return new int[] { current, required };
+		}
+
+		int increase = getConfig().getVotePartyIncreaseVotesRequired();
+		for (int i = 0; i < acceptedVotes; i++) {
+			current++;
+			if (current >= required) {
+				current -= required;
+				required += increase;
+			}
+		}
+		return new int[] { current, required };
 	}
 
 	public abstract String getPluginVersion();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -854,7 +854,7 @@ public abstract class VotingPluginProxy {
 	}
 
 	private synchronized void retryCachedVoteDeliveryPersistence() {
-		for (String server : new LinkedHashSet<>(getVoteCacheHandler().getCachedVotesServers())) {
+		for (String server : new LinkedHashSet<>(Arrays.asList(getVoteCacheHandler().getCachedVotesServers()))) {
 			for (OfflineBungeeVote vote : new ArrayList<>(getVoteCacheHandler().getVotes(server))) {
 				if (vote.isDeliveryStateDirty()) {
 					persistServerVoteDelivery(server, vote);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -693,6 +693,27 @@ public abstract class VotingPluginProxy {
 		}
 	}
 
+	protected synchronized void retryPendingTimeBroadcasts(String server) {
+		List<String> blockedServers = getConfig().getBlockedServers();
+		if (server == null || (blockedServers != null && blockedServers.contains(server))) {
+			return;
+		}
+		if (getVoteCacheHandler().getTimeChangeQueue() == null) {
+			return;
+		}
+		for (VoteTimeQueue vote : new ArrayList<>(getVoteCacheHandler().getTimeChangeQueue())) {
+			if (!vote.isProxyBroadcastHandled() || vote.getUuid().isEmpty() || !vote.getBroadcastTargets().contains(server)
+					|| vote.getBroadcastForwardedServers().contains(server)) {
+				continue;
+			}
+			Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server), vote.getUuid(), vote.getName(),
+					vote.getService(), vote.getTime(), vote.getTotals(), false);
+			if (vote.getBroadcastForwardedServers().addAll(forwarded)) {
+				getVoteCacheHandler().updateTimeVote(vote);
+			}
+		}
+	}
+
 	/**
 	 * Periodically retries every pending voter-keyed standalone broadcast. This is
 	 * required for broker transports whose recovery does not produce a player-login
@@ -720,6 +741,29 @@ public abstract class VotingPluginProxy {
 						getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
 					}
 				}
+			}
+		}
+		retryPendingTimeBroadcasts();
+	}
+
+	public synchronized void retryPendingTimeBroadcasts() {
+		if (getVoteCacheHandler().getTimeChangeQueue() == null) {
+			return;
+		}
+		for (VoteTimeQueue vote : new ArrayList<>(getVoteCacheHandler().getTimeChangeQueue())) {
+			if (!vote.isProxyBroadcastHandled() || vote.getUuid().isEmpty()) {
+				continue;
+			}
+			Set<String> pendingTargets = new LinkedHashSet<>(vote.getBroadcastTargets());
+			pendingTargets.removeAll(vote.getBroadcastForwardedServers());
+			List<String> blockedServers = getConfig().getBlockedServers();
+			if (blockedServers != null) {
+				pendingTargets.removeAll(blockedServers);
+			}
+			Set<String> forwarded = sendProxyBroadcast(pendingTargets, vote.getUuid(), vote.getName(), vote.getService(),
+					vote.getTime(), vote.getTotals(), false);
+			if (vote.getBroadcastForwardedServers().addAll(forwarded)) {
+				getVoteCacheHandler().updateTimeVote(vote);
 			}
 		}
 	}
@@ -1442,6 +1486,7 @@ public abstract class VotingPluginProxy {
 
 			checkCachedVotes(serverName);
 			retryPendingOnlineBroadcasts(serverName);
+			retryPendingTimeBroadcasts(serverName);
 			checkOnlineVotes(playerName, uuid, serverName);
 			multiProxyHandler.login(uuid, playerName);
 		}
@@ -1554,9 +1599,15 @@ public abstract class VotingPluginProxy {
 			if (!vote.isProcessed()) {
 				VoteTotalsSnapshot queuedTotals = vote.getTotals() == null || vote.getTotals().isEmpty() ? null
 						: VoteTotalsSnapshot.parseStorage(vote.getTotals());
-				if (!vote(vote.getName(), vote.getService(), true, false, vote.getTime(), queuedTotals, null, vote)) {
+				QueuedVoteResult result = vote(vote.getName(), vote.getService(), true, false, vote.getTime(), queuedTotals,
+						null, vote);
+				if (result == QueuedVoteResult.RETRY) {
 					scheduleTimeVoteRetry();
 					return;
+				}
+				if (result == QueuedVoteResult.TERMINAL) {
+					warn("Removing terminal rollover vote " + vote.getVoteId() + " for " + vote.getName() + "/"
+							+ ServiceSiteValidator.sanitizeForLog(vote.getService()));
 				}
 			}
 			if (!getVoteCacheHandler().removeTimeVote(vote)) {
@@ -1936,18 +1987,22 @@ public abstract class VotingPluginProxy {
 		vote(player, service, realVote, timeQueue, queueTime, text, uuid, null);
 	}
 
-	private synchronized boolean vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
+	private enum QueuedVoteResult {
+		SUCCESS, RETRY, TERMINAL
+	}
+
+	private synchronized QueuedVoteResult vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
 			VoteTotalsSnapshot text, String uuid, VoteTimeQueue queuedVote) {
 		try {
 			if (!ServiceSiteValidator.isValid(service)) {
 				warn("Rejected vote with invalid service site '" + ServiceSiteValidator.sanitizeForLog(service) + "'");
-				return false;
+				return QueuedVoteResult.TERMINAL;
 			}
 			if (!MinecraftUsernameValidator.isValid(player, getConfig().getBedrockPlayerPrefix())) {
 				warn("Rejected vote with invalid Minecraft username '"
 						+ MinecraftUsernameValidator.sanitizeForLog(player) + "' from service '"
 						+ MinecraftUsernameValidator.sanitizeForLog(service) + "'");
-				return false;
+				return QueuedVoteResult.TERMINAL;
 			}
 
 			UUID voteId = queuedVote == null ? null : queuedVote.getVoteId();
@@ -1978,15 +2033,15 @@ public abstract class VotingPluginProxy {
 			if (uuid.isEmpty()) {
 				if (player.startsWith(getConfig().getBedrockPlayerPrefix())) {
 					log("Ignoring vote since unable to get UUID of bedrock player");
-					return false;
+					return QueuedVoteResult.TERMINAL;
 				}
 				if (!getConfig().getAllowUnJoined()) {
 					log("Ignoring vote from " + player + " since player hasn't joined before");
-					return false;
+					return QueuedVoteResult.TERMINAL;
 				}
 				if (!getConfig().getUUIDLookup()) {
 					log("Failed to get uuid for " + player);
-					return false;
+					return QueuedVoteResult.TERMINAL;
 				}
 
 				debug("Fetching UUID online, since allowunjoined is enabled");
@@ -2002,7 +2057,7 @@ public abstract class VotingPluginProxy {
 				}
 				if (u == null) {
 					debug("Failed to get uuid for " + player);
-					return false;
+					return QueuedVoteResult.TERMINAL;
 				}
 				uuid = u.toString();
 			}
@@ -2048,7 +2103,7 @@ public abstract class VotingPluginProxy {
 			if (managesTotals) {
 				if (getProxyMySQL() == null) {
 					logSevere("Mysql is not loaded correctly, stopping vote processing");
-					return false;
+					return QueuedVoteResult.RETRY;
 				}
 
 				if (!getProxyMySQL().containsKeyQuery(uuid)) {
@@ -2060,7 +2115,7 @@ public abstract class VotingPluginProxy {
 				if (!checkVoteDelay(uuid, player, service, data, queuedVote == null)) {
 					log("Vote delay is not met for " + player + "/" + service + ", skipping vote");
 					sendVoteDelayRejected(player, uuid, service, playerOnline, playerServer);
-					return false;
+					return QueuedVoteResult.TERMINAL;
 				}
 			}
 
@@ -2075,11 +2130,11 @@ public abstract class VotingPluginProxy {
 				}
 				VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
 						proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers,
-						text == null ? "" : text.toString(), false);
+						projectedTotals == null ? "" : projectedTotals.toString(), false, uuid);
 				if (!getVoteCacheHandler().addTimeVoteToCache(delayedVote)) {
 					logSevere("Unable to persist queued rollover vote for " + player + "/" + service
 							+ "; skipping proxy broadcast");
-					return false;
+					return QueuedVoteResult.RETRY;
 				}
 				if (proxyBroadcastHandled) {
 					for (String target : broadcastTargets) {
@@ -2093,7 +2148,7 @@ public abstract class VotingPluginProxy {
 				}
 				log("Caching vote from " + player + "/" + service
 						+ " because time change is happening right now");
-				return true;
+				return QueuedVoteResult.SUCCESS;
 			}
 
 			addVoteParty();
@@ -2305,10 +2360,10 @@ public abstract class VotingPluginProxy {
 							+ "; attempting durable removal immediately");
 				}
 			}
-			return true;
+			return QueuedVoteResult.SUCCESS;
 		} catch (Exception e) {
 			e.printStackTrace();
-			return false;
+			return QueuedVoteResult.RETRY;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -854,7 +854,7 @@ public abstract class VotingPluginProxy {
 	}
 
 	private synchronized void retryCachedVoteDeliveryPersistence() {
-		for (String server : new LinkedHashSet<>(Arrays.asList(getVoteCacheHandler().getCachedVotesServers()))) {
+		for (String server : getVoteCacheHandler().getCachedVotesServers()) {
 			for (OfflineBungeeVote vote : new ArrayList<>(getVoteCacheHandler().getVotes(server))) {
 				if (vote.isDeliveryStateDirty()) {
 					persistServerVoteDelivery(server, vote);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -17,7 +17,9 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -475,14 +477,23 @@ public abstract class VotingPluginProxy {
 
 	public abstract void broadcast(String message);
 
-	private void sendProxyBroadcast(Set<String> targets, String uuid, String player, String service, long time,
-			String text) {
+	private Set<String> sendProxyBroadcast(Set<String> targets, String uuid, String player, String service, long time,
+			String text, boolean wasOnline) {
+		Set<String> forwarded = new LinkedHashSet<>();
 		int delay = 1;
 		for (String targetServer : targets) {
-			globalMessageProxyHandler.sendMessage(targetServer, delay,
-					VotingPluginWire.voteBroadcast(uuid, player, service, time, text));
+			JsonEnvelope envelope = VotingPluginWire.voteBroadcast(uuid, player, service, time, text, wasOnline);
+			if (method == BungeeMethod.PLUGINMESSAGING) {
+				if (sendPluginMessageServerNow(targetServer, envelope)) {
+					forwarded.add(targetServer);
+				}
+			} else {
+				globalMessageProxyHandler.sendMessage(targetServer, delay, envelope);
+				forwarded.add(targetServer);
+			}
 			delay++;
 		}
+		return forwarded;
 	}
 
 	public synchronized void checkCachedVotes(String server) {
@@ -1354,7 +1365,7 @@ public abstract class VotingPluginProxy {
 	public void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
 			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().remove();
-			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote.getVoteId());
+			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote);
 		}
 	}
 
@@ -1377,71 +1388,77 @@ public abstract class VotingPluginProxy {
 
 	public abstract void reloadCore(boolean mysql);
 
-	public abstract void sendPluginMessageData(String server, String channel, byte[] data, boolean queue);
+	public abstract boolean sendPluginMessageData(String server, String channel, byte[] data, boolean queue);
 
 	private static final int PLUGIN_MESSAGE_HARD_LIMIT = 32767;
 	private static final int PLUGIN_MESSAGE_SOFT_LIMIT = 30000;
 
 	public void sendPluginMessageServer(String server, int delay, JsonEnvelope envelope) {
-		getScheduler().schedule(() -> {
-			final String subChannel = envelope.getSubChannel();
-			final String payload = JsonEnvelopeCodec.encode(envelope);
+		getScheduler().schedule(() -> sendPluginMessageServerNow(server, envelope), delay * 5L, TimeUnit.MILLISECONDS);
+	}
 
-			final byte[] subChannelBytes = subChannel.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-			final byte[] payloadBytes = payload.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+	/**
+	 * Sends a plugin-message envelope immediately and reports whether the proxy
+	 * accepted it for delivery.
+	 *
+	 * @param server target backend server
+	 * @param envelope envelope to send
+	 * @return true when the proxy accepted the message for delivery
+	 */
+	protected boolean sendPluginMessageServerNow(String server, JsonEnvelope envelope) {
+		final String subChannel = envelope.getSubChannel();
+		final String payload = JsonEnvelopeCodec.encode(envelope);
 
-			// Estimate bytes written:
-			// - writeUTF adds 2-byte length prefix + UTF-8 bytes
-			// - writeInt is 4 bytes
-			int estimatedSize = 2 + subChannelBytes.length + // subChannel UTF (len prefix + bytes)
-					4 + // payload length int
-					2 + payloadBytes.length; // payload UTF (len prefix + bytes)
+		final byte[] subChannelBytes = subChannel.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+		final byte[] payloadBytes = payload.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
-			if (estimatedSize > PLUGIN_MESSAGE_SOFT_LIMIT) {
-				debug("[PluginMessage] Payload nearing limit (" + estimatedSize + " bytes) server=" + server
-						+ " subChannel=" + subChannel + " — consider Redis instead");
+		// Estimate bytes written:
+		// - writeUTF adds 2-byte length prefix + UTF-8 bytes
+		// - writeInt is 4 bytes
+		int estimatedSize = 2 + subChannelBytes.length + // subChannel UTF (len prefix + bytes)
+				4 + // payload length int
+				2 + payloadBytes.length; // payload UTF (len prefix + bytes)
+
+		if (estimatedSize > PLUGIN_MESSAGE_SOFT_LIMIT) {
+			debug("[PluginMessage] Payload nearing limit (" + estimatedSize + " bytes) server=" + server
+					+ " subChannel=" + subChannel + " — consider Redis instead");
+		}
+
+		if (estimatedSize > PLUGIN_MESSAGE_HARD_LIMIT) {
+			debug("[PluginMessage] Payload TOO LARGE (" + estimatedSize + " bytes, max=" + PLUGIN_MESSAGE_HARD_LIMIT
+					+ ") server=" + server + " subChannel=" + subChannel + " — NOT sent");
+			return false;
+		}
+
+		try (ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+				DataOutputStream out = new DataOutputStream(byteOutStream)) {
+			if (getConfig().getPluginMessageEncryption() && encryptionHandler != null) {
+				out.writeUTF(encryptionHandler.encrypt(subChannel));
+			} else {
+				out.writeUTF(subChannel);
 			}
 
-			if (estimatedSize > PLUGIN_MESSAGE_HARD_LIMIT) {
-				debug("[PluginMessage] Payload TOO LARGE (" + estimatedSize + " bytes, max=" + PLUGIN_MESSAGE_HARD_LIMIT
-						+ ") server=" + server + " subChannel=" + subChannel + " — NOT sent");
-				return;
+			// sanity only: MUST be bytes, not chars
+			out.writeInt(payloadBytes.length);
+
+			if (getConfig().getPluginMessageEncryption() && encryptionHandler != null) {
+				out.writeUTF(encryptionHandler.encrypt(payload));
+			} else {
+				out.writeUTF(payload);
 			}
+			out.flush();
 
-			ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
-			DataOutputStream out = new DataOutputStream(byteOutStream);
-
-			try {
-				if (getConfig().getPluginMessageEncryption() && encryptionHandler != null) {
-					out.writeUTF(encryptionHandler.encrypt(subChannel));
-				} else {
-					out.writeUTF(subChannel);
-				}
-
-				// sanity only: MUST be bytes, not chars
-				out.writeInt(payloadBytes.length);
-
-				if (getConfig().getPluginMessageEncryption() && encryptionHandler != null) {
-					out.writeUTF(encryptionHandler.encrypt(payload));
-				} else {
-					out.writeUTF(payload);
-				}
-
-				if (isSomeoneOnlineServer(server)) {
-					sendPluginMessageData(server, getConfig().getPluginMessageChannel().toLowerCase(),
-							byteOutStream.toByteArray(), false);
-				}
-
-				out.close();
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-
+			boolean sent = sendPluginMessageData(server, getConfig().getPluginMessageChannel().toLowerCase(),
+					byteOutStream.toByteArray(), false);
 			if (getConfig().getDebug()) {
-				debug("Sending plugin envelope (" + estimatedSize + " bytes) " + server + " " + subChannel + " "
-						+ envelope.getFields());
+				debug((sent ? "Sent" : "Could not send") + " plugin envelope (" + estimatedSize + " bytes) " + server
+						+ " " + subChannel + " " + envelope.getFields());
 			}
-		}, delay * 5L, TimeUnit.MILLISECONDS);
+			return sent;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
 	}
 
 	public void sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
@@ -1624,7 +1641,7 @@ public abstract class VotingPluginProxy {
 	}
 
 	private synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
-			VoteTotalsSnapshot text, String uuid, UUID existingVoteId) {
+			VoteTotalsSnapshot text, String uuid, VoteTimeQueue queuedVote) {
 		try {
 			if (!ServiceSiteValidator.isValid(service)) {
 				warn("Rejected vote with invalid service site '" + ServiceSiteValidator.sanitizeForLog(service) + "'");
@@ -1637,23 +1654,9 @@ public abstract class VotingPluginProxy {
 				return;
 			}
 
-			UUID voteId = existingVoteId;
+			UUID voteId = queuedVote == null ? null : queuedVote.getVoteId();
 			if (voteId == null) {
 				voteId = UUID.randomUUID();
-			}
-
-			// Handle time change queue
-			if (getConfig().getGlobalDataEnabled()) {
-				if (getGlobalDataHandler().isTimeChangedHappened()) {
-					getGlobalDataHandler().checkForFinishedTimeChanges();
-					if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
-						getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(voteId, player, service,
-								LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
-						log("Caching vote from " + player + "/" + service
-								+ " because time change is happening right now");
-						return;
-					}
-				}
 			}
 
 			// UUID resolution
@@ -1722,6 +1725,32 @@ public abstract class VotingPluginProxy {
 			// Cache online state/server once (IMPORTANT for broadcast logic correctness)
 			final boolean playerOnline = isPlayerOnline(player);
 			final String playerServer = playerOnline ? getCurrentPlayerServer(player) : null;
+			long time = queueTime != 0 ? queueTime
+					: LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+
+			Set<String> broadcastForwardedServers = queuedVote == null ? new LinkedHashSet<>()
+					: new LinkedHashSet<>(queuedVote.getBroadcastForwardedServers());
+			boolean proxyBroadcastHandled = queuedVote != null && queuedVote.isProxyBroadcastHandled();
+
+			// Resolve identity and forward an offline broadcast before a GlobalData time
+			// change queues the reward/totals work. The queued delivery state prevents
+			// replaying broadcasts that already reached a backend.
+			if (getConfig().getGlobalDataEnabled() && getGlobalDataHandler().isTimeChangedHappened()) {
+				getGlobalDataHandler().checkForFinishedTimeChanges();
+				if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
+					if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
+						Set<String> targets = proxyBroadcastDecider.resolveTargets(false, null);
+						broadcastForwardedServers.addAll(
+								sendProxyBroadcast(targets, uuid, player, service, time, "", false));
+						proxyBroadcastHandled = true;
+					}
+					getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(voteId, player, service, time,
+							proxyBroadcastHandled, broadcastForwardedServers));
+					log("Caching vote from " + player + "/" + service
+							+ " because time change is happening right now");
+					return;
+				}
+			}
 
 			addVoteParty();
 
@@ -1798,16 +1827,18 @@ public abstract class VotingPluginProxy {
 				}
 			}
 
-			long time = LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-			if (queueTime != 0) {
-				time = queueTime;
-			}
-
 			VoteLogStatus voteStatus = VoteLogStatus.IMMEDIATE;
-			boolean immediateProxyBroadcast = proxyBroadcastDecider.usesImmediateForwarding(playerOnline);
-			if (immediateProxyBroadcast) {
-				Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
-				sendProxyBroadcast(targets, uuid, player, service, time, text == null ? "" : text.toString());
+			boolean standaloneProxyBroadcast = proxyBroadcastHandled
+					|| proxyBroadcastDecider.usesImmediateForwarding(playerOnline);
+			Set<String> proxyBroadcastTargets = Collections.emptySet();
+			if (standaloneProxyBroadcast) {
+				// A handled queued broadcast was necessarily sampled while the player was
+				// offline. Retry only targets that did not previously accept delivery.
+				proxyBroadcastTargets = proxyBroadcastDecider.resolveTargets(false, null);
+				Set<String> remainingTargets = new LinkedHashSet<>(proxyBroadcastTargets);
+				remainingTargets.removeAll(broadcastForwardedServers);
+				broadcastForwardedServers.addAll(sendProxyBroadcast(remainingTargets, uuid, player, service, time,
+						text == null ? "" : text.toString(), false));
 			}
 
 			// ===========================
@@ -1827,17 +1858,14 @@ public abstract class VotingPluginProxy {
 						voteStatus = VoteLogStatus.CACHED;
 						getVoteCacheHandler().addServerVote(s,
 								new OfflineBungeeVote(voteId, player, uuid, service, time, realVote,
-										text.toString(), immediateProxyBroadcast));
+										text.toString(), broadcastForwardedServers.contains(s)));
 						debug("Caching vote for " + player + " on " + service + " for " + s);
 					} else {
-						boolean broadcastHere = true;
-						if (getConfig().getProxyBroadcastEnabled()) {
-							if (immediateProxyBroadcast) {
-								broadcastHere = false;
-							} else {
-								Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
-								broadcastHere = proxyBroadcastDecider.shouldBroadcast(s, targets);
-							}
+						boolean broadcastHere = !broadcastForwardedServers.contains(s);
+						if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+							Set<String> targets = standaloneProxyBroadcast ? proxyBroadcastTargets
+									: proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
+							broadcastHere = proxyBroadcastDecider.shouldBroadcast(s, targets);
 						}
 
 						globalMessageProxyHandler.sendMessage(s, 2,
@@ -1851,21 +1879,18 @@ public abstract class VotingPluginProxy {
 				if (playerOnline && playerServer != null && getAllAvailableServers().contains(playerServer)) {
 					String server = playerServer;
 
-					boolean broadcastHere = true;
-					if (getConfig().getProxyBroadcastEnabled()) {
-						if (immediateProxyBroadcast) {
-							broadcastHere = false;
-						} else {
-							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
-							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
-						}
+					boolean broadcastHere = !broadcastForwardedServers.contains(server);
+					if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+						Set<String> targets = standaloneProxyBroadcast ? proxyBroadcastTargets
+								: proxyBroadcastDecider.resolveTargets(true, playerServer);
+						broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
 					}
 
 					globalMessageProxyHandler.sendMessage(server, 1,
 							VotingPluginWire.voteOnline(player, uuid, service, time, true, realVote, text.toString(),
 									voteId, getConfig().getBungeeManageTotals(), broadcastHere, 1, 1));
 
-					if (getConfig().getProxyBroadcastEnabled() && !immediateProxyBroadcast) {
+					if (getConfig().getProxyBroadcastEnabled() && !standaloneProxyBroadcast) {
 						Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
 
 						int bDelay = 2;
@@ -1878,8 +1903,9 @@ public abstract class VotingPluginProxy {
 								continue;
 							}
 
-							globalMessageProxyHandler.sendMessage(targetServer, bDelay, VotingPluginWire
-									.voteBroadcast(uuid, player, service, time, text == null ? "" : text.toString()));
+							globalMessageProxyHandler.sendMessage(targetServer, bDelay,
+									VotingPluginWire.voteBroadcast(uuid, player, service, time,
+											text == null ? "" : text.toString(), true));
 							bDelay++;
 						}
 					}
@@ -1890,9 +1916,11 @@ public abstract class VotingPluginProxy {
 					}
 				} else {
 					voteStatus = VoteLogStatus.CACHED;
+					boolean broadcastForwarded = standaloneProxyBroadcast && !proxyBroadcastTargets.isEmpty()
+							&& broadcastForwardedServers.containsAll(proxyBroadcastTargets);
 					getVoteCacheHandler().addOnlineVote(uuid,
 							new OfflineBungeeVote(voteId, player, uuid, service, time, realVote, text.toString(),
-									immediateProxyBroadcast));
+									broadcastForwarded));
 					debug("Caching online vote for " + player + " on " + service);
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -118,6 +118,7 @@ public abstract class VotingPluginProxy {
 	private JedisPool redisPublisherPool;
 	private volatile long redisPublisherRetryAfter;
 	private boolean timeVoteRetryScheduled;
+	private boolean timeVoteDeliveryRetryScheduled;
 
 	private boolean enabled;
 
@@ -702,6 +703,9 @@ public abstract class VotingPluginProxy {
 			return;
 		}
 		for (VoteTimeQueue vote : new ArrayList<>(getVoteCacheHandler().getTimeChangeQueue())) {
+			if (vote.isDeliveryStateDirty() && !persistTimeVoteDelivery(vote)) {
+				continue;
+			}
 			if (!vote.isProxyBroadcastHandled() || vote.getUuid().isEmpty() || !vote.getBroadcastTargets().contains(server)
 					|| vote.getBroadcastForwardedServers().contains(server)) {
 				continue;
@@ -709,7 +713,7 @@ public abstract class VotingPluginProxy {
 			Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server), vote.getUuid(), vote.getName(),
 					vote.getService(), vote.getTime(), vote.getTotals(), false);
 			if (vote.getBroadcastForwardedServers().addAll(forwarded)) {
-				getVoteCacheHandler().updateTimeVote(vote);
+				persistTimeVoteDelivery(vote);
 			}
 		}
 	}
@@ -751,6 +755,9 @@ public abstract class VotingPluginProxy {
 			return;
 		}
 		for (VoteTimeQueue vote : new ArrayList<>(getVoteCacheHandler().getTimeChangeQueue())) {
+			if (vote.isDeliveryStateDirty() && !persistTimeVoteDelivery(vote)) {
+				continue;
+			}
 			if (!vote.isProxyBroadcastHandled() || vote.getUuid().isEmpty()) {
 				continue;
 			}
@@ -763,8 +770,36 @@ public abstract class VotingPluginProxy {
 			Set<String> forwarded = sendProxyBroadcast(pendingTargets, vote.getUuid(), vote.getName(), vote.getService(),
 					vote.getTime(), vote.getTotals(), false);
 			if (vote.getBroadcastForwardedServers().addAll(forwarded)) {
-				getVoteCacheHandler().updateTimeVote(vote);
+				persistTimeVoteDelivery(vote);
 			}
+		}
+	}
+
+	protected synchronized boolean persistTimeVoteDelivery(VoteTimeQueue vote) {
+		if (getVoteCacheHandler().updateTimeVote(vote)) {
+			vote.setDeliveryStateDirty(false);
+			return true;
+		}
+		vote.setDeliveryStateDirty(true);
+		scheduleTimeVoteDeliveryRetry();
+		return false;
+	}
+
+	private void scheduleTimeVoteDeliveryRetry() {
+		if (timeVoteDeliveryRetryScheduled || getScheduler() == null) {
+			return;
+		}
+		timeVoteDeliveryRetryScheduled = true;
+		try {
+			getScheduler().schedule(() -> {
+				synchronized (VotingPluginProxy.this) {
+					timeVoteDeliveryRetryScheduled = false;
+				}
+				retryPendingTimeBroadcasts();
+			}, 5, TimeUnit.SECONDS);
+		} catch (RuntimeException e) {
+			timeVoteDeliveryRetryScheduled = false;
+			debug("Unable to schedule timed broadcast state retry: " + e.getMessage());
 		}
 	}
 
@@ -2165,7 +2200,7 @@ public abstract class VotingPluginProxy {
 								service, time, projectedTotals == null ? "" : projectedTotals.toString(), false);
 						if (delayedVote.getBroadcastForwardedServers().addAll(forwarded)) {
 							broadcastForwardedServers.addAll(forwarded);
-							getVoteCacheHandler().updateTimeVote(delayedVote);
+							persistTimeVoteDelivery(delayedVote);
 						}
 					}
 				}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -119,6 +119,7 @@ public abstract class VotingPluginProxy {
 	private volatile long redisPublisherRetryAfter;
 	private boolean timeVoteRetryScheduled;
 	private boolean timeVoteDeliveryRetryScheduled;
+	private boolean cachedVoteDeliveryRetryScheduled;
 
 	private boolean enabled;
 
@@ -545,13 +546,18 @@ public abstract class VotingPluginProxy {
 						int num = 1;
 						int numberOfVotes = c.size();
 						for (OfflineBungeeVote cache : c) {
+							if (cache.isDeliveryStateDirty() && !persistServerVoteDelivery(server, cache)) {
+								continue;
+							}
 							if (cache.isProxyBroadcastHandled() && cache.needsBroadcastOn(server)) {
 								Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server),
 										cache.getUuid(), cache.getPlayerName(), cache.getService(), cache.getTime(),
 										cache.getText(), false);
 								if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
 									cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
-									getVoteCacheHandler().updateServerVote(server, cache);
+									if (!persistServerVoteDelivery(server, cache)) {
+										continue;
+									}
 								}
 							}
 
@@ -677,6 +683,9 @@ public abstract class VotingPluginProxy {
 		}
 		for (String cachedUuid : getVoteCacheHandler().getOnlineVoteUUIDs()) {
 			for (OfflineBungeeVote cache : new ArrayList<>(getVoteCacheHandler().getOnlineVotes(cachedUuid))) {
+				if (cache.isDeliveryStateDirty() && !persistOnlineVoteDelivery(cachedUuid, cache)) {
+					continue;
+				}
 				if (!cache.isProxyBroadcastHandled() || !cache.needsBroadcastOn(server)) {
 					continue;
 				}
@@ -687,7 +696,7 @@ public abstract class VotingPluginProxy {
 					if (cache.isRewardDelivered() && cache.isProxyBroadcastComplete()) {
 						getVoteCacheHandler().removeOnlineVote(cachedUuid, cache);
 					} else {
-						getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
+						persistOnlineVoteDelivery(cachedUuid, cache);
 					}
 				}
 			}
@@ -726,6 +735,9 @@ public abstract class VotingPluginProxy {
 	public synchronized void retryPendingOnlineBroadcasts() {
 		for (String cachedUuid : new LinkedHashSet<>(getVoteCacheHandler().getOnlineVoteUUIDs())) {
 			for (OfflineBungeeVote cache : new ArrayList<>(getVoteCacheHandler().getOnlineVotes(cachedUuid))) {
+				if (cache.isDeliveryStateDirty() && !persistOnlineVoteDelivery(cachedUuid, cache)) {
+					continue;
+				}
 				if (!cache.isProxyBroadcastHandled() || cache.isProxyBroadcastComplete()) {
 					continue;
 				}
@@ -742,7 +754,7 @@ public abstract class VotingPluginProxy {
 					if (cache.isRewardDelivered() && cache.isProxyBroadcastComplete()) {
 						getVoteCacheHandler().removeOnlineVote(cachedUuid, cache);
 					} else {
-						getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
+						persistOnlineVoteDelivery(cachedUuid, cache);
 					}
 				}
 			}
@@ -800,6 +812,61 @@ public abstract class VotingPluginProxy {
 		} catch (RuntimeException e) {
 			timeVoteDeliveryRetryScheduled = false;
 			debug("Unable to schedule timed broadcast state retry: " + e.getMessage());
+		}
+	}
+
+	protected synchronized boolean persistServerVoteDelivery(String server, OfflineBungeeVote vote) {
+		if (getVoteCacheHandler().updateServerVote(server, vote)) {
+			vote.setDeliveryStateDirty(false);
+			return true;
+		}
+		vote.setDeliveryStateDirty(true);
+		scheduleCachedVoteDeliveryRetry();
+		return false;
+	}
+
+	protected synchronized boolean persistOnlineVoteDelivery(String uuid, OfflineBungeeVote vote) {
+		if (getVoteCacheHandler().updateOnlineVote(uuid, vote)) {
+			vote.setDeliveryStateDirty(false);
+			return true;
+		}
+		vote.setDeliveryStateDirty(true);
+		scheduleCachedVoteDeliveryRetry();
+		return false;
+	}
+
+	private void scheduleCachedVoteDeliveryRetry() {
+		if (cachedVoteDeliveryRetryScheduled || getScheduler() == null) {
+			return;
+		}
+		cachedVoteDeliveryRetryScheduled = true;
+		try {
+			getScheduler().schedule(() -> {
+				synchronized (VotingPluginProxy.this) {
+					cachedVoteDeliveryRetryScheduled = false;
+				}
+				retryCachedVoteDeliveryPersistence();
+			}, 5, TimeUnit.SECONDS);
+		} catch (RuntimeException e) {
+			cachedVoteDeliveryRetryScheduled = false;
+			debug("Unable to schedule cached broadcast state retry: " + e.getMessage());
+		}
+	}
+
+	private synchronized void retryCachedVoteDeliveryPersistence() {
+		for (String server : new LinkedHashSet<>(getVoteCacheHandler().getCachedVotesServers())) {
+			for (OfflineBungeeVote vote : new ArrayList<>(getVoteCacheHandler().getVotes(server))) {
+				if (vote.isDeliveryStateDirty()) {
+					persistServerVoteDelivery(server, vote);
+				}
+			}
+		}
+		for (String uuid : new LinkedHashSet<>(getVoteCacheHandler().getOnlineVoteUUIDs())) {
+			for (OfflineBungeeVote vote : new ArrayList<>(getVoteCacheHandler().getOnlineVotes(uuid))) {
+				if (vote.isDeliveryStateDirty()) {
+					persistOnlineVoteDelivery(uuid, vote);
+				}
+			}
 		}
 	}
 
@@ -979,6 +1046,10 @@ public abstract class VotingPluginProxy {
 		int[] projectedVoteParty = getProjectedVotePartyState(acceptedGlobalQueuedVotes + 1);
 		return new VoteTotalsSnapshot(allTimeTotal, monthTotal, weeklyTotal, dailyTotal, points,
 				projectedVoteParty[0], projectedVoteParty[1], dateMonthTotal);
+	}
+
+	protected boolean canForwardStandaloneBroadcast(boolean managesTotals) {
+		return managesTotals;
 	}
 
 	protected int[] getProjectedVotePartyState(int acceptedVotes) {
@@ -2144,6 +2215,7 @@ public abstract class VotingPluginProxy {
 			boolean proxyBroadcastHandled = queuedVote != null && queuedVote.isProxyBroadcastHandled();
 			boolean processesTotals = getConfig().getPrimaryServer() || !getConfig().getMultiProxySupport();
 			boolean managesTotals = processesTotals && getConfig().getBungeeManageTotals();
+			boolean canValidateStandaloneBroadcast = canForwardStandaloneBroadcast(managesTotals);
 			ArrayList<Column> data = null;
 			boolean queueForTimeChange = false;
 
@@ -2182,7 +2254,7 @@ public abstract class VotingPluginProxy {
 			// replaying broadcasts that already reached a backend.
 			if (queueForTimeChange) {
 				VoteTotalsSnapshot projectedTotals = managesTotals ? getProjectedRolloverTotals(data, player) : text;
-				if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
+				if (canValidateStandaloneBroadcast && proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
 					broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
 					proxyBroadcastHandled = true;
 				}
@@ -2268,8 +2340,8 @@ public abstract class VotingPluginProxy {
 			}
 
 			VoteLogStatus voteStatus = VoteLogStatus.IMMEDIATE;
-			boolean standaloneProxyBroadcast = proxyBroadcastHandled
-					|| proxyBroadcastDecider.usesImmediateForwarding(playerOnline);
+			boolean standaloneProxyBroadcast = canValidateStandaloneBroadcast && (proxyBroadcastHandled
+					|| proxyBroadcastDecider.usesImmediateForwarding(playerOnline));
 			Set<String> proxyBroadcastTargets = Collections.emptySet();
 			if (standaloneProxyBroadcast) {
 				// A handled queued broadcast was necessarily sampled while the player was
@@ -2334,7 +2406,8 @@ public abstract class VotingPluginProxy {
 							VotingPluginWire.voteOnline(player, uuid, service, time, true, realVote, text.toString(),
 									voteId, getConfig().getBungeeManageTotals(), broadcastHere, 1, 1));
 
-					if (getConfig().getProxyBroadcastEnabled() && !standaloneProxyBroadcast) {
+					if (canValidateStandaloneBroadcast && getConfig().getProxyBroadcastEnabled()
+							&& !standaloneProxyBroadcast) {
 						Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
 
 						int bDelay = 2;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -117,8 +117,6 @@ public abstract class VotingPluginProxy {
 	private RedisHandler redisHandler;
 	private JedisPool redisPublisherPool;
 	private volatile long redisPublisherRetryAfter;
-	private final Set<VoteTimeQueue> processedTimeVotesPendingRemoval = Collections
-			.newSetFromMap(new java.util.IdentityHashMap<VoteTimeQueue, Boolean>());
 	private boolean timeVoteRetryScheduled;
 
 	private boolean enabled;
@@ -683,6 +681,37 @@ public abstract class VotingPluginProxy {
 				}
 				Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server), cache.getUuid(),
 						cache.getPlayerName(), cache.getService(), cache.getTime(), cache.getText(), false);
+				if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
+					cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
+					if (cache.isRewardDelivered() && cache.isProxyBroadcastComplete()) {
+						getVoteCacheHandler().removeOnlineVote(cachedUuid, cache);
+					} else {
+						getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Periodically retries every pending voter-keyed standalone broadcast. This is
+	 * required for broker transports whose recovery does not produce a player-login
+	 * carrier event.
+	 */
+	public synchronized void retryPendingOnlineBroadcasts() {
+		for (String cachedUuid : new LinkedHashSet<>(getVoteCacheHandler().getOnlineVoteUUIDs())) {
+			for (OfflineBungeeVote cache : new ArrayList<>(getVoteCacheHandler().getOnlineVotes(cachedUuid))) {
+				if (!cache.isProxyBroadcastHandled() || cache.isProxyBroadcastComplete()) {
+					continue;
+				}
+				Set<String> pendingTargets = new LinkedHashSet<>(cache.getBroadcastTargets());
+				pendingTargets.removeAll(cache.getBroadcastForwardedServers());
+				List<String> blockedServers = getConfig().getBlockedServers();
+				if (blockedServers != null) {
+					pendingTargets.removeAll(blockedServers);
+				}
+				Set<String> forwarded = sendProxyBroadcast(pendingTargets, cache.getUuid(), cache.getPlayerName(),
+						cache.getService(), cache.getTime(), cache.getText(), false);
 				if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
 					cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
 					if (cache.isRewardDelivered() && cache.isProxyBroadcastComplete()) {
@@ -1522,18 +1551,18 @@ public abstract class VotingPluginProxy {
 	public synchronized void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
 			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().element();
-			if (!processedTimeVotesPendingRemoval.contains(vote)) {
-				if (!vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote)) {
+			if (!vote.isProcessed()) {
+				VoteTotalsSnapshot queuedTotals = vote.getTotals() == null || vote.getTotals().isEmpty() ? null
+						: VoteTotalsSnapshot.parseStorage(vote.getTotals());
+				if (!vote(vote.getName(), vote.getService(), true, false, vote.getTime(), queuedTotals, null, vote)) {
 					scheduleTimeVoteRetry();
 					return;
 				}
-				processedTimeVotesPendingRemoval.add(vote);
 			}
 			if (!getVoteCacheHandler().removeTimeVote(vote)) {
 				scheduleTimeVoteRetry();
 				return;
 			}
-			processedTimeVotesPendingRemoval.remove(vote);
 		}
 	}
 
@@ -2045,7 +2074,8 @@ public abstract class VotingPluginProxy {
 					proxyBroadcastHandled = true;
 				}
 				VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
-						proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers);
+						proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers,
+						text == null ? "" : text.toString(), false);
 				if (!getVoteCacheHandler().addTimeVoteToCache(delayedVote)) {
 					logSevere("Unable to persist queued rollover vote for " + player + "/" + service
 							+ "; skipping proxy broadcast");
@@ -2119,6 +2149,9 @@ public abstract class VotingPluginProxy {
 				} else {
 					text = new VoteTotalsSnapshot(0, 0, 0, 0, 0, votePartyVotes, currentVotePartyVotesRequired, 0);
 				}
+			}
+			if (text == null) {
+				text = new VoteTotalsSnapshot(0, 0, 0, 0, 0, votePartyVotes, currentVotePartyVotesRequired, 0);
 			}
 
 			VoteLogStatus voteStatus = VoteLogStatus.IMMEDIATE;
@@ -2263,6 +2296,13 @@ public abstract class VotingPluginProxy {
 					} else {
 						debug("Not sending global proxy message for voteonline, player already got reward");
 					}
+				}
+			}
+			if (queuedVote != null) {
+				queuedVote.setProcessed(true);
+				if (!getVoteCacheHandler().updateTimeVote(queuedVote)) {
+					warn("Unable to persist completed rollover vote " + queuedVote.getVoteId()
+							+ "; attempting durable removal immediately");
 				}
 			}
 			return true;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -5,6 +5,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -72,6 +74,10 @@ import com.bencodez.votingplugin.votelog.VoteLogMysqlTable;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable.VoteLogStatus;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -1550,14 +1556,20 @@ public abstract class VotingPluginProxy {
 	}
 
 	public boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
-		if (redisHandler == null) {
-			return false;
+		DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
+				.database(getConfig().getRedisDbIndex()).connectionTimeoutMillis(2000).socketTimeoutMillis(2000);
+		if (getConfig().getRedisUsername() != null && !getConfig().getRedisUsername().isEmpty()) {
+			config.user(getConfig().getRedisUsername());
 		}
-		try {
-			redisHandler.publishEnvelope(getConfig().getRedisPrefix() + "VotingPlugin_" + server, envelope);
-			// RedisHandler currently swallows publish failures and exposes no acknowledgement,
-			// so the standalone delivery must remain pending.
-			return false;
+		if (getConfig().getRedisPassword() != null && !getConfig().getRedisPassword().isEmpty()) {
+			config.password(getConfig().getRedisPassword());
+		}
+
+		try (Jedis jedis = new Jedis(new HostAndPort(getConfig().getRedisHost(), getConfig().getRedisPort()),
+				config.build())) {
+			String channel = getConfig().getRedisPrefix() + "VotingPlugin_" + server;
+			long subscribers = jedis.publish(channel, JsonEnvelopeCodec.encode(envelope));
+			return subscribers > 0;
 		} catch (Exception e) {
 			debug(e.getMessage());
 			return false;
@@ -1580,18 +1592,25 @@ public abstract class VotingPluginProxy {
 	}
 
 	public boolean sendSocketEnvelopeServer(String server, JsonEnvelope envelope) {
-		if (clientHandles == null) {
+		Map<String, Object> configuration = getConfig().getSpigotServerConfiguration(server);
+		if (configuration == null) {
 			return false;
 		}
-		ClientHandler client = clientHandles.get(server);
-		if (client == null) {
+		String host = configuration.get("Host") instanceof String ? (String) configuration.get("Host") : "";
+		int port = configuration.get("Port") instanceof Number ? ((Number) configuration.get("Port")).intValue() : 1298;
+		if (host.isEmpty()) {
 			return false;
 		}
-		try {
-			client.sendEnvelope(envelope);
-			// ClientHandler currently swallows connect/write failures and exposes no
-			// acknowledgement, so the standalone delivery must remain pending.
-			return false;
+
+		String payload = JsonEnvelopeCodec.encode(envelope);
+		String encoded = encryptionHandler != null ? encryptionHandler.encrypt(payload) : payload;
+		try (Socket socket = new Socket()) {
+			socket.connect(new InetSocketAddress(host, port), 2000);
+			try (DataOutputStream output = new DataOutputStream(socket.getOutputStream())) {
+				output.writeUTF(encoded);
+				output.flush();
+			}
+			return true;
 		} catch (Exception e) {
 			debug(e.getMessage());
 			return false;
@@ -1876,6 +1895,15 @@ public abstract class VotingPluginProxy {
 			boolean processesTotals = getConfig().getPrimaryServer() || !getConfig().getMultiProxySupport();
 			boolean managesTotals = processesTotals && getConfig().getBungeeManageTotals();
 			ArrayList<Column> data = null;
+			boolean queueForTimeChange = false;
+
+			// A completion callback can wipe totals and replay older queued votes. Run it
+			// before loading this vote's database snapshot so the calculations below use
+			// the post-rollover state.
+			if (getConfig().getGlobalDataEnabled() && getGlobalDataHandler().isTimeChangedHappened()) {
+				getGlobalDataHandler().checkForFinishedTimeChanges();
+				queueForTimeChange = timeQueue && getGlobalDataHandler().isTimeChangedHappened();
+			}
 
 			// Validate the vote before any immediate announcement. This keeps duplicate
 			// votes rejected by the delay check out of the GlobalData rollover queue and
@@ -1899,29 +1927,26 @@ public abstract class VotingPluginProxy {
 				}
 			}
 
-			// Resolve identity and forward an offline broadcast before a GlobalData time
+			// Forward an accepted offline broadcast before the still-active GlobalData
 			// change queues the reward/totals work. The queued delivery state prevents
 			// replaying broadcasts that already reached a backend.
-			if (getConfig().getGlobalDataEnabled() && getGlobalDataHandler().isTimeChangedHappened()) {
-				getGlobalDataHandler().checkForFinishedTimeChanges();
-				if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
-					if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
-						broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
-						proxyBroadcastHandled = true;
-					}
-					VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
-							proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers);
-					getVoteCacheHandler().getTimeChangeQueue().add(delayedVote);
-					if (proxyBroadcastHandled) {
-						Set<String> forwarded = sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "",
-								false);
-						broadcastForwardedServers.addAll(forwarded);
-						delayedVote.getBroadcastForwardedServers().addAll(forwarded);
-					}
-					log("Caching vote from " + player + "/" + service
-							+ " because time change is happening right now");
-					return;
+			if (queueForTimeChange) {
+				if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
+					broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
+					proxyBroadcastHandled = true;
 				}
+				VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
+						proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers);
+				getVoteCacheHandler().getTimeChangeQueue().add(delayedVote);
+				if (proxyBroadcastHandled) {
+					Set<String> forwarded = sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "",
+							false);
+					broadcastForwardedServers.addAll(forwarded);
+					delayedVote.getBroadcastForwardedServers().addAll(forwarded);
+				}
+				log("Caching vote from " + player + "/" + service
+						+ " because time change is happening right now");
+				return;
 			}
 
 			addVoteParty();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -506,20 +506,15 @@ public abstract class VotingPluginProxy {
 								}
 							}
 							if (toSend) {
-								boolean broadcastHere = true;
-								if (getConfig().getProxyBroadcastEnabled()) {
-									if (proxyBroadcastDecider.usesImmediateForwarding()) {
-										broadcastHere = false;
-									} else {
-										boolean playerOnline = isPlayerOnline(cache.getPlayerName());
-										String playerServer = playerOnline
-												? getCurrentPlayerServer(cache.getPlayerName())
-												: null;
+								boolean broadcastHere = !cache.isBroadcastForwarded();
+								if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+									boolean playerOnline = isPlayerOnline(cache.getPlayerName());
+									String playerServer = playerOnline ? getCurrentPlayerServer(cache.getPlayerName())
+											: null;
 
-										Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline,
-												playerServer);
-										broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
-									}
+									Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline,
+											playerServer);
+									broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
 								}
 
 								globalMessageProxyHandler.sendMessage(server, delay,
@@ -560,16 +555,12 @@ public abstract class VotingPluginProxy {
 					int num = 1;
 					int numberOfVotes = c.size();
 					for (OfflineBungeeVote cache : c) {
-						boolean broadcastHere = true;
-						if (getConfig().getProxyBroadcastEnabled()) {
-							if (proxyBroadcastDecider.usesImmediateForwarding()) {
-								broadcastHere = false;
-							} else {
-								String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
+						boolean broadcastHere = !cache.isBroadcastForwarded();
+						if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+							String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
 
-								Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
-								broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
-							}
+							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
+							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
 						}
 
 						globalMessageProxyHandler.sendMessage(server, delay,
@@ -1813,7 +1804,7 @@ public abstract class VotingPluginProxy {
 			}
 
 			VoteLogStatus voteStatus = VoteLogStatus.IMMEDIATE;
-			boolean immediateProxyBroadcast = proxyBroadcastDecider.usesImmediateForwarding();
+			boolean immediateProxyBroadcast = proxyBroadcastDecider.usesImmediateForwarding(playerOnline);
 			if (immediateProxyBroadcast) {
 				Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
 				sendProxyBroadcast(targets, uuid, player, service, time, text == null ? "" : text.toString());
@@ -1835,7 +1826,8 @@ public abstract class VotingPluginProxy {
 					if ((!isSomeoneOnlineServer(s) && method.requiresPlayerOnline()) || forceCache) {
 						voteStatus = VoteLogStatus.CACHED;
 						getVoteCacheHandler().addServerVote(s,
-								new OfflineBungeeVote(voteId, player, uuid, service, time, realVote, text.toString()));
+								new OfflineBungeeVote(voteId, player, uuid, service, time, realVote,
+										text.toString(), immediateProxyBroadcast));
 						debug("Caching vote for " + player + " on " + service + " for " + s);
 					} else {
 						boolean broadcastHere = true;
@@ -1899,7 +1891,8 @@ public abstract class VotingPluginProxy {
 				} else {
 					voteStatus = VoteLogStatus.CACHED;
 					getVoteCacheHandler().addOnlineVote(uuid,
-							new OfflineBungeeVote(voteId, player, uuid, service, time, realVote, text.toString()));
+							new OfflineBungeeVote(voteId, player, uuid, service, time, realVote, text.toString(),
+									immediateProxyBroadcast));
 					debug("Caching online vote for " + player + " on " + service);
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -480,20 +480,47 @@ public abstract class VotingPluginProxy {
 	private Set<String> sendProxyBroadcast(Set<String> targets, String uuid, String player, String service, long time,
 			String text, boolean wasOnline) {
 		Set<String> forwarded = new LinkedHashSet<>();
-		int delay = 1;
 		for (String targetServer : targets) {
 			JsonEnvelope envelope = VotingPluginWire.voteBroadcast(uuid, player, service, time, text, wasOnline);
-			if (method == BungeeMethod.PLUGINMESSAGING) {
-				if (sendPluginMessageServerNow(targetServer, envelope)) {
-					forwarded.add(targetServer);
-				}
-			} else {
-				globalMessageProxyHandler.sendMessage(targetServer, delay, envelope);
+			if (sendProxyBroadcastEnvelopeNow(targetServer, envelope)) {
 				forwarded.add(targetServer);
 			}
-			delay++;
 		}
 		return forwarded;
+	}
+
+	/**
+	 * Sends a standalone proxy broadcast through the selected transport and reports
+	 * whether that transport accepted the message.
+	 *
+	 * @param server target backend server
+	 * @param envelope standalone broadcast envelope
+	 * @return true only when the transport accepted the message
+	 */
+	protected boolean sendProxyBroadcastEnvelopeNow(String server, JsonEnvelope envelope) {
+		switch (method) {
+		case MQTT:
+			return sendMqttEnvelopeServer(server, envelope);
+		case MYSQL:
+			if (proxyMysqlMessenger == null) {
+				return false;
+			}
+			try {
+				proxyMysqlMessenger.sendToBackend(server, envelope);
+				return true;
+			} catch (SQLException e) {
+				debug(e.getMessage());
+				return false;
+			}
+		case PLUGINMESSAGING:
+			return sendPluginMessageServerNow(server, envelope);
+		case REDIS:
+			return sendRedisEnvelopeServer(server, envelope);
+		case SOCKETS:
+			return sendSocketEnvelopeServer(server, envelope);
+		default:
+			return false;
+		}
 	}
 
 	public synchronized void checkCachedVotes(String server) {
@@ -621,6 +648,32 @@ public abstract class VotingPluginProxy {
 							&& getConfig().getMultiProxyOneGlobalReward()) {
 						multiProxyHandler.sendClearVote(uuid, player);
 					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Retries voter-keyed standalone broadcasts when any player makes a target
+	 * backend available as a plugin-message carrier.
+	 *
+	 * @param server backend server that gained a carrier
+	 */
+	protected synchronized void retryPendingOnlineBroadcasts(String server) {
+		List<String> blockedServers = getConfig().getBlockedServers();
+		if (server == null || (blockedServers != null && blockedServers.contains(server))) {
+			return;
+		}
+		for (String cachedUuid : getVoteCacheHandler().getOnlineVoteUUIDs()) {
+			for (OfflineBungeeVote cache : new ArrayList<>(getVoteCacheHandler().getOnlineVotes(cachedUuid))) {
+				if (!cache.isProxyBroadcastHandled() || !cache.needsBroadcastOn(server)) {
+					continue;
+				}
+				Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server), cache.getUuid(),
+						cache.getPlayerName(), cache.getService(), cache.getTime(), cache.getText(), false);
+				if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
+					cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
+					getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
 				}
 			}
 		}
@@ -1294,6 +1347,7 @@ public abstract class VotingPluginProxy {
 			}
 
 			checkCachedVotes(serverName);
+			retryPendingOnlineBroadcasts(serverName);
 			checkOnlineVotes(playerName, uuid, serverName);
 			multiProxyHandler.login(uuid, playerName);
 		}
@@ -1495,26 +1549,52 @@ public abstract class VotingPluginProxy {
 		}
 	}
 
-	public void sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
-		redisHandler.publishEnvelope(getConfig().getRedisPrefix() + "VotingPlugin_" + server, envelope);
+	public boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
+		if (redisHandler == null) {
+			return false;
+		}
+		try {
+			redisHandler.publishEnvelope(getConfig().getRedisPrefix() + "VotingPlugin_" + server, envelope);
+			// RedisHandler currently swallows publish failures and exposes no acknowledgement,
+			// so the standalone delivery must remain pending.
+			return false;
+		} catch (Exception e) {
+			debug(e.getMessage());
+			return false;
+		}
 	}
 
-	public void sendMqttEnvelopeServer(String server, JsonEnvelope envelope) {
+	public boolean sendMqttEnvelopeServer(String server, JsonEnvelope envelope) {
+		if (mqttHandler == null) {
+			return false;
+		}
 		try {
 			mqttHandler.publishEnvelope(getConfig().getMqttPrefix() + "votingplugin/servers/" + server, envelope);
+			return true;
 		} catch (Exception e) {
 			if (getConfig().getDebug()) {
 				e.printStackTrace();
 			}
+			return false;
 		}
 	}
 
-	public void sendSocketEnvelopeServer(String server, JsonEnvelope envelope) {
+	public boolean sendSocketEnvelopeServer(String server, JsonEnvelope envelope) {
 		if (clientHandles == null) {
-			return;
+			return false;
 		}
-		if (clientHandles.containsKey(server)) {
-			clientHandles.get(server).sendEnvelope(envelope);
+		ClientHandler client = clientHandles.get(server);
+		if (client == null) {
+			return false;
+		}
+		try {
+			client.sendEnvelope(envelope);
+			// ClientHandler currently swallows connect/write failures and exposes no
+			// acknowledgement, so the standalone delivery must remain pending.
+			return false;
+		} catch (Exception e) {
+			debug(e.getMessage());
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -639,6 +639,10 @@ public abstract class VotingPluginProxy {
 						if (cache.isProxyBroadcastHandled()) {
 							Set<String> pendingTargets = new LinkedHashSet<>(cache.getBroadcastTargets());
 							pendingTargets.removeAll(cache.getBroadcastForwardedServers());
+							List<String> blockedServers = getConfig().getBlockedServers();
+							if (blockedServers != null) {
+								pendingTargets.removeAll(blockedServers);
+							}
 							cache.getBroadcastForwardedServers().addAll(sendProxyBroadcast(pendingTargets,
 									cache.getUuid(), cache.getPlayerName(), cache.getService(), cache.getTime(),
 									cache.getText(), false));

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -524,7 +524,7 @@ public abstract class VotingPluginProxy {
 		case PLUGINMESSAGING:
 			return sendPluginMessageServerNow(server, envelope);
 		case REDIS:
-			return sendRedisEnvelopeServer(server, envelope);
+			return sendRedisEnvelopeServer(server, envelope, true);
 		case SOCKETS:
 			return sendSocketEnvelopeServer(server, envelope);
 		default:
@@ -682,7 +682,11 @@ public abstract class VotingPluginProxy {
 						cache.getPlayerName(), cache.getService(), cache.getTime(), cache.getText(), false);
 				if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
 					cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
-					getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
+					if (cache.isRewardDelivered() && cache.isProxyBroadcastComplete()) {
+						getVoteCacheHandler().removeOnlineVote(cachedUuid, cache);
+					} else {
+						getVoteCacheHandler().updateOnlineVote(cachedUuid, cache);
+					}
 				}
 			}
 		}
@@ -1062,7 +1066,10 @@ public abstract class VotingPluginProxy {
 					sendRedisEnvelopeServer(server, envelope);
 					break;
 				case SOCKETS:
-					sendSocketEnvelopeServer(server, envelope);
+					ClientHandler socketClient = clientHandles == null ? null : clientHandles.get(server);
+					if (socketClient != null) {
+						socketClient.sendEnvelope(envelope);
+					}
 					break;
 				default:
 					break;
@@ -1467,8 +1474,9 @@ public abstract class VotingPluginProxy {
 
 	public synchronized void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
-			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().remove();
+			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().element();
 			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote);
+			getVoteCacheHandler().removeTimeVote(vote);
 		}
 	}
 
@@ -1577,8 +1585,12 @@ public abstract class VotingPluginProxy {
 	}
 
 	public boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
+		return sendRedisEnvelopeServer(server, envelope, false);
+	}
+
+	private boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope, boolean useRetryCooldown) {
 		JedisPool publisherPool = redisPublisherPool;
-		if (publisherPool == null || System.currentTimeMillis() < redisPublisherRetryAfter) {
+		if (publisherPool == null || (useRetryCooldown && System.currentTimeMillis() < redisPublisherRetryAfter)) {
 			return false;
 		}
 
@@ -1588,8 +1600,10 @@ public abstract class VotingPluginProxy {
 			redisPublisherRetryAfter = 0L;
 			return subscribers > 0;
 		} catch (Exception e) {
-			// Avoid paying the connection timeout once per target while Redis is down.
-			redisPublisherRetryAfter = System.currentTimeMillis() + 2000L;
+			if (useRetryCooldown) {
+				// Standalone broadcasts remain queued, so their retries can be throttled safely.
+				redisPublisherRetryAfter = System.currentTimeMillis() + 2000L;
+			}
 			debug(e.getMessage());
 			return false;
 		}
@@ -1956,12 +1970,20 @@ public abstract class VotingPluginProxy {
 				}
 				VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
 						proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers);
-				getVoteCacheHandler().getTimeChangeQueue().add(delayedVote);
+				if (!getVoteCacheHandler().addTimeVoteToCache(delayedVote)) {
+					logSevere("Unable to persist queued rollover vote for " + player + "/" + service
+							+ "; skipping proxy broadcast");
+					return;
+				}
 				if (proxyBroadcastHandled) {
-					Set<String> forwarded = sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "",
-							false);
-					broadcastForwardedServers.addAll(forwarded);
-					delayedVote.getBroadcastForwardedServers().addAll(forwarded);
+					for (String target : broadcastTargets) {
+						Set<String> forwarded = sendProxyBroadcast(Collections.singleton(target), uuid, player,
+								service, time, "", false);
+						if (delayedVote.getBroadcastForwardedServers().addAll(forwarded)) {
+							broadcastForwardedServers.addAll(forwarded);
+							getVoteCacheHandler().updateTimeVote(delayedVote);
+						}
+					}
 				}
 				log("Caching vote from " + player + "/" + service
 						+ " because time change is happening right now");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -507,6 +507,16 @@ public abstract class VotingPluginProxy {
 						int num = 1;
 						int numberOfVotes = c.size();
 						for (OfflineBungeeVote cache : c) {
+							if (cache.isProxyBroadcastHandled() && cache.needsBroadcastOn(server)) {
+								Set<String> forwarded = sendProxyBroadcast(Collections.singleton(server),
+										cache.getUuid(), cache.getPlayerName(), cache.getService(), cache.getTime(),
+										cache.getText(), false);
+								if (cache.getBroadcastForwardedServers().addAll(forwarded)) {
+									cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
+									getVoteCacheHandler().updateServerVote(server, cache);
+								}
+							}
+
 							boolean toSend = true;
 							if (getConfig().getWaitForUserOnline()) {
 								if (!isPlayerOnline(cache.getPlayerName())) {
@@ -1386,7 +1396,7 @@ public abstract class VotingPluginProxy {
 		return new UUID(mostSigBits, leastSigBits);
 	}
 
-	public void processQueue() {
+	public synchronized void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
 			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().remove();
 			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote);
@@ -1571,7 +1581,8 @@ public abstract class VotingPluginProxy {
 		return "";
 	}
 
-	private long getLastVotesTime(String uuid, ArrayList<Column> cols, String site, String service) {
+	private long getLastVotesTime(String uuid, ArrayList<Column> cols, String site, String service, String player,
+			boolean includeTimeChangeQueue) {
 		long mostRecentTime = 0;
 
 		if (getVoteCacheHandler().hasOnlineVotes(uuid)) {
@@ -1587,6 +1598,15 @@ public abstract class VotingPluginProxy {
 			for (OfflineBungeeVote vote : getVoteCacheHandler().getVotes(server)) {
 				if (vote.getUuid().equals(uuid) && vote.getService().equalsIgnoreCase(service)) {
 					mostRecentTime = Math.max(mostRecentTime, vote.getTime());
+				}
+			}
+		}
+
+		if (includeTimeChangeQueue && player != null) {
+			for (VoteTimeQueue queuedVote : getVoteCacheHandler().getTimeChangeQueue()) {
+				if (queuedVote.getName().equalsIgnoreCase(player)
+						&& queuedVote.getService().equalsIgnoreCase(service)) {
+					mostRecentTime = Math.max(mostRecentTime, queuedVote.getTime());
 				}
 			}
 		}
@@ -1607,6 +1627,22 @@ public abstract class VotingPluginProxy {
 	}
 
 	public boolean checkVoteDelay(String uuid, String service, ArrayList<Column> data) {
+		return checkVoteDelay(uuid, null, service, data, false);
+	}
+
+	/**
+	 * Checks the configured vote delay, optionally including accepted votes waiting
+	 * for a GlobalData time change to finish.
+	 *
+	 * @param uuid player UUID
+	 * @param player player name used by the time-change queue
+	 * @param service vote service
+	 * @param data current player data
+	 * @param includeTimeChangeQueue whether queued votes reserve their delay slot
+	 * @return true when the vote may be accepted
+	 */
+	public boolean checkVoteDelay(String uuid, String player, String service, ArrayList<Column> data,
+			boolean includeTimeChangeQueue) {
 		String site = getWaitUntilDelaySiteFromService(service);
 		if (site.isEmpty()) {
 			debug("No service site set for " + service + ", skipping vote delay check");
@@ -1616,7 +1652,7 @@ public abstract class VotingPluginProxy {
 		int voteDelay = getConfig().getWaitUntilVoteDelayVoteDelay(site);
 		int voteDelayMin = getConfig().getWaitUntilVoteDelayVoteDelayMin(site);
 
-		long lastVote = getLastVotesTime(uuid, data, site, service);
+		long lastVote = getLastVotesTime(uuid, data, site, service, player, includeTimeChangeQueue);
 		if (lastVote == 0) {
 			debug("No last vote time found for " + uuid + "/" + service + ", skipping vote delay check");
 			return true;
@@ -1776,7 +1812,7 @@ public abstract class VotingPluginProxy {
 				}
 
 				data = getProxyMySQL().getExactQuery(new Column("uuid", new DataValueString(uuid)));
-				if (!checkVoteDelay(uuid, service, data)) {
+				if (!checkVoteDelay(uuid, player, service, data, queuedVote == null)) {
 					log("Vote delay is not met for " + player + "/" + service + ", skipping vote");
 					sendVoteDelayRejected(player, uuid, service, playerOnline, playerServer);
 					return;
@@ -1791,12 +1827,17 @@ public abstract class VotingPluginProxy {
 				if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
 					if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
 						broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
-						broadcastForwardedServers.addAll(
-								sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "", false));
 						proxyBroadcastHandled = true;
 					}
-					getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(voteId, player, service, time,
-							proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers));
+					VoteTimeQueue delayedVote = new VoteTimeQueue(voteId, player, service, time,
+							proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers);
+					getVoteCacheHandler().getTimeChangeQueue().add(delayedVote);
+					if (proxyBroadcastHandled) {
+						Set<String> forwarded = sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "",
+								false);
+						broadcastForwardedServers.addAll(forwarded);
+						delayedVote.getBroadcastForwardedServers().addAll(forwarded);
+					}
 					log("Caching vote from " + player + "/" + service
 							+ " because time change is happening right now");
 					return;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -78,6 +78,7 @@ import com.google.gson.JsonObject;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -114,6 +115,8 @@ public abstract class VotingPluginProxy {
 
 	@Getter
 	private RedisHandler redisHandler;
+	private JedisPool redisPublisherPool;
+	private volatile long redisPublisherRetryAfter;
 
 	private boolean enabled;
 
@@ -1008,6 +1011,8 @@ public abstract class VotingPluginProxy {
 					debug2(message);
 				}
 			};
+			redisPublisherPool = new JedisPool(new HostAndPort(getConfig().getRedisHost(), getConfig().getRedisPort()),
+					buildRedisClientConfig());
 
 			runAsync(() -> {
 				RedisListener listener = redisHandler.createEnvelopeListener(
@@ -1199,7 +1204,7 @@ public abstract class VotingPluginProxy {
 
 			@Override
 			public void clearVote(String uuid) {
-				getVoteCacheHandler().removeOnlineVotes(uuid);
+				getVoteCacheHandler().clearOnlineVoteRewards(uuid);
 			}
 
 			@Override
@@ -1386,6 +1391,10 @@ public abstract class VotingPluginProxy {
 		if (redisHandler != null) {
 			redisHandler.close();
 		}
+		if (redisPublisherPool != null) {
+			redisPublisherPool.close();
+			redisPublisherPool = null;
+		}
 
 		bungeeTimeChecker.shutdown();
 
@@ -1555,7 +1564,7 @@ public abstract class VotingPluginProxy {
 		}
 	}
 
-	public boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
+	private DefaultJedisClientConfig buildRedisClientConfig() {
 		DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
 				.database(getConfig().getRedisDbIndex()).connectionTimeoutMillis(2000).socketTimeoutMillis(2000);
 		if (getConfig().getRedisUsername() != null && !getConfig().getRedisUsername().isEmpty()) {
@@ -1564,13 +1573,23 @@ public abstract class VotingPluginProxy {
 		if (getConfig().getRedisPassword() != null && !getConfig().getRedisPassword().isEmpty()) {
 			config.password(getConfig().getRedisPassword());
 		}
+		return config.build();
+	}
 
-		try (Jedis jedis = new Jedis(new HostAndPort(getConfig().getRedisHost(), getConfig().getRedisPort()),
-				config.build())) {
+	public boolean sendRedisEnvelopeServer(String server, JsonEnvelope envelope) {
+		JedisPool publisherPool = redisPublisherPool;
+		if (publisherPool == null || System.currentTimeMillis() < redisPublisherRetryAfter) {
+			return false;
+		}
+
+		try (Jedis jedis = publisherPool.getResource()) {
 			String channel = getConfig().getRedisPrefix() + "VotingPlugin_" + server;
 			long subscribers = jedis.publish(channel, JsonEnvelopeCodec.encode(envelope));
+			redisPublisherRetryAfter = 0L;
 			return subscribers > 0;
 		} catch (Exception e) {
+			// Avoid paying the connection timeout once per target while Redis is down.
+			redisPublisherRetryAfter = System.currentTimeMillis() + 2000L;
 			debug(e.getMessage());
 			return false;
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -517,8 +517,9 @@ public abstract class VotingPluginProxy {
 								}
 							}
 							if (toSend) {
-								boolean broadcastHere = !cache.isBroadcastForwarded();
-								if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+								boolean broadcastHere = cache.needsBroadcastOn(server);
+								if (!cache.isProxyBroadcastHandled() && broadcastHere
+										&& getConfig().getProxyBroadcastEnabled()) {
 									boolean playerOnline = isPlayerOnline(cache.getPlayerName());
 									String playerServer = playerOnline ? getCurrentPlayerServer(cache.getPlayerName())
 											: null;
@@ -564,27 +565,50 @@ public abstract class VotingPluginProxy {
 				}
 				if (!getConfig().getBlockedServers().contains(server)) {
 					int num = 1;
-					int numberOfVotes = c.size();
+					int numberOfVotes = (int) c.stream().filter(vote -> !vote.isRewardDelivered()).count();
+					boolean deliveredReward = false;
+					ArrayList<OfflineBungeeVote> retained = new ArrayList<>();
 					for (OfflineBungeeVote cache : c) {
-						boolean broadcastHere = !cache.isBroadcastForwarded();
-						if (broadcastHere && getConfig().getProxyBroadcastEnabled()) {
+						if (cache.isProxyBroadcastHandled()) {
+							Set<String> pendingTargets = new LinkedHashSet<>(cache.getBroadcastTargets());
+							pendingTargets.removeAll(cache.getBroadcastForwardedServers());
+							cache.getBroadcastForwardedServers().addAll(sendProxyBroadcast(pendingTargets,
+									cache.getUuid(), cache.getPlayerName(), cache.getService(), cache.getTime(),
+									cache.getText(), false));
+							cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
+						}
+						boolean broadcastHere = cache.needsBroadcastOn(server);
+						if (!cache.isProxyBroadcastHandled() && broadcastHere
+								&& getConfig().getProxyBroadcastEnabled()) {
 							String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
 
 							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
 							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
 						}
 
-						globalMessageProxyHandler.sendMessage(server, delay,
-								VotingPluginWire.voteOnline(cache.getPlayerName(), cache.getUuid(), cache.getService(),
-										cache.getTime(), false, cache.isRealVote(), cache.getText(), cache.getVoteId(),
-										getConfig().getBungeeManageTotals(), broadcastHere, num, numberOfVotes));
-						delay++;
-						num++;
+						if (!cache.isRewardDelivered()) {
+							globalMessageProxyHandler.sendMessage(server, delay,
+									VotingPluginWire.voteOnline(cache.getPlayerName(), cache.getUuid(), cache.getService(),
+											cache.getTime(), false, cache.isRealVote(), cache.getText(), cache.getVoteId(),
+											getConfig().getBungeeManageTotals(), broadcastHere, num, numberOfVotes));
+							cache.setRewardDelivered(true);
+							deliveredReward = true;
+							delay++;
+							num++;
+						}
+
+						if (cache.isProxyBroadcastHandled() && !cache.isProxyBroadcastComplete()) {
+							retained.add(cache);
+						}
 					}
 					getVoteCacheHandler().removeOnlineVotes(uuid);
+					for (OfflineBungeeVote pending : retained) {
+						getVoteCacheHandler().addOnlineVote(uuid, pending);
+					}
 
 					// multiproxy: envelope-only
-					if (getConfig().getMultiProxySupport() && getConfig().getMultiProxyOneGlobalReward()) {
+					if (deliveredReward && getConfig().getMultiProxySupport()
+							&& getConfig().getMultiProxyOneGlobalReward()) {
 						multiProxyHandler.sendClearVote(uuid, player);
 					}
 				}
@@ -1728,9 +1752,36 @@ public abstract class VotingPluginProxy {
 			long time = queueTime != 0 ? queueTime
 					: LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
+			Set<String> broadcastTargets = queuedVote == null ? new LinkedHashSet<>()
+					: new LinkedHashSet<>(queuedVote.getBroadcastTargets());
 			Set<String> broadcastForwardedServers = queuedVote == null ? new LinkedHashSet<>()
 					: new LinkedHashSet<>(queuedVote.getBroadcastForwardedServers());
 			boolean proxyBroadcastHandled = queuedVote != null && queuedVote.isProxyBroadcastHandled();
+			boolean processesTotals = getConfig().getPrimaryServer() || !getConfig().getMultiProxySupport();
+			boolean managesTotals = processesTotals && getConfig().getBungeeManageTotals();
+			ArrayList<Column> data = null;
+
+			// Validate the vote before any immediate announcement. This keeps duplicate
+			// votes rejected by the delay check out of the GlobalData rollover queue and
+			// prevents announcing a vote that will not be processed.
+			if (managesTotals) {
+				if (getProxyMySQL() == null) {
+					logSevere("Mysql is not loaded correctly, stopping vote processing");
+					return;
+				}
+
+				if (!getProxyMySQL().containsKeyQuery(uuid)) {
+					getProxyMySQL().update(uuid, "PlayerName", new DataValueString(player));
+					getProxyMySQL().getUuids().add(uuid);
+				}
+
+				data = getProxyMySQL().getExactQuery(new Column("uuid", new DataValueString(uuid)));
+				if (!checkVoteDelay(uuid, service, data)) {
+					log("Vote delay is not met for " + player + "/" + service + ", skipping vote");
+					sendVoteDelayRejected(player, uuid, service, playerOnline, playerServer);
+					return;
+				}
+			}
 
 			// Resolve identity and forward an offline broadcast before a GlobalData time
 			// change queues the reward/totals work. The queued delivery state prevents
@@ -1739,13 +1790,13 @@ public abstract class VotingPluginProxy {
 				getGlobalDataHandler().checkForFinishedTimeChanges();
 				if (timeQueue && getGlobalDataHandler().isTimeChangedHappened()) {
 					if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
-						Set<String> targets = proxyBroadcastDecider.resolveTargets(false, null);
+						broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
 						broadcastForwardedServers.addAll(
-								sendProxyBroadcast(targets, uuid, player, service, time, "", false));
+								sendProxyBroadcast(broadcastTargets, uuid, player, service, time, "", false));
 						proxyBroadcastHandled = true;
 					}
 					getVoteCacheHandler().getTimeChangeQueue().add(new VoteTimeQueue(voteId, player, service, time,
-							proxyBroadcastHandled, broadcastForwardedServers));
+							proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers));
 					log("Caching vote from " + player + "/" + service
 							+ " because time change is happening right now");
 					return;
@@ -1755,28 +1806,8 @@ public abstract class VotingPluginProxy {
 			addVoteParty();
 
 			// Totals processing (primary server OR no multiproxy)
-			if (getConfig().getPrimaryServer() || !getConfig().getMultiProxySupport()) {
-				if (getConfig().getBungeeManageTotals()) {
-
-					if (getProxyMySQL() == null) {
-						logSevere("Mysql is not loaded correctly, stopping vote processing");
-						return;
-					}
-
-					if (!getProxyMySQL().containsKeyQuery(uuid)) {
-						getProxyMySQL().update(uuid, "PlayerName", new DataValueString(player));
-						getProxyMySQL().getUuids().add(uuid);
-					}
-
-					ArrayList<Column> data = getProxyMySQL()
-							.getExactQuery(new Column("uuid", new DataValueString(uuid)));
-
-					if (!checkVoteDelay(uuid, service, data)) {
-						log("Vote delay is not met for " + player + "/" + service + ", skipping vote");
-						sendVoteDelayRejected(player, uuid, service, playerOnline, playerServer);
-						return;
-					}
-
+			if (processesTotals) {
+				if (managesTotals) {
 					int allTimeTotal = getValue(data, "AllTimeTotal", 1);
 					int monthTotal = getValue(data, "MonthTotal", 1);
 
@@ -1834,7 +1865,8 @@ public abstract class VotingPluginProxy {
 			if (standaloneProxyBroadcast) {
 				// A handled queued broadcast was necessarily sampled while the player was
 				// offline. Retry only targets that did not previously accept delivery.
-				proxyBroadcastTargets = proxyBroadcastDecider.resolveTargets(false, null);
+				proxyBroadcastTargets = proxyBroadcastHandled ? new LinkedHashSet<>(broadcastTargets)
+						: proxyBroadcastDecider.resolveTargets(false, null);
 				Set<String> remainingTargets = new LinkedHashSet<>(proxyBroadcastTargets);
 				remainingTargets.removeAll(broadcastForwardedServers);
 				broadcastForwardedServers.addAll(sendProxyBroadcast(remainingTargets, uuid, player, service, time,
@@ -1856,9 +1888,12 @@ public abstract class VotingPluginProxy {
 
 					if ((!isSomeoneOnlineServer(s) && method.requiresPlayerOnline()) || forceCache) {
 						voteStatus = VoteLogStatus.CACHED;
+						boolean broadcastForwarded = standaloneProxyBroadcast
+								&& broadcastForwardedServers.containsAll(proxyBroadcastTargets);
 						getVoteCacheHandler().addServerVote(s,
 								new OfflineBungeeVote(voteId, player, uuid, service, time, realVote,
-										text.toString(), broadcastForwardedServers.contains(s)));
+										text.toString(), broadcastForwarded, standaloneProxyBroadcast,
+										proxyBroadcastTargets, broadcastForwardedServers, false));
 						debug("Caching vote for " + player + " on " + service + " for " + s);
 					} else {
 						boolean broadcastHere = !broadcastForwardedServers.contains(s);
@@ -1916,11 +1951,12 @@ public abstract class VotingPluginProxy {
 					}
 				} else {
 					voteStatus = VoteLogStatus.CACHED;
-					boolean broadcastForwarded = standaloneProxyBroadcast && !proxyBroadcastTargets.isEmpty()
+					boolean broadcastForwarded = standaloneProxyBroadcast
 							&& broadcastForwardedServers.containsAll(proxyBroadcastTargets);
 					getVoteCacheHandler().addOnlineVote(uuid,
 							new OfflineBungeeVote(voteId, player, uuid, service, time, realVote, text.toString(),
-									broadcastForwarded));
+									broadcastForwarded, standaloneProxyBroadcast, proxyBroadcastTargets,
+									broadcastForwardedServers, false));
 					debug("Caching online vote for " + player + " on " + service);
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -529,7 +529,20 @@ public abstract class VotingPluginProxy {
 		case REDIS:
 			return sendRedisEnvelopeServer(server, envelope, true);
 		case SOCKETS:
-			return sendSocketEnvelopeServer(server, envelope);
+			// Standalone broadcasts use the same initialized client as normal
+			// envelopes. This preserves the socket connection and its delivery
+			// acknowledgement instead of creating a second short-lived socket.
+			ClientHandler socketClient = clientHandles == null ? null : clientHandles.get(server);
+			if (socketClient == null) {
+				return false;
+			}
+			try {
+				socketClient.sendEnvelope(envelope);
+				return true;
+			} catch (RuntimeException e) {
+				debug(e.getMessage());
+				return false;
+			}
 		default:
 			return false;
 		}
@@ -1729,7 +1742,7 @@ public abstract class VotingPluginProxy {
 				VoteTotalsSnapshot queuedTotals = vote.getTotals() == null || vote.getTotals().isEmpty() ? null
 						: VoteTotalsSnapshot.parseStorage(vote.getTotals());
 				QueuedVoteResult result = vote(vote.getName(), vote.getService(), true, false, vote.getTime(), queuedTotals,
-						null, vote);
+						vote.getUuid(), vote);
 				if (result == QueuedVoteResult.RETRY) {
 					scheduleTimeVoteRetry();
 					return;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -475,6 +475,16 @@ public abstract class VotingPluginProxy {
 
 	public abstract void broadcast(String message);
 
+	private void sendProxyBroadcast(Set<String> targets, String uuid, String player, String service, long time,
+			String text) {
+		int delay = 1;
+		for (String targetServer : targets) {
+			globalMessageProxyHandler.sendMessage(targetServer, delay,
+					VotingPluginWire.voteBroadcast(uuid, player, service, time, text));
+			delay++;
+		}
+	}
+
 	public synchronized void checkCachedVotes(String server) {
 		int delay = 1;
 		if (isServerValid(server)) {
@@ -498,13 +508,18 @@ public abstract class VotingPluginProxy {
 							if (toSend) {
 								boolean broadcastHere = true;
 								if (getConfig().getProxyBroadcastEnabled()) {
-									boolean playerOnline = isPlayerOnline(cache.getPlayerName());
-									String playerServer = playerOnline ? getCurrentPlayerServer(cache.getPlayerName())
-											: null;
+									if (proxyBroadcastDecider.usesImmediateForwarding()) {
+										broadcastHere = false;
+									} else {
+										boolean playerOnline = isPlayerOnline(cache.getPlayerName());
+										String playerServer = playerOnline
+												? getCurrentPlayerServer(cache.getPlayerName())
+												: null;
 
-									Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline,
-											playerServer);
-									broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+										Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline,
+												playerServer);
+										broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+									}
 								}
 
 								globalMessageProxyHandler.sendMessage(server, delay,
@@ -547,10 +562,14 @@ public abstract class VotingPluginProxy {
 					for (OfflineBungeeVote cache : c) {
 						boolean broadcastHere = true;
 						if (getConfig().getProxyBroadcastEnabled()) {
-							String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
+							if (proxyBroadcastDecider.usesImmediateForwarding()) {
+								broadcastHere = false;
+							} else {
+								String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
 
-							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
-							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+								Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
+								broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+							}
 						}
 
 						globalMessageProxyHandler.sendMessage(server, delay,
@@ -1794,6 +1813,11 @@ public abstract class VotingPluginProxy {
 			}
 
 			VoteLogStatus voteStatus = VoteLogStatus.IMMEDIATE;
+			boolean immediateProxyBroadcast = proxyBroadcastDecider.usesImmediateForwarding();
+			if (immediateProxyBroadcast) {
+				Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
+				sendProxyBroadcast(targets, uuid, player, service, time, text == null ? "" : text.toString());
+			}
 
 			// ===========================
 			// Send vote(s) to backend(s)
@@ -1816,8 +1840,12 @@ public abstract class VotingPluginProxy {
 					} else {
 						boolean broadcastHere = true;
 						if (getConfig().getProxyBroadcastEnabled()) {
-							Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
-							broadcastHere = proxyBroadcastDecider.shouldBroadcast(s, targets);
+							if (immediateProxyBroadcast) {
+								broadcastHere = false;
+							} else {
+								Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline, playerServer);
+								broadcastHere = proxyBroadcastDecider.shouldBroadcast(s, targets);
+							}
 						}
 
 						globalMessageProxyHandler.sendMessage(s, 2,
@@ -1833,15 +1861,19 @@ public abstract class VotingPluginProxy {
 
 					boolean broadcastHere = true;
 					if (getConfig().getProxyBroadcastEnabled()) {
-						Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
-						broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+						if (immediateProxyBroadcast) {
+							broadcastHere = false;
+						} else {
+							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
+							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
+						}
 					}
 
 					globalMessageProxyHandler.sendMessage(server, 1,
 							VotingPluginWire.voteOnline(player, uuid, service, time, true, realVote, text.toString(),
 									voteId, getConfig().getBungeeManageTotals(), broadcastHere, 1, 1));
 
-					if (getConfig().getProxyBroadcastEnabled()) {
+					if (getConfig().getProxyBroadcastEnabled() && !immediateProxyBroadcast) {
 						Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
 
 						int bDelay = 2;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -662,6 +662,13 @@ public abstract class VotingPluginProxy {
 									VotingPluginWire.voteOnline(cache.getPlayerName(), cache.getUuid(), cache.getService(),
 											cache.getTime(), false, cache.isRealVote(), cache.getText(), cache.getVoteId(),
 											getConfig().getBungeeManageTotals(), broadcastHere, num, numberOfVotes));
+							// The normal envelope is also a valid broadcast delivery for the
+							// current target. Record it so a previously pending standalone
+							// retry cannot announce the same vote again later.
+							if (cache.isProxyBroadcastHandled() && broadcastHere) {
+								cache.getBroadcastForwardedServers().add(server);
+								cache.setBroadcastForwarded(cache.isProxyBroadcastComplete());
+							}
 							cache.setRewardDelivered(true);
 							deliveredReward = true;
 							delay++;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -117,6 +117,9 @@ public abstract class VotingPluginProxy {
 	private RedisHandler redisHandler;
 	private JedisPool redisPublisherPool;
 	private volatile long redisPublisherRetryAfter;
+	private final Set<VoteTimeQueue> processedTimeVotesPendingRemoval = Collections
+			.newSetFromMap(new java.util.IdentityHashMap<VoteTimeQueue, Boolean>());
+	private boolean timeVoteRetryScheduled;
 
 	private boolean enabled;
 
@@ -821,6 +824,50 @@ public abstract class VotingPluginProxy {
 		return toAdd;
 	}
 
+	private VoteTotalsSnapshot getProjectedRolloverTotals(ArrayList<Column> data, String player) {
+		List<TimeType> timeChanges = getGlobalDataHandler().getTimeChanges();
+		boolean resetMonth = timeChanges.contains(TimeType.MONTH);
+		boolean resetWeek = timeChanges.contains(TimeType.WEEK);
+		boolean resetDay = timeChanges.contains(TimeType.DAY);
+		int acceptedQueuedVotes = 0;
+		for (VoteTimeQueue queued : getVoteCacheHandler().getTimeChangeQueue()) {
+			if (queued.getName() != null && queued.getName().equalsIgnoreCase(player)) {
+				acceptedQueuedVotes++;
+			}
+		}
+		int voteIncrement = acceptedQueuedVotes + 1;
+
+		int allTimeTotal = getValue(data, "AllTimeTotal", voteIncrement);
+		int monthTotal = resetMonth ? voteIncrement : getValue(data, "MonthTotal", voteIncrement);
+		int weeklyTotal = resetWeek ? voteIncrement : getValue(data, "WeeklyTotal", voteIncrement);
+		int dailyTotal = resetDay ? voteIncrement : getValue(data, "DailyTotal", voteIncrement);
+		int points = getValue(data, "Points", voteIncrement * getConfig().getPointsOnVote());
+
+		int maxVotes = getConfig().getMaxAmountOfVotesPerDay();
+		if (maxVotes > 0) {
+			int days = getBungeeTimeChecker().getTime().getDayOfMonth();
+			if (monthTotal > days * maxVotes) {
+				monthTotal = days * maxVotes;
+			}
+		}
+		if (getConfig().getLimitVotePoints() > 0 && points > getConfig().getLimitVotePoints()) {
+			points = getConfig().getLimitVotePoints();
+		}
+
+		int dateMonthTotal = -1;
+		if (getConfig().getStoreMonthTotalsWithDate()) {
+			if (getConfig().getUseMonthDateTotalsAsPrimaryTotal()) {
+				dateMonthTotal = resetMonth ? voteIncrement
+						: getValue(data, getMonthTotalsWithDatePath(), voteIncrement);
+			} else {
+				dateMonthTotal = monthTotal;
+			}
+		}
+
+		return new VoteTotalsSnapshot(allTimeTotal, monthTotal, weeklyTotal, dailyTotal, points, votePartyVotes,
+				currentVotePartyVotesRequired, dateMonthTotal);
+	}
+
 	public abstract String getPluginVersion();
 
 	public abstract int getVoteCacheCurrentVotePartyVotes();
@@ -1475,8 +1522,36 @@ public abstract class VotingPluginProxy {
 	public synchronized void processQueue() {
 		while (getVoteCacheHandler().getTimeChangeQueue().size() > 0) {
 			VoteTimeQueue vote = getVoteCacheHandler().getTimeChangeQueue().element();
-			vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote);
-			getVoteCacheHandler().removeTimeVote(vote);
+			if (!processedTimeVotesPendingRemoval.contains(vote)) {
+				if (!vote(vote.getName(), vote.getService(), true, false, vote.getTime(), null, null, vote)) {
+					scheduleTimeVoteRetry();
+					return;
+				}
+				processedTimeVotesPendingRemoval.add(vote);
+			}
+			if (!getVoteCacheHandler().removeTimeVote(vote)) {
+				scheduleTimeVoteRetry();
+				return;
+			}
+			processedTimeVotesPendingRemoval.remove(vote);
+		}
+	}
+
+	private void scheduleTimeVoteRetry() {
+		if (timeVoteRetryScheduled || getScheduler() == null) {
+			return;
+		}
+		timeVoteRetryScheduled = true;
+		try {
+			getScheduler().schedule(() -> {
+				synchronized (VotingPluginProxy.this) {
+					timeVoteRetryScheduled = false;
+				}
+				processQueue();
+			}, 5, TimeUnit.SECONDS);
+		} catch (RuntimeException e) {
+			timeVoteRetryScheduled = false;
+			debug("Unable to schedule rollover vote retry: " + e.getMessage());
 		}
 	}
 
@@ -1832,18 +1907,18 @@ public abstract class VotingPluginProxy {
 		vote(player, service, realVote, timeQueue, queueTime, text, uuid, null);
 	}
 
-	private synchronized void vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
+	private synchronized boolean vote(String player, String service, boolean realVote, boolean timeQueue, long queueTime,
 			VoteTotalsSnapshot text, String uuid, VoteTimeQueue queuedVote) {
 		try {
 			if (!ServiceSiteValidator.isValid(service)) {
 				warn("Rejected vote with invalid service site '" + ServiceSiteValidator.sanitizeForLog(service) + "'");
-				return;
+				return false;
 			}
 			if (!MinecraftUsernameValidator.isValid(player, getConfig().getBedrockPlayerPrefix())) {
 				warn("Rejected vote with invalid Minecraft username '"
 						+ MinecraftUsernameValidator.sanitizeForLog(player) + "' from service '"
 						+ MinecraftUsernameValidator.sanitizeForLog(service) + "'");
-				return;
+				return false;
 			}
 
 			UUID voteId = queuedVote == null ? null : queuedVote.getVoteId();
@@ -1874,15 +1949,15 @@ public abstract class VotingPluginProxy {
 			if (uuid.isEmpty()) {
 				if (player.startsWith(getConfig().getBedrockPlayerPrefix())) {
 					log("Ignoring vote since unable to get UUID of bedrock player");
-					return;
+					return false;
 				}
 				if (!getConfig().getAllowUnJoined()) {
 					log("Ignoring vote from " + player + " since player hasn't joined before");
-					return;
+					return false;
 				}
 				if (!getConfig().getUUIDLookup()) {
 					log("Failed to get uuid for " + player);
-					return;
+					return false;
 				}
 
 				debug("Fetching UUID online, since allowunjoined is enabled");
@@ -1898,7 +1973,7 @@ public abstract class VotingPluginProxy {
 				}
 				if (u == null) {
 					debug("Failed to get uuid for " + player);
-					return;
+					return false;
 				}
 				uuid = u.toString();
 			}
@@ -1944,7 +2019,7 @@ public abstract class VotingPluginProxy {
 			if (managesTotals) {
 				if (getProxyMySQL() == null) {
 					logSevere("Mysql is not loaded correctly, stopping vote processing");
-					return;
+					return false;
 				}
 
 				if (!getProxyMySQL().containsKeyQuery(uuid)) {
@@ -1956,7 +2031,7 @@ public abstract class VotingPluginProxy {
 				if (!checkVoteDelay(uuid, player, service, data, queuedVote == null)) {
 					log("Vote delay is not met for " + player + "/" + service + ", skipping vote");
 					sendVoteDelayRejected(player, uuid, service, playerOnline, playerServer);
-					return;
+					return false;
 				}
 			}
 
@@ -1964,6 +2039,7 @@ public abstract class VotingPluginProxy {
 			// change queues the reward/totals work. The queued delivery state prevents
 			// replaying broadcasts that already reached a backend.
 			if (queueForTimeChange) {
+				VoteTotalsSnapshot projectedTotals = managesTotals ? getProjectedRolloverTotals(data, player) : text;
 				if (proxyBroadcastDecider.usesImmediateForwarding(playerOnline)) {
 					broadcastTargets.addAll(proxyBroadcastDecider.resolveTargets(false, null));
 					proxyBroadcastHandled = true;
@@ -1973,12 +2049,12 @@ public abstract class VotingPluginProxy {
 				if (!getVoteCacheHandler().addTimeVoteToCache(delayedVote)) {
 					logSevere("Unable to persist queued rollover vote for " + player + "/" + service
 							+ "; skipping proxy broadcast");
-					return;
+					return false;
 				}
 				if (proxyBroadcastHandled) {
 					for (String target : broadcastTargets) {
 						Set<String> forwarded = sendProxyBroadcast(Collections.singleton(target), uuid, player,
-								service, time, "", false);
+								service, time, projectedTotals == null ? "" : projectedTotals.toString(), false);
 						if (delayedVote.getBroadcastForwardedServers().addAll(forwarded)) {
 							broadcastForwardedServers.addAll(forwarded);
 							getVoteCacheHandler().updateTimeVote(delayedVote);
@@ -1987,7 +2063,7 @@ public abstract class VotingPluginProxy {
 				}
 				log("Caching vote from " + player + "/" + service
 						+ " because time change is happening right now");
-				return;
+				return true;
 			}
 
 			addVoteParty();
@@ -2189,8 +2265,10 @@ public abstract class VotingPluginProxy {
 					}
 				}
 			}
+			return true;
 		} catch (Exception e) {
 			e.printStackTrace();
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginWire.java
@@ -114,9 +114,11 @@ public final class VotingPluginWire {
 				.put(K_SERVICE, safe(service)).put(K_WAS_ONLINE, wasOnline).build();
 	}
 
-	public static JsonEnvelope voteBroadcast(String uuid, String player, String service, long time, String totals) {
+	public static JsonEnvelope voteBroadcast(String uuid, String player, String service, long time, String totals,
+			boolean wasOnline) {
 		return base(SUB_VOTE_BROADCAST).put(K_UUID, safe(uuid)).put(K_PLAYER, safe(player))
-				.put(K_SERVICE, safe(service)).put(K_TIME, time).put(K_TOTALS, safe(totals)).build();
+				.put(K_SERVICE, safe(service)).put(K_TIME, time).put(K_TOTALS, safe(totals))
+				.put(K_WAS_ONLINE, wasOnline).build();
 	}
 
 	public static JsonEnvelope voteUpdate(String playerUuid, int votePartyCurrent, int votePartyRequired,

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/broadcast/ProxyBroadcastDecider.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/broadcast/ProxyBroadcastDecider.java
@@ -102,11 +102,12 @@ public final class ProxyBroadcastDecider {
 	 * logs in. Sending a standalone broadcast also prevents reward-delivery settings
 	 * such as WaitForUserOnline from changing broadcast timing.
 	 *
-	 * @return true when immediate standalone forwarding is enabled
+	 * @param playerOnline whether the voting player is currently online
+	 * @return true when an offline player's broadcast should be forwarded immediately
 	 */
-	public boolean usesImmediateForwarding() {
+	public boolean usesImmediateForwarding(boolean playerOnline) {
 		VotingPluginProxyConfig cfg = config.get();
-		return cfg != null && cfg.getProxyBroadcastEnabled() && OfflineMode
+		return !playerOnline && cfg != null && cfg.getProxyBroadcastEnabled() && OfflineMode
 				.parse(cfg.getProxyBroadcastOfflineMode(), OfflineMode.QUEUE) == OfflineMode.FORWARD;
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/broadcast/ProxyBroadcastDecider.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/broadcast/ProxyBroadcastDecider.java
@@ -96,6 +96,21 @@ public final class ProxyBroadcastDecider {
 	}
 
 	/**
+	 * Check whether broadcasts should be sent independently from vote delivery.
+	 *
+	 * FORWARD must not wait for a cached vote to be released when the voting player
+	 * logs in. Sending a standalone broadcast also prevents reward-delivery settings
+	 * such as WaitForUserOnline from changing broadcast timing.
+	 *
+	 * @return true when immediate standalone forwarding is enabled
+	 */
+	public boolean usesImmediateForwarding() {
+		VotingPluginProxyConfig cfg = config.get();
+		return cfg != null && cfg.getProxyBroadcastEnabled() && OfflineMode
+				.parse(cfg.getProxyBroadcastOfflineMode(), OfflineMode.QUEUE) == OfflineMode.FORWARD;
+	}
+
+	/**
 	 * Convenience check for "should this specific server broadcast?"
 	 * @param server the server name
 	 * @param targets the target servers

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -52,6 +52,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setBoolean(path + ".Real", voteData.isRealVote());
 		setString(path + ".Text", voteData.getText());
 		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
+		setBoolean(path + ".BroadcastForwarded", voteData.isBroadcastForwarded());
 	}
 
 	public void addVoteOnline(String player, int num, OfflineBungeeVote voteData) {
@@ -63,6 +64,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setBoolean(path + ".Real", voteData.isRealVote());
 		setString(path + ".Text", voteData.getText());
 		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
+		setBoolean(path + ".BroadcastForwarded", voteData.isBroadcastForwarded());
 	}
 
 	public void clearData() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -42,6 +42,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setLong(path + ".Time", voteTimedQueue.getTime());
 		setString(path + ".VoteId", voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString());
 		setBoolean(path + ".ProxyBroadcastHandled", voteTimedQueue.isProxyBroadcastHandled());
+		setString(path + ".BroadcastTargets", voteTimedQueue.encodeBroadcastTargets());
 		setString(path + ".BroadcastForwardedServers", voteTimedQueue.encodeBroadcastForwardedServers());
 	}
 
@@ -55,6 +56,10 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setString(path + ".Text", voteData.getText());
 		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
 		setBoolean(path + ".BroadcastForwarded", voteData.isBroadcastForwarded());
+		setBoolean(path + ".ProxyBroadcastHandled", voteData.isProxyBroadcastHandled());
+		setString(path + ".BroadcastTargets", voteData.encodeBroadcastTargets());
+		setString(path + ".BroadcastForwardedServers", voteData.encodeBroadcastForwardedServers());
+		setBoolean(path + ".RewardDelivered", voteData.isRewardDelivered());
 	}
 
 	public void addVoteOnline(String player, int num, OfflineBungeeVote voteData) {
@@ -67,6 +72,10 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setString(path + ".Text", voteData.getText());
 		setString(path + ".VoteId", voteData.getVoteId() != null ? voteData.getVoteId().toString() : null);
 		setBoolean(path + ".BroadcastForwarded", voteData.isBroadcastForwarded());
+		setBoolean(path + ".ProxyBroadcastHandled", voteData.isProxyBroadcastHandled());
+		setString(path + ".BroadcastTargets", voteData.encodeBroadcastTargets());
+		setString(path + ".BroadcastForwardedServers", voteData.encodeBroadcastForwardedServers());
+		setBoolean(path + ".RewardDelivered", voteData.isRewardDelivered());
 	}
 
 	public void clearData() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -41,6 +41,7 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setString(path + ".Service", voteTimedQueue.getService());
 		setLong(path + ".Time", voteTimedQueue.getTime());
 		setString(path + ".VoteId", voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString());
+		setString(path + ".UUID", voteTimedQueue.getUuid());
 		setBoolean(path + ".ProxyBroadcastHandled", voteTimedQueue.isProxyBroadcastHandled());
 		setString(path + ".Totals", voteTimedQueue.getTotals());
 		setBoolean(path + ".Processed", voteTimedQueue.isProcessed());

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -41,6 +41,8 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setString(path + ".Service", voteTimedQueue.getService());
 		setLong(path + ".Time", voteTimedQueue.getTime());
 		setString(path + ".VoteId", voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString());
+		setBoolean(path + ".ProxyBroadcastHandled", voteTimedQueue.isProxyBroadcastHandled());
+		setString(path + ".BroadcastForwardedServers", voteTimedQueue.encodeBroadcastForwardedServers());
 	}
 
 	public void addVote(String server, int num, OfflineBungeeVote voteData) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -117,6 +117,11 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		return new GsonDataNode(getNode("TimedVoteCache." + key));
 	}
 
+	@Override
+	public void removeTimedVotes() {
+		setString("TimedVoteCache", null);
+	}
+
 	public int getVotePartyCache(String server) {
 		return getInt("VoteParty.Cache." + server, 0);
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeJsonVoteCache.java
@@ -42,6 +42,8 @@ public class BungeeJsonVoteCache extends BungeeJsonFile implements IVoteCache {
 		setLong(path + ".Time", voteTimedQueue.getTime());
 		setString(path + ".VoteId", voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString());
 		setBoolean(path + ".ProxyBroadcastHandled", voteTimedQueue.isProxyBroadcastHandled());
+		setString(path + ".Totals", voteTimedQueue.getTotals());
+		setBoolean(path + ".Processed", voteTimedQueue.isProcessed());
 		setString(path + ".BroadcastTargets", voteTimedQueue.encodeBroadcastTargets());
 		setString(path + ".BroadcastForwardedServers", voteTimedQueue.encodeBroadcastForwardedServers());
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VotingPluginBungee.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VotingPluginBungee.java
@@ -825,6 +825,7 @@ public class VotingPluginBungee extends Plugin implements Listener {
 		voteCheckTask = getProxy().getScheduler().schedule(this, new Runnable() {
 			@Override
 			public void run() {
+				getVotingPluginProxy().retryPendingOnlineBroadcasts();
 				for (String server : getVotingPluginProxy().getVoteCacheHandler().getCachedVotesServers()) {
 					getVotingPluginProxy().checkCachedVotes(server);
 				}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VotingPluginBungee.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/VotingPluginBungee.java
@@ -644,10 +644,11 @@ public class VotingPluginBungee extends Plugin implements Listener {
 			}
 
 			@Override
-			public void sendPluginMessageData(String server, String channel, byte[] data, boolean queue) {
+			public boolean sendPluginMessageData(String server, String channel, byte[] data, boolean queue) {
 				if (getProxy().getServerInfo(server) != null) {
-					getProxy().getServerInfo(server).sendData(channel, data, queue);
+					return getProxy().getServerInfo(server).sendData(channel, data, queue);
 				}
+				return false;
 			}
 
 			@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/IVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/IVoteCache.java
@@ -105,6 +105,11 @@ public interface IVoteCache {
 	DataNode getTimedVoteCache(String key);
 
 	/**
+	 * Removes all persisted timed vote entries.
+	 */
+	void removeTimedVotes();
+
+	/**
 	 * Gets the vote party cache for a server.
 	 *
 	 * @param server the server name

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -25,7 +25,6 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 
 	// Prevent repeated startup DDL across multiple instances/subclasses
 	private static final Set<String> MIGRATED_VOTEID = ConcurrentHashMap.newKeySet();
-	private static final Set<String> MIGRATED_BROADCAST_FORWARDED = ConcurrentHashMap.newKeySet();
 	private static final Set<String> ENSURED_INDEXES = ConcurrentHashMap.newKeySet();
 
 	@Override
@@ -93,7 +92,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissing();
 		ensureIndexesOnce();
 	}
 
@@ -107,7 +106,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissing();
 		ensureIndexesOnce();
 	}
 
@@ -205,14 +204,6 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			logSevere("Failed to add voteid column to " + getTableName() + ": " + e.getMessage());
 			debug(e);
 		}
-	}
-
-	private void addBroadcastForwardedColumnIfMissingOnce() {
-		String key = getDbType() + ":" + getTableName() + ":broadcastForwarded";
-		if (!MIGRATED_BROADCAST_FORWARDED.add(key)) {
-			return;
-		}
-		addBroadcastForwardedColumnIfMissing();
 	}
 
 	private void addBroadcastForwardedColumnIfMissing() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -149,6 +149,45 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
+	/**
+	 * Updates proxy broadcast and reward delivery state for a voter-keyed cached
+	 * vote.
+	 *
+	 * @param vote cached vote with updated delivery state
+	 */
+	public void updateProxyBroadcastState(OfflineBungeeVote vote) {
+		if (vote == null) {
+			return;
+		}
+
+		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("broadcastForwarded") + " = ?, "
+				+ qi("proxyBroadcastHandled") + " = ?, " + qi("broadcastTargets") + " = ?, "
+				+ qi("broadcastForwardedServers") + " = ?, " + qi("rewardDelivered") + " = ? WHERE "
+				+ qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;";
+
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(sql)) {
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(1, vote.isBroadcastForwarded());
+				ps.setBoolean(2, vote.isProxyBroadcastHandled());
+				ps.setBoolean(5, vote.isRewardDelivered());
+				ps.setObject(6, UUID.fromString(vote.getUuid()));
+			} else {
+				ps.setInt(1, vote.isBroadcastForwarded() ? 1 : 0);
+				ps.setInt(2, vote.isProxyBroadcastHandled() ? 1 : 0);
+				ps.setInt(5, vote.isRewardDelivered() ? 1 : 0);
+				ps.setString(6, vote.getUuid());
+			}
+			ps.setString(3, vote.encodeBroadcastTargets());
+			ps.setString(4, vote.encodeBroadcastForwardedServers());
+			ps.setString(7, vote.getService());
+			ps.setLong(8, vote.getTime());
+			ps.executeUpdate();
+		} catch (SQLException | IllegalArgumentException e) {
+			debug(e);
+		}
+	}
+
 	private void ensureIndexesOnce() {
 		if (getDbType() != DbType.POSTGRESQL) {
 			return;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -25,6 +25,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 
 	// Prevent repeated startup DDL across multiple instances/subclasses
 	private static final Set<String> MIGRATED_VOTEID = ConcurrentHashMap.newKeySet();
+	private static final Set<String> MIGRATED_BROADCAST_FORWARDED = ConcurrentHashMap.newKeySet();
 	private static final Set<String> ENSURED_INDEXES = ConcurrentHashMap.newKeySet();
 
 	@Override
@@ -38,13 +39,15 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			return "CREATE TABLE IF NOT EXISTS " + qi(getTableName()) + " (" + qi("id") + " BIGSERIAL PRIMARY KEY, "
 					+ qi("uuid") + " " + bestUuidType() + ", " + qi("voteid") + " VARCHAR(36), " + qi("playerName")
 					+ " VARCHAR(100), " + qi("service") + " VARCHAR(100), " + qi("time") + " BIGINT, " + qi("realVote")
-					+ " BOOLEAN, " + qi("text") + " TEXT" + ");";
+					+ " BOOLEAN, " + qi("text") + " TEXT, " + qi("broadcastForwarded")
+					+ " BOOLEAN NOT NULL DEFAULT FALSE" + ");";
 		}
 
 		return "CREATE TABLE IF NOT EXISTS " + qi(getTableName()) + " (" + qi("id") + " INT AUTO_INCREMENT PRIMARY KEY,"
 				+ qi("uuid") + " VARCHAR(37)," + qi("voteid") + " VARCHAR(36)," + qi("playerName") + " VARCHAR(100),"
 				+ qi("service") + " VARCHAR(100)," + qi("time") + " BIGINT," + qi("realVote") + " TINYINT(1),"
-				+ qi("text") + " TEXT," + "INDEX idx_uuid (" + qi("uuid") + ")," + "INDEX idx_time (" + qi("time") + ")"
+				+ qi("text") + " TEXT," + qi("broadcastForwarded") + " TINYINT(1) NOT NULL DEFAULT 0,"
+				+ "INDEX idx_uuid (" + qi("uuid") + ")," + "INDEX idx_time (" + qi("time") + ")"
 				+ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
 	}
 
@@ -90,6 +93,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissingOnce();
 		ensureIndexesOnce();
 	}
 
@@ -103,6 +107,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissingOnce();
 		ensureIndexesOnce();
 	}
 
@@ -202,6 +207,43 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
+	private void addBroadcastForwardedColumnIfMissingOnce() {
+		String key = getDbType() + ":" + getTableName() + ":broadcastForwarded";
+		if (!MIGRATED_BROADCAST_FORWARDED.add(key)) {
+			return;
+		}
+		addBroadcastForwardedColumnIfMissing();
+	}
+
+	private void addBroadcastForwardedColumnIfMissing() {
+		final boolean pg = getDbType() == DbType.POSTGRESQL;
+		final String schemaFilter = pg ? "table_schema = current_schema()" : "TABLE_SCHEMA = DATABASE()";
+		final String checkSql = "SELECT 1 FROM information_schema.columns WHERE " + schemaFilter
+				+ " AND LOWER(table_name) = LOWER(?) AND LOWER(column_name) = LOWER(?) LIMIT 1;";
+
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(checkSql)) {
+			ps.setString(1, getTableName());
+			ps.setString(2, "broadcastForwarded");
+
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					return;
+				}
+			}
+
+			String type = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
+			String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("broadcastForwarded")
+					+ " " + type + ";";
+			try (Statement st = conn.createStatement()) {
+				st.executeUpdate(alter);
+			}
+		} catch (SQLException e) {
+			logSevere("Failed to add broadcastForwarded column to " + getTableName() + ": " + e.getMessage());
+			debug(e);
+		}
+	}
+
 	// --- INSERT ---
 
 	/**
@@ -213,13 +255,14 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 	 * @param time the vote time
 	 * @param real whether this is a real vote
 	 * @param text the vote text/payload
+	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
 	 */
 	public void insertVote(UUID voteId, String uuid, String playerName, String service, long time, boolean real,
-			String text) {
+			String text, boolean broadcastForwarded) {
 
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("uuid") + ", " + qi("voteid") + ", "
 				+ qi("playerName") + ", " + qi("service") + ", " + qi("time") + ", " + qi("realVote") + ", "
-				+ qi("text") + ") VALUES (?, ?, ?, ?, ?, ?, ?);";
+				+ qi("text") + ", " + qi("broadcastForwarded") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -242,6 +285,11 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			}
 
 			ps.setString(7, text);
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(8, broadcastForwarded);
+			} else {
+				ps.setInt(8, broadcastForwarded ? 1 : 0);
+			}
 
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
@@ -346,7 +394,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 					list.add(new VoteRow(rs.getInt("id"), rs.getString("voteid"), rs.getString("uuid"),
 							rs.getString("playerName"), rs.getString("service"), rs.getLong("time"),
 							(getDbType() == DbType.POSTGRESQL ? rs.getBoolean("realVote") : rs.getInt("realVote") == 1),
-							rs.getString("text")));
+							rs.getString("text"), rs.getBoolean("broadcastForwarded")));
 				}
 			}
 		} catch (SQLException e) {
@@ -367,6 +415,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		private final long time;
 		private final boolean realVote;
 		private final String text;
+		private final boolean broadcastForwarded;
 
 		/**
 		 * Constructor for VoteRow.
@@ -378,9 +427,10 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		 * @param time the vote time
 		 * @param realVote whether this is a real vote
 		 * @param text the vote text
+		 * @param broadcastForwarded whether the proxy already forwarded the broadcast
 		 */
 		public VoteRow(int id, String voteId, String uuid, String playerName, String service, long time,
-				boolean realVote, String text) {
+				boolean realVote, String text, boolean broadcastForwarded) {
 			this.id = id;
 			this.voteId = voteId;
 			this.uuid = uuid;
@@ -389,6 +439,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			this.time = time;
 			this.realVote = realVote;
 			this.text = text;
+			this.broadcastForwarded = broadcastForwarded;
 		}
 
 		/**
@@ -453,6 +504,14 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		 */
 		public String getText() {
 			return text;
+		}
+
+		/**
+		 * Checks whether the proxy already forwarded the broadcast.
+		 * @return true if the broadcast was already forwarded
+		 */
+		public boolean isBroadcastForwarded() {
+			return broadcastForwarded;
 		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -160,10 +160,12 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			return;
 		}
 
+		boolean hasVoteId = vote.getVoteId() != null;
 		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("broadcastForwarded") + " = ?, "
 				+ qi("proxyBroadcastHandled") + " = ?, " + qi("broadcastTargets") + " = ?, "
 				+ qi("broadcastForwardedServers") + " = ?, " + qi("rewardDelivered") + " = ? WHERE "
-				+ qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;";
+				+ (hasVoteId ? qi("voteid") + " = ?;"
+						: qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;");
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -171,17 +173,24 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 				ps.setBoolean(1, vote.isBroadcastForwarded());
 				ps.setBoolean(2, vote.isProxyBroadcastHandled());
 				ps.setBoolean(5, vote.isRewardDelivered());
-				ps.setObject(6, UUID.fromString(vote.getUuid()));
 			} else {
 				ps.setInt(1, vote.isBroadcastForwarded() ? 1 : 0);
 				ps.setInt(2, vote.isProxyBroadcastHandled() ? 1 : 0);
 				ps.setInt(5, vote.isRewardDelivered() ? 1 : 0);
-				ps.setString(6, vote.getUuid());
 			}
 			ps.setString(3, vote.encodeBroadcastTargets());
 			ps.setString(4, vote.encodeBroadcastForwardedServers());
-			ps.setString(7, vote.getService());
-			ps.setLong(8, vote.getTime());
+			if (hasVoteId) {
+				ps.setString(6, vote.getVoteId().toString());
+			} else {
+				if (getDbType() == DbType.POSTGRESQL) {
+					ps.setObject(6, UUID.fromString(vote.getUuid()));
+				} else {
+					ps.setString(6, vote.getUuid());
+				}
+				ps.setString(7, vote.getService());
+				ps.setLong(8, vote.getTime());
+			}
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
 			debug(e);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -39,6 +39,9 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 					+ qi("uuid") + " " + bestUuidType() + ", " + qi("voteid") + " VARCHAR(36), " + qi("playerName")
 					+ " VARCHAR(100), " + qi("service") + " VARCHAR(100), " + qi("time") + " BIGINT, " + qi("realVote")
 					+ " BOOLEAN, " + qi("text") + " TEXT, " + qi("broadcastForwarded")
+					+ " BOOLEAN NOT NULL DEFAULT FALSE, " + qi("proxyBroadcastHandled")
+					+ " BOOLEAN NOT NULL DEFAULT FALSE, " + qi("broadcastTargets") + " TEXT, "
+					+ qi("broadcastForwardedServers") + " TEXT, " + qi("rewardDelivered")
 					+ " BOOLEAN NOT NULL DEFAULT FALSE" + ");";
 		}
 
@@ -46,6 +49,9 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 				+ qi("uuid") + " VARCHAR(37)," + qi("voteid") + " VARCHAR(36)," + qi("playerName") + " VARCHAR(100),"
 				+ qi("service") + " VARCHAR(100)," + qi("time") + " BIGINT," + qi("realVote") + " TINYINT(1),"
 				+ qi("text") + " TEXT," + qi("broadcastForwarded") + " TINYINT(1) NOT NULL DEFAULT 0,"
+				+ qi("proxyBroadcastHandled") + " TINYINT(1) NOT NULL DEFAULT 0," + qi("broadcastTargets")
+				+ " TEXT," + qi("broadcastForwardedServers") + " TEXT," + qi("rewardDelivered")
+				+ " TINYINT(1) NOT NULL DEFAULT 0,"
 				+ "INDEX idx_uuid (" + qi("uuid") + ")," + "INDEX idx_time (" + qi("time") + ")"
 				+ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
 	}
@@ -92,7 +98,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissing();
+		ensureProxyBroadcastStateColumns();
 		ensureIndexesOnce();
 	}
 
@@ -106,7 +112,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissing();
+		ensureProxyBroadcastStateColumns();
 		ensureIndexesOnce();
 	}
 
@@ -206,7 +212,17 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
-	private void addBroadcastForwardedColumnIfMissing() {
+	private void ensureProxyBroadcastStateColumns() {
+		final boolean pg = getDbType() == DbType.POSTGRESQL;
+		final String booleanType = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
+		ensureColumn("broadcastForwarded", booleanType);
+		ensureColumn("proxyBroadcastHandled", booleanType);
+		ensureColumn("broadcastTargets", "TEXT");
+		ensureColumn("broadcastForwardedServers", "TEXT");
+		ensureColumn("rewardDelivered", booleanType);
+	}
+
+	private void ensureColumn(String column, String type) {
 		final boolean pg = getDbType() == DbType.POSTGRESQL;
 		final String schemaFilter = pg ? "table_schema = current_schema()" : "TABLE_SCHEMA = DATABASE()";
 		final String checkSql = "SELECT 1 FROM information_schema.columns WHERE " + schemaFilter
@@ -215,7 +231,7 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(checkSql)) {
 			ps.setString(1, getTableName());
-			ps.setString(2, "broadcastForwarded");
+			ps.setString(2, column);
 
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
@@ -223,14 +239,12 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 				}
 			}
 
-			String type = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
-			String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("broadcastForwarded")
-					+ " " + type + ";";
+			String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi(column) + " " + type + ";";
 			try (Statement st = conn.createStatement()) {
 				st.executeUpdate(alter);
 			}
 		} catch (SQLException e) {
-			logSevere("Failed to add broadcastForwarded column to " + getTableName() + ": " + e.getMessage());
+			logSevere("Failed to add " + column + " column to " + getTableName() + ": " + e.getMessage());
 			debug(e);
 		}
 	}
@@ -246,14 +260,21 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 	 * @param time the vote time
 	 * @param real whether this is a real vote
 	 * @param text the vote text/payload
-	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+	 * @param broadcastForwarded legacy aggregate forwarded state
+	 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+	 * @param broadcastTargets encoded original broadcast targets
+	 * @param broadcastForwardedServers encoded delivered broadcast targets
+	 * @param rewardDelivered whether the cached reward vote was already delivered
 	 */
 	public void insertVote(UUID voteId, String uuid, String playerName, String service, long time, boolean real,
-			String text, boolean broadcastForwarded) {
+			String text, boolean broadcastForwarded, boolean proxyBroadcastHandled, String broadcastTargets,
+			String broadcastForwardedServers, boolean rewardDelivered) {
 
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("uuid") + ", " + qi("voteid") + ", "
 				+ qi("playerName") + ", " + qi("service") + ", " + qi("time") + ", " + qi("realVote") + ", "
-				+ qi("text") + ", " + qi("broadcastForwarded") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+				+ qi("text") + ", " + qi("broadcastForwarded") + ", " + qi("proxyBroadcastHandled") + ", "
+				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers") + ", " + qi("rewardDelivered")
+				+ ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -278,9 +299,15 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			ps.setString(7, text);
 			if (getDbType() == DbType.POSTGRESQL) {
 				ps.setBoolean(8, broadcastForwarded);
+				ps.setBoolean(9, proxyBroadcastHandled);
+				ps.setBoolean(12, rewardDelivered);
 			} else {
 				ps.setInt(8, broadcastForwarded ? 1 : 0);
+				ps.setInt(9, proxyBroadcastHandled ? 1 : 0);
+				ps.setInt(12, rewardDelivered ? 1 : 0);
 			}
+			ps.setString(10, broadcastTargets);
+			ps.setString(11, broadcastForwardedServers);
 
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
@@ -385,7 +412,9 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 					list.add(new VoteRow(rs.getInt("id"), rs.getString("voteid"), rs.getString("uuid"),
 							rs.getString("playerName"), rs.getString("service"), rs.getLong("time"),
 							(getDbType() == DbType.POSTGRESQL ? rs.getBoolean("realVote") : rs.getInt("realVote") == 1),
-							rs.getString("text"), rs.getBoolean("broadcastForwarded")));
+							rs.getString("text"), rs.getBoolean("broadcastForwarded"),
+							rs.getBoolean("proxyBroadcastHandled"), rs.getString("broadcastTargets"),
+							rs.getString("broadcastForwardedServers"), rs.getBoolean("rewardDelivered")));
 				}
 			}
 		} catch (SQLException e) {
@@ -407,6 +436,10 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		private final boolean realVote;
 		private final String text;
 		private final boolean broadcastForwarded;
+		private final boolean proxyBroadcastHandled;
+		private final String broadcastTargets;
+		private final String broadcastForwardedServers;
+		private final boolean rewardDelivered;
 
 		/**
 		 * Constructor for VoteRow.
@@ -418,10 +451,15 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		 * @param time the vote time
 		 * @param realVote whether this is a real vote
 		 * @param text the vote text
-		 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+		 * @param broadcastForwarded legacy aggregate forwarded state
+		 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+		 * @param broadcastTargets encoded original broadcast targets
+		 * @param broadcastForwardedServers encoded delivered broadcast targets
+		 * @param rewardDelivered whether the cached reward vote was already delivered
 		 */
 		public VoteRow(int id, String voteId, String uuid, String playerName, String service, long time,
-				boolean realVote, String text, boolean broadcastForwarded) {
+				boolean realVote, String text, boolean broadcastForwarded, boolean proxyBroadcastHandled,
+				String broadcastTargets, String broadcastForwardedServers, boolean rewardDelivered) {
 			this.id = id;
 			this.voteId = voteId;
 			this.uuid = uuid;
@@ -431,6 +469,10 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 			this.realVote = realVote;
 			this.text = text;
 			this.broadcastForwarded = broadcastForwarded;
+			this.proxyBroadcastHandled = proxyBroadcastHandled;
+			this.broadcastTargets = broadcastTargets;
+			this.broadcastForwardedServers = broadcastForwardedServers;
+			this.rewardDelivered = rewardDelivered;
 		}
 
 		/**
@@ -503,6 +545,22 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 		 */
 		public boolean isBroadcastForwarded() {
 			return broadcastForwarded;
+		}
+
+		public boolean isProxyBroadcastHandled() {
+			return proxyBroadcastHandled;
+		}
+
+		public String getBroadcastTargets() {
+			return broadcastTargets;
+		}
+
+		public String getBroadcastForwardedServers() {
+			return broadcastForwardedServers;
+		}
+
+		public boolean isRewardDelivered() {
+			return rewardDelivered;
 		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyOnlineVoteCacheTable.java
@@ -155,9 +155,9 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 	 *
 	 * @param vote cached vote with updated delivery state
 	 */
-	public void updateProxyBroadcastState(OfflineBungeeVote vote) {
+	public boolean updateProxyBroadcastState(OfflineBungeeVote vote) {
 		if (vote == null) {
-			return;
+			return false;
 		}
 
 		boolean hasVoteId = vote.getVoteId() != null;
@@ -191,9 +191,10 @@ public abstract class ProxyOnlineVoteCacheTable extends AbstractSqlTable {
 				ps.setString(7, vote.getService());
 				ps.setLong(8, vote.getTime());
 			}
-			ps.executeUpdate();
+			return ps.executeUpdate() > 0;
 		} catch (SQLException | IllegalArgumentException e) {
 			debug(e);
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -242,8 +242,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * Removes one processed queued vote by vote ID, with a legacy tuple fallback.
 	 *
 	 * @param vote processed queued vote
+	 * @return true when the durable delete completed
 	 */
-	public void removeVote(VoteTimeQueue vote) {
+	public boolean removeVote(VoteTimeQueue vote) {
 		boolean hasVoteId = vote.getVoteId() != null;
 		String sql = "DELETE FROM " + qi(getTableName()) + " WHERE "
 				+ (hasVoteId ? qi("voteId") + " = ?;"
@@ -258,8 +259,10 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				ps.setLong(3, vote.getTime());
 			}
 			ps.executeUpdate();
+			return true;
 		} catch (SQLException e) {
 			debug(e);
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -36,6 +36,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 					+ qi("time") + " BIGINT, "
 					+ qi("voteId") + " VARCHAR(36), "
 					+ qi("proxyBroadcastHandled") + " BOOLEAN NOT NULL DEFAULT FALSE, "
+					+ qi("totals") + " TEXT, "
+					+ qi("processed") + " BOOLEAN NOT NULL DEFAULT FALSE, "
 					+ qi("broadcastTargets") + " TEXT, "
 					+ qi("broadcastForwardedServers") + " TEXT"
 					+ ");";
@@ -48,6 +50,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				+ qi("time") + " BIGINT,"
 				+ qi("voteId") + " VARCHAR(36),"
 				+ qi("proxyBroadcastHandled") + " TINYINT(1) NOT NULL DEFAULT 0,"
+				+ qi("totals") + " TEXT,"
+				+ qi("processed") + " TINYINT(1) NOT NULL DEFAULT 0,"
 				+ qi("broadcastTargets") + " TEXT,"
 				+ qi("broadcastForwardedServers") + " TEXT,"
 				+ "INDEX idx_time (" + qi("time") + ")"
@@ -100,6 +104,10 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				: "TINYINT(1) NOT NULL DEFAULT 0");
 		ensureColumn("broadcastTargets", "TEXT");
 		ensureColumn("broadcastForwardedServers", "TEXT");
+		ensureColumn("totals", "TEXT");
+		ensureColumn("processed", getDbType() == DbType.POSTGRESQL
+				? "BOOLEAN NOT NULL DEFAULT FALSE"
+				: "TINYINT(1) NOT NULL DEFAULT 0");
 	}
 
 	private void ensureColumn(String column, String type) {
@@ -141,14 +149,17 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
 	 * @param broadcastTargets encoded original broadcast targets
 	 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
+	 * @param totals incoming multi-proxy totals snapshot
+	 * @param processed whether normal replay processing completed
 	 * @return true when the row was inserted
 	 */
 	public boolean insertTimedVote(UUID voteId, String playerName, String service, long time,
-			boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers) {
+			boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers, String totals,
+			boolean processed) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
 				+ qi("time") + ", " + qi("voteId") + ", " + qi("proxyBroadcastHandled") + ", "
-				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers")
-				+ ") VALUES (?, ?, ?, ?, ?, ?, ?);";
+				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers") + ", " + qi("totals") + ", "
+				+ qi("processed") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setString(1, playerName);
@@ -162,6 +173,12 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			}
 			ps.setString(6, broadcastTargets);
 			ps.setString(7, broadcastForwardedServers);
+			ps.setString(8, totals);
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(9, processed);
+			} else {
+				ps.setInt(9, processed ? 1 : 0);
+			}
 			ps.executeUpdate();
 			return true;
 		} catch (SQLException e) {
@@ -174,11 +191,13 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * Updates a queued vote's standalone broadcast delivery state.
 	 *
 	 * @param vote queued vote with current delivery state
+	 * @return true when the durable state update completed
 	 */
-	public void updateTimedVote(VoteTimeQueue vote) {
+	public boolean updateTimedVote(VoteTimeQueue vote) {
 		boolean hasVoteId = vote.getVoteId() != null;
 		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("proxyBroadcastHandled") + " = ?, "
-				+ qi("broadcastTargets") + " = ?, " + qi("broadcastForwardedServers") + " = ? WHERE "
+				+ qi("broadcastTargets") + " = ?, " + qi("broadcastForwardedServers") + " = ?, " + qi("totals")
+				+ " = ?, " + qi("processed") + " = ? WHERE "
 				+ (hasVoteId ? qi("voteId") + " = ?;"
 						: qi("playerName") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;");
 		try (Connection conn = mysql.getConnectionManager().getConnection();
@@ -190,16 +209,24 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			}
 			ps.setString(2, vote.encodeBroadcastTargets());
 			ps.setString(3, vote.encodeBroadcastForwardedServers());
-			if (hasVoteId) {
-				ps.setString(4, vote.getVoteId().toString());
+			ps.setString(4, vote.getTotals());
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(5, vote.isProcessed());
 			} else {
-				ps.setString(4, vote.getName());
-				ps.setString(5, vote.getService());
-				ps.setLong(6, vote.getTime());
+				ps.setInt(5, vote.isProcessed() ? 1 : 0);
+			}
+			if (hasVoteId) {
+				ps.setString(6, vote.getVoteId().toString());
+			} else {
+				ps.setString(6, vote.getName());
+				ps.setString(7, vote.getService());
+				ps.setLong(8, vote.getTime());
 			}
 			ps.executeUpdate();
+			return true;
 		} catch (SQLException e) {
 			debug(e);
+			return false;
 		}
 	}
 
@@ -317,7 +344,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 							parseUuid(rs.getString("voteId")),
 							rs.getBoolean("proxyBroadcastHandled"),
 							rs.getString("broadcastTargets"),
-							rs.getString("broadcastForwardedServers")
+							rs.getString("broadcastForwardedServers"),
+							rs.getString("totals"),
+							rs.getBoolean("processed")
 					));
 				}
 			}
@@ -350,6 +379,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		private final boolean proxyBroadcastHandled;
 		private final String broadcastTargets;
 		private final String broadcastForwardedServers;
+		private final String totals;
+		private final boolean processed;
 
 		/**
 		 * Constructor for TimedVoteRow.
@@ -361,9 +392,12 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
 		 * @param broadcastTargets encoded original broadcast targets
 		 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
+		 * @param totals incoming multi-proxy totals snapshot
+		 * @param processed whether normal replay processing completed
 		 */
 		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId,
-				boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers) {
+				boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers, String totals,
+				boolean processed) {
 			this.id = id;
 			this.playerName = playerName;
 			this.service = service;
@@ -372,6 +406,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			this.proxyBroadcastHandled = proxyBroadcastHandled;
 			this.broadcastTargets = broadcastTargets;
 			this.broadcastForwardedServers = broadcastForwardedServers;
+			this.totals = totals;
+			this.processed = processed;
 		}
 
 		/**
@@ -433,6 +469,14 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 */
 		public String getBroadcastForwardedServers() {
 			return broadcastForwardedServers;
+		}
+
+		public String getTotals() {
+			return totals;
+		}
+
+		public boolean isProcessed() {
+			return processed;
 		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -32,7 +33,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 					+ qi("playerName") + " VARCHAR(100), "
 					+ qi("service") + " VARCHAR(100), "
 					+ qi("time") + " BIGINT, "
-					+ qi("voteId") + " VARCHAR(36)"
+					+ qi("voteId") + " VARCHAR(36), "
+					+ qi("proxyBroadcastHandled") + " BOOLEAN NOT NULL DEFAULT FALSE, "
+					+ qi("broadcastForwardedServers") + " TEXT"
 					+ ");";
 		}
 
@@ -42,6 +45,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				+ qi("service") + " VARCHAR(100),"
 				+ qi("time") + " BIGINT,"
 				+ qi("voteId") + " VARCHAR(36),"
+				+ qi("proxyBroadcastHandled") + " TINYINT(1) NOT NULL DEFAULT 0,"
+				+ qi("broadcastForwardedServers") + " TEXT,"
 				+ "INDEX idx_time (" + qi("time") + ")"
 				+ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
 	}
@@ -66,6 +71,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				existingMysql,
 				debug);
 		ensureVoteIdColumn();
+		ensureProxyBroadcastColumns();
 		ensureIndexes();
 	}
 
@@ -77,11 +83,23 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	public ProxyTimedVoteCacheTable(MysqlConfig config, boolean debug) {
 		super("votingplugin_timedvotecache", config, debug);
 		ensureVoteIdColumn();
+		ensureProxyBroadcastColumns();
 		ensureIndexes();
 	}
 
 	private void ensureVoteIdColumn() {
-		String probeSql = "SELECT " + qi("voteId") + " FROM " + qi(getTableName()) + " WHERE 1 = 0;";
+		ensureColumn("voteId", "VARCHAR(36)");
+	}
+
+	private void ensureProxyBroadcastColumns() {
+		ensureColumn("proxyBroadcastHandled", getDbType() == DbType.POSTGRESQL
+				? "BOOLEAN NOT NULL DEFAULT FALSE"
+				: "TINYINT(1) NOT NULL DEFAULT 0");
+		ensureColumn("broadcastForwardedServers", "TEXT");
+	}
+
+	private void ensureColumn(String column, String type) {
+		String probeSql = "SELECT " + qi(column) + " FROM " + qi(getTableName()) + " WHERE 1 = 0;";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(probeSql)) {
 			ps.executeQuery();
@@ -90,9 +108,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			// Column does not exist yet.
 		}
 
-		try {
-			new Query(mysql, "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("voteId")
-					+ " VARCHAR(36);").executeUpdate();
+		String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi(column) + " " + type + ";";
+		try (Connection conn = mysql.getConnectionManager().getConnection(); Statement st = conn.createStatement()) {
+			st.executeUpdate(alter);
 		} catch (SQLException e) {
 			debug(e);
 		}
@@ -116,16 +134,26 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * @param playerName the player name
 	 * @param service the voting service
 	 * @param time the vote time
+	 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
+	 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
 	 */
-	public void insertTimedVote(UUID voteId, String playerName, String service, long time) {
+	public void insertTimedVote(UUID voteId, String playerName, String service, long time,
+			boolean proxyBroadcastHandled, String broadcastForwardedServers) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
-				+ qi("time") + ", " + qi("voteId") + ") VALUES (?, ?, ?, ?);";
+				+ qi("time") + ", " + qi("voteId") + ", " + qi("proxyBroadcastHandled") + ", "
+				+ qi("broadcastForwardedServers") + ") VALUES (?, ?, ?, ?, ?, ?);";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setString(1, playerName);
 			ps.setString(2, service);
 			ps.setLong(3, time);
 			ps.setString(4, voteId == null ? null : voteId.toString());
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(5, proxyBroadcastHandled);
+			} else {
+				ps.setInt(5, proxyBroadcastHandled ? 1 : 0);
+			}
+			ps.setString(6, broadcastForwardedServers);
 			ps.executeUpdate();
 		} catch (SQLException e) {
 			debug(e);
@@ -215,7 +243,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 							rs.getString("playerName"),
 							rs.getString("service"),
 							rs.getLong("time"),
-							parseUuid(rs.getString("voteId"))
+							parseUuid(rs.getString("voteId")),
+							rs.getBoolean("proxyBroadcastHandled"),
+							rs.getString("broadcastForwardedServers")
 					));
 				}
 			}
@@ -245,6 +275,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		private final String service;
 		private final long time;
 		private final UUID voteId;
+		private final boolean proxyBroadcastHandled;
+		private final String broadcastForwardedServers;
 
 		/**
 		 * Constructor for TimedVoteRow.
@@ -253,13 +285,18 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 * @param service the voting service
 		 * @param time the vote time
 		 * @param voteId unique vote identifier
+		 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
+		 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
 		 */
-		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId) {
+		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId,
+				boolean proxyBroadcastHandled, String broadcastForwardedServers) {
 			this.id = id;
 			this.playerName = playerName;
 			this.service = service;
 			this.time = time;
 			this.voteId = voteId;
+			this.proxyBroadcastHandled = proxyBroadcastHandled;
+			this.broadcastForwardedServers = broadcastForwardedServers;
 		}
 
 		/**
@@ -301,6 +338,22 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 */
 		public UUID getVoteId() {
 			return voteId;
+		}
+
+		/**
+		 * Checks whether standalone proxy forwarding was handled.
+		 * @return true when forwarding was handled before queueing
+		 */
+		public boolean isProxyBroadcastHandled() {
+			return proxyBroadcastHandled;
+		}
+
+		/**
+		 * Gets the encoded servers that received the standalone broadcast.
+		 * @return encoded server set
+		 */
+		public String getBroadcastForwardedServers() {
+			return broadcastForwardedServers;
 		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -35,6 +35,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 					+ qi("service") + " VARCHAR(100), "
 					+ qi("time") + " BIGINT, "
 					+ qi("voteId") + " VARCHAR(36), "
+					+ qi("uuid") + " VARCHAR(36), "
 					+ qi("proxyBroadcastHandled") + " BOOLEAN NOT NULL DEFAULT FALSE, "
 					+ qi("totals") + " TEXT, "
 					+ qi("processed") + " BOOLEAN NOT NULL DEFAULT FALSE, "
@@ -49,6 +50,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				+ qi("service") + " VARCHAR(100),"
 				+ qi("time") + " BIGINT,"
 				+ qi("voteId") + " VARCHAR(36),"
+				+ qi("uuid") + " VARCHAR(36),"
 				+ qi("proxyBroadcastHandled") + " TINYINT(1) NOT NULL DEFAULT 0,"
 				+ qi("totals") + " TEXT,"
 				+ qi("processed") + " TINYINT(1) NOT NULL DEFAULT 0,"
@@ -96,6 +98,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 
 	private void ensureVoteIdColumn() {
 		ensureColumn("voteId", "VARCHAR(36)");
+		ensureColumn("uuid", "VARCHAR(36)");
 	}
 
 	private void ensureProxyBroadcastColumns() {
@@ -153,31 +156,32 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * @param processed whether normal replay processing completed
 	 * @return true when the row was inserted
 	 */
-	public boolean insertTimedVote(UUID voteId, String playerName, String service, long time,
+	public boolean insertTimedVote(UUID voteId, String uuid, String playerName, String service, long time,
 			boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers, String totals,
 			boolean processed) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
-				+ qi("time") + ", " + qi("voteId") + ", " + qi("proxyBroadcastHandled") + ", "
+				+ qi("time") + ", " + qi("voteId") + ", " + qi("uuid") + ", " + qi("proxyBroadcastHandled") + ", "
 				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers") + ", " + qi("totals") + ", "
-				+ qi("processed") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
+				+ qi("processed") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setString(1, playerName);
 			ps.setString(2, service);
 			ps.setLong(3, time);
 			ps.setString(4, voteId == null ? null : voteId.toString());
+			ps.setString(5, uuid);
 			if (getDbType() == DbType.POSTGRESQL) {
-				ps.setBoolean(5, proxyBroadcastHandled);
+				ps.setBoolean(6, proxyBroadcastHandled);
 			} else {
-				ps.setInt(5, proxyBroadcastHandled ? 1 : 0);
+				ps.setInt(6, proxyBroadcastHandled ? 1 : 0);
 			}
-			ps.setString(6, broadcastTargets);
-			ps.setString(7, broadcastForwardedServers);
-			ps.setString(8, totals);
+			ps.setString(7, broadcastTargets);
+			ps.setString(8, broadcastForwardedServers);
+			ps.setString(9, totals);
 			if (getDbType() == DbType.POSTGRESQL) {
-				ps.setBoolean(9, processed);
+				ps.setBoolean(10, processed);
 			} else {
-				ps.setInt(9, processed ? 1 : 0);
+				ps.setInt(10, processed ? 1 : 0);
 			}
 			ps.executeUpdate();
 			return true;
@@ -197,7 +201,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		boolean hasVoteId = vote.getVoteId() != null;
 		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("proxyBroadcastHandled") + " = ?, "
 				+ qi("broadcastTargets") + " = ?, " + qi("broadcastForwardedServers") + " = ?, " + qi("totals")
-				+ " = ?, " + qi("processed") + " = ? WHERE "
+				+ " = ?, " + qi("processed") + " = ?, " + qi("uuid") + " = ? WHERE "
 				+ (hasVoteId ? qi("voteId") + " = ?;"
 						: qi("playerName") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;");
 		try (Connection conn = mysql.getConnectionManager().getConnection();
@@ -215,12 +219,13 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			} else {
 				ps.setInt(5, vote.isProcessed() ? 1 : 0);
 			}
+			ps.setString(6, vote.getUuid());
 			if (hasVoteId) {
-				ps.setString(6, vote.getVoteId().toString());
+				ps.setString(7, vote.getVoteId().toString());
 			} else {
-				ps.setString(6, vote.getName());
-				ps.setString(7, vote.getService());
-				ps.setLong(8, vote.getTime());
+				ps.setString(7, vote.getName());
+				ps.setString(8, vote.getService());
+				ps.setLong(9, vote.getTime());
 			}
 			ps.executeUpdate();
 			return true;
@@ -342,6 +347,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 							rs.getString("service"),
 							rs.getLong("time"),
 							parseUuid(rs.getString("voteId")),
+							rs.getString("uuid"),
 							rs.getBoolean("proxyBroadcastHandled"),
 							rs.getString("broadcastTargets"),
 							rs.getString("broadcastForwardedServers"),
@@ -376,6 +382,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		private final String service;
 		private final long time;
 		private final UUID voteId;
+		private final String uuid;
 		private final boolean proxyBroadcastHandled;
 		private final String broadcastTargets;
 		private final String broadcastForwardedServers;
@@ -395,7 +402,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 * @param totals incoming multi-proxy totals snapshot
 		 * @param processed whether normal replay processing completed
 		 */
-		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId,
+		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId, String uuid,
 				boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers, String totals,
 				boolean processed) {
 			this.id = id;
@@ -403,6 +410,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			this.service = service;
 			this.time = time;
 			this.voteId = voteId;
+			this.uuid = uuid;
 			this.proxyBroadcastHandled = proxyBroadcastHandled;
 			this.broadcastTargets = broadcastTargets;
 			this.broadcastForwardedServers = broadcastForwardedServers;
@@ -449,6 +457,10 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 */
 		public UUID getVoteId() {
 			return voteId;
+		}
+
+		public String getUuid() {
+			return uuid;
 		}
 
 		/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -14,6 +14,7 @@ import com.bencodez.simpleapi.sql.mysql.DbType;
 import com.bencodez.simpleapi.sql.mysql.MySQL;
 import com.bencodez.simpleapi.sql.mysql.config.MysqlConfig;
 import com.bencodez.simpleapi.sql.mysql.queries.Query;
+import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 
 /**
  * Table for caching timed votes in the proxy.
@@ -140,8 +141,9 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
 	 * @param broadcastTargets encoded original broadcast targets
 	 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
+	 * @return true when the row was inserted
 	 */
-	public void insertTimedVote(UUID voteId, String playerName, String service, long time,
+	public boolean insertTimedVote(UUID voteId, String playerName, String service, long time,
 			boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
 				+ qi("time") + ", " + qi("voteId") + ", " + qi("proxyBroadcastHandled") + ", "
@@ -160,6 +162,41 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			}
 			ps.setString(6, broadcastTargets);
 			ps.setString(7, broadcastForwardedServers);
+			ps.executeUpdate();
+			return true;
+		} catch (SQLException e) {
+			debug(e);
+			return false;
+		}
+	}
+
+	/**
+	 * Updates a queued vote's standalone broadcast delivery state.
+	 *
+	 * @param vote queued vote with current delivery state
+	 */
+	public void updateTimedVote(VoteTimeQueue vote) {
+		boolean hasVoteId = vote.getVoteId() != null;
+		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("proxyBroadcastHandled") + " = ?, "
+				+ qi("broadcastTargets") + " = ?, " + qi("broadcastForwardedServers") + " = ? WHERE "
+				+ (hasVoteId ? qi("voteId") + " = ?;"
+						: qi("playerName") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;");
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(sql)) {
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(1, vote.isProxyBroadcastHandled());
+			} else {
+				ps.setInt(1, vote.isProxyBroadcastHandled() ? 1 : 0);
+			}
+			ps.setString(2, vote.encodeBroadcastTargets());
+			ps.setString(3, vote.encodeBroadcastForwardedServers());
+			if (hasVoteId) {
+				ps.setString(4, vote.getVoteId().toString());
+			} else {
+				ps.setString(4, vote.getName());
+				ps.setString(5, vote.getService());
+				ps.setLong(6, vote.getTime());
+			}
 			ps.executeUpdate();
 		} catch (SQLException e) {
 			debug(e);
@@ -195,6 +232,31 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setInt(1, id);
+			ps.executeUpdate();
+		} catch (SQLException e) {
+			debug(e);
+		}
+	}
+
+	/**
+	 * Removes one processed queued vote by vote ID, with a legacy tuple fallback.
+	 *
+	 * @param vote processed queued vote
+	 */
+	public void removeVote(VoteTimeQueue vote) {
+		boolean hasVoteId = vote.getVoteId() != null;
+		String sql = "DELETE FROM " + qi(getTableName()) + " WHERE "
+				+ (hasVoteId ? qi("voteId") + " = ?;"
+						: qi("playerName") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ?;");
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(sql)) {
+			if (hasVoteId) {
+				ps.setString(1, vote.getVoteId().toString());
+			} else {
+				ps.setString(1, vote.getName());
+				ps.setString(2, vote.getService());
+				ps.setLong(3, vote.getTime());
+			}
 			ps.executeUpdate();
 		} catch (SQLException e) {
 			debug(e);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyTimedVoteCacheTable.java
@@ -35,6 +35,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 					+ qi("time") + " BIGINT, "
 					+ qi("voteId") + " VARCHAR(36), "
 					+ qi("proxyBroadcastHandled") + " BOOLEAN NOT NULL DEFAULT FALSE, "
+					+ qi("broadcastTargets") + " TEXT, "
 					+ qi("broadcastForwardedServers") + " TEXT"
 					+ ");";
 		}
@@ -46,6 +47,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 				+ qi("time") + " BIGINT,"
 				+ qi("voteId") + " VARCHAR(36),"
 				+ qi("proxyBroadcastHandled") + " TINYINT(1) NOT NULL DEFAULT 0,"
+				+ qi("broadcastTargets") + " TEXT,"
 				+ qi("broadcastForwardedServers") + " TEXT,"
 				+ "INDEX idx_time (" + qi("time") + ")"
 				+ ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
@@ -95,6 +97,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		ensureColumn("proxyBroadcastHandled", getDbType() == DbType.POSTGRESQL
 				? "BOOLEAN NOT NULL DEFAULT FALSE"
 				: "TINYINT(1) NOT NULL DEFAULT 0");
+		ensureColumn("broadcastTargets", "TEXT");
 		ensureColumn("broadcastForwardedServers", "TEXT");
 	}
 
@@ -135,13 +138,15 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 	 * @param service the voting service
 	 * @param time the vote time
 	 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
+	 * @param broadcastTargets encoded original broadcast targets
 	 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
 	 */
 	public void insertTimedVote(UUID voteId, String playerName, String service, long time,
-			boolean proxyBroadcastHandled, String broadcastForwardedServers) {
+			boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers) {
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("playerName") + ", " + qi("service") + ", "
 				+ qi("time") + ", " + qi("voteId") + ", " + qi("proxyBroadcastHandled") + ", "
-				+ qi("broadcastForwardedServers") + ") VALUES (?, ?, ?, ?, ?, ?);";
+				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers")
+				+ ") VALUES (?, ?, ?, ?, ?, ?, ?);";
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
 			ps.setString(1, playerName);
@@ -153,7 +158,8 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 			} else {
 				ps.setInt(5, proxyBroadcastHandled ? 1 : 0);
 			}
-			ps.setString(6, broadcastForwardedServers);
+			ps.setString(6, broadcastTargets);
+			ps.setString(7, broadcastForwardedServers);
 			ps.executeUpdate();
 		} catch (SQLException e) {
 			debug(e);
@@ -245,6 +251,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 							rs.getLong("time"),
 							parseUuid(rs.getString("voteId")),
 							rs.getBoolean("proxyBroadcastHandled"),
+							rs.getString("broadcastTargets"),
 							rs.getString("broadcastForwardedServers")
 					));
 				}
@@ -276,6 +283,7 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		private final long time;
 		private final UUID voteId;
 		private final boolean proxyBroadcastHandled;
+		private final String broadcastTargets;
 		private final String broadcastForwardedServers;
 
 		/**
@@ -286,16 +294,18 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 * @param time the vote time
 		 * @param voteId unique vote identifier
 		 * @param proxyBroadcastHandled whether standalone proxy forwarding was handled
+		 * @param broadcastTargets encoded original broadcast targets
 		 * @param broadcastForwardedServers encoded servers that received the standalone broadcast
 		 */
 		public TimedVoteRow(int id, String playerName, String service, long time, UUID voteId,
-				boolean proxyBroadcastHandled, String broadcastForwardedServers) {
+				boolean proxyBroadcastHandled, String broadcastTargets, String broadcastForwardedServers) {
 			this.id = id;
 			this.playerName = playerName;
 			this.service = service;
 			this.time = time;
 			this.voteId = voteId;
 			this.proxyBroadcastHandled = proxyBroadcastHandled;
+			this.broadcastTargets = broadcastTargets;
 			this.broadcastForwardedServers = broadcastForwardedServers;
 		}
 
@@ -346,6 +356,10 @@ public abstract class ProxyTimedVoteCacheTable extends AbstractSqlTable {
 		 */
 		public boolean isProxyBroadcastHandled() {
 			return proxyBroadcastHandled;
+		}
+
+		public String getBroadcastTargets() {
+			return broadcastTargets;
 		}
 
 		/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -33,7 +33,6 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 	// Ensure we don't run the same migration repeatedly during startup (or for each
 	// subclass).
 	private static final Set<String> MIGRATED_VOTEID = ConcurrentHashMap.newKeySet();
-	private static final Set<String> MIGRATED_BROADCAST_FORWARDED = ConcurrentHashMap.newKeySet();
 	private static final Set<String> ENSURED_INDEXES = ConcurrentHashMap.newKeySet();
 
 	// ---- Required hooks ----
@@ -130,7 +129,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (safe for pool size 1; no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissing();
 		ensureIndexesOnce();
 	}
 
@@ -144,7 +143,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissing();
 		ensureIndexesOnce();
 	}
 
@@ -217,14 +216,6 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			logSevere("Failed to add voteid column to " + getTableName() + ": " + e.getMessage());
 			debug(e);
 		}
-	}
-
-	private void addBroadcastForwardedColumnIfMissingOnce() {
-		final String key = getDbType() + ":" + getTableName() + ":broadcastForwarded";
-		if (!MIGRATED_BROADCAST_FORWARDED.add(key)) {
-			return;
-		}
-		addBroadcastForwardedColumnIfMissing();
 	}
 
 	private void addBroadcastForwardedColumnIfMissing() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -33,6 +33,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 	// Ensure we don't run the same migration repeatedly during startup (or for each
 	// subclass).
 	private static final Set<String> MIGRATED_VOTEID = ConcurrentHashMap.newKeySet();
+	private static final Set<String> MIGRATED_BROADCAST_FORWARDED = ConcurrentHashMap.newKeySet();
 	private static final Set<String> ENSURED_INDEXES = ConcurrentHashMap.newKeySet();
 
 	// ---- Required hooks ----
@@ -54,13 +55,15 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 					.append(", ").append(qi("voteid")).append(" VARCHAR(36), ").append(qi("playerName"))
 					.append(" VARCHAR(100), ").append(qi("service")).append(" VARCHAR(100), ").append(qi("time"))
 					.append(" BIGINT, ").append(qi("realVote")).append(" BOOLEAN, ").append(qi("text"))
-					.append(" TEXT, ").append(qi("server")).append(" VARCHAR(100)").append(");");
+					.append(" TEXT, ").append(qi("broadcastForwarded")).append(" BOOLEAN NOT NULL DEFAULT FALSE, ")
+					.append(qi("server")).append(" VARCHAR(100)").append(");");
 		} else {
 			sb.append("CREATE TABLE IF NOT EXISTS ").append(qi(getTableName())).append(" (").append(qi("id"))
 					.append(" INT AUTO_INCREMENT PRIMARY KEY,").append(qi("uuid")).append(" VARCHAR(37),")
 					.append(qi("voteid")).append(" VARCHAR(36),").append(qi("playerName")).append(" VARCHAR(100),")
 					.append(qi("service")).append(" VARCHAR(100),").append(qi("time")).append(" BIGINT,")
 					.append(qi("realVote")).append(" TINYINT(1),").append(qi("text")).append(" TEXT,")
+					.append(qi("broadcastForwarded")).append(" TINYINT(1) NOT NULL DEFAULT 0,")
 					.append(qi("server")).append(" VARCHAR(100),").append("INDEX idx_server (").append(qi("server"))
 					.append("),").append("INDEX idx_uuid (").append(qi("uuid")).append("),").append("INDEX idx_time (")
 					.append(qi("time")).append(")").append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
@@ -127,6 +130,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (safe for pool size 1; no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissingOnce();
 		ensureIndexesOnce();
 	}
 
@@ -140,6 +144,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
+		addBroadcastForwardedColumnIfMissingOnce();
 		ensureIndexesOnce();
 	}
 
@@ -214,6 +219,43 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
+	private void addBroadcastForwardedColumnIfMissingOnce() {
+		final String key = getDbType() + ":" + getTableName() + ":broadcastForwarded";
+		if (!MIGRATED_BROADCAST_FORWARDED.add(key)) {
+			return;
+		}
+		addBroadcastForwardedColumnIfMissing();
+	}
+
+	private void addBroadcastForwardedColumnIfMissing() {
+		final boolean pg = getDbType() == DbType.POSTGRESQL;
+		final String schemaFilter = pg ? "table_schema = current_schema()" : "TABLE_SCHEMA = DATABASE()";
+		final String checkSql = "SELECT 1 FROM information_schema.columns WHERE " + schemaFilter
+				+ " AND LOWER(table_name) = LOWER(?) AND LOWER(column_name) = LOWER(?) LIMIT 1;";
+
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(checkSql)) {
+			ps.setString(1, getTableName());
+			ps.setString(2, "broadcastForwarded");
+
+			try (ResultSet rs = ps.executeQuery()) {
+				if (rs.next()) {
+					return;
+				}
+			}
+
+			final String type = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
+			final String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("broadcastForwarded")
+					+ " " + type + ";";
+			try (Statement st = conn.createStatement()) {
+				st.executeUpdate(alter);
+			}
+		} catch (SQLException e) {
+			logSevere("Failed to add broadcastForwarded column to " + getTableName() + ": " + e.getMessage());
+			debug(e);
+		}
+	}
+
 	// ---- INSERT ----
 
 	/**
@@ -225,14 +267,16 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 	 * @param time the vote time
 	 * @param real whether this is a real vote
 	 * @param text the vote text/payload
+	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
 	 * @param server the server name
 	 */
 	public void insertVote(UUID voteId, String uuid, String playerName, String service, long time, boolean real,
-			String text, String server) {
+			String text, boolean broadcastForwarded, String server) {
 
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("uuid") + ", " + qi("voteid") + ", "
 				+ qi("playerName") + ", " + qi("service") + ", " + qi("time") + ", " + qi("realVote") + ", "
-				+ qi("text") + ", " + qi("server") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?);";
+				+ qi("text") + ", " + qi("broadcastForwarded") + ", " + qi("server")
+				+ ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -255,7 +299,12 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			}
 
 			ps.setString(7, text);
-			ps.setString(8, server);
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(8, broadcastForwarded);
+			} else {
+				ps.setInt(8, broadcastForwarded ? 1 : 0);
+			}
+			ps.setString(9, server);
 
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
@@ -457,7 +506,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 					VoteRow v = new VoteRow(rs.getInt("id"), rs.getString("voteid"), rs.getString("uuid"),
 							rs.getString("playerName"), rs.getString("service"), rs.getLong("time"),
 							(getDbType() == DbType.POSTGRESQL ? rs.getBoolean("realVote") : rs.getInt("realVote") == 1),
-							rs.getString("text"), rs.getString("server"));
+							rs.getString("text"), rs.getBoolean("broadcastForwarded"), rs.getString("server"));
 					list.add(v);
 				}
 			}
@@ -479,6 +528,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		private final long time;
 		private final boolean realVote;
 		private final String text;
+		private final boolean broadcastForwarded;
 		private final String server;
 
 		/**
@@ -491,10 +541,11 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		 * @param time the vote time
 		 * @param realVote whether this is a real vote
 		 * @param text the vote text
+		 * @param broadcastForwarded whether the proxy already forwarded the broadcast
 		 * @param server the server name
 		 */
 		public VoteRow(int id, String voteId, String uuid, String playerName, String service, long time,
-				boolean realVote, String text, String server) {
+				boolean realVote, String text, boolean broadcastForwarded, String server) {
 			this.id = id;
 			this.voteId = voteId;
 			this.uuid = uuid;
@@ -503,6 +554,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			this.time = time;
 			this.realVote = realVote;
 			this.text = text;
+			this.broadcastForwarded = broadcastForwarded;
 			this.server = server;
 		}
 
@@ -568,6 +620,14 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		 */
 		public String getText() {
 			return text;
+		}
+
+		/**
+		 * Checks whether the proxy already forwarded the broadcast.
+		 * @return true if the broadcast was already forwarded
+		 */
+		public boolean isBroadcastForwarded() {
+			return broadcastForwarded;
 		}
 
 		/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -123,11 +123,13 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			return;
 		}
 
+		boolean hasVoteId = vote.getVoteId() != null;
 		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("broadcastForwarded") + " = ?, "
 				+ qi("proxyBroadcastHandled") + " = ?, " + qi("broadcastTargets") + " = ?, "
 				+ qi("broadcastForwardedServers") + " = ?, " + qi("rewardDelivered") + " = ? WHERE "
-				+ qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ? AND "
-				+ qi("server") + " = ?;";
+				+ (hasVoteId ? qi("voteid") + " = ? AND " + qi("server") + " = ?;"
+						: qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ? AND "
+								+ qi("server") + " = ?;");
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -135,18 +137,26 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 				ps.setBoolean(1, vote.isBroadcastForwarded());
 				ps.setBoolean(2, vote.isProxyBroadcastHandled());
 				ps.setBoolean(5, vote.isRewardDelivered());
-				ps.setObject(6, UUID.fromString(vote.getUuid()));
 			} else {
 				ps.setInt(1, vote.isBroadcastForwarded() ? 1 : 0);
 				ps.setInt(2, vote.isProxyBroadcastHandled() ? 1 : 0);
 				ps.setInt(5, vote.isRewardDelivered() ? 1 : 0);
-				ps.setString(6, vote.getUuid());
 			}
 			ps.setString(3, vote.encodeBroadcastTargets());
 			ps.setString(4, vote.encodeBroadcastForwardedServers());
-			ps.setString(7, vote.getService());
-			ps.setLong(8, vote.getTime());
-			ps.setString(9, server);
+			if (hasVoteId) {
+				ps.setString(6, vote.getVoteId().toString());
+				ps.setString(7, server);
+			} else {
+				if (getDbType() == DbType.POSTGRESQL) {
+					ps.setObject(6, UUID.fromString(vote.getUuid()));
+				} else {
+					ps.setString(6, vote.getUuid());
+				}
+				ps.setString(7, vote.getService());
+				ps.setLong(8, vote.getTime());
+				ps.setString(9, server);
+			}
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
 			debug(e);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -118,9 +118,9 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 	 * @param vote cached vote with updated delivery state
 	 * @param server backend server owning the cached reward
 	 */
-	public void updateProxyBroadcastState(OfflineBungeeVote vote, String server) {
+	public boolean updateProxyBroadcastState(OfflineBungeeVote vote, String server) {
 		if (vote == null || server == null) {
-			return;
+			return false;
 		}
 
 		boolean hasVoteId = vote.getVoteId() != null;
@@ -157,9 +157,10 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 				ps.setLong(8, vote.getTime());
 				ps.setString(9, server);
 			}
-			ps.executeUpdate();
+			return ps.executeUpdate() > 0;
 		} catch (SQLException | IllegalArgumentException e) {
 			debug(e);
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -112,6 +112,47 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
+	/**
+	 * Updates proxy broadcast and reward delivery state for a cached vote.
+	 *
+	 * @param vote cached vote with updated delivery state
+	 * @param server backend server owning the cached reward
+	 */
+	public void updateProxyBroadcastState(OfflineBungeeVote vote, String server) {
+		if (vote == null || server == null) {
+			return;
+		}
+
+		String sql = "UPDATE " + qi(getTableName()) + " SET " + qi("broadcastForwarded") + " = ?, "
+				+ qi("proxyBroadcastHandled") + " = ?, " + qi("broadcastTargets") + " = ?, "
+				+ qi("broadcastForwardedServers") + " = ?, " + qi("rewardDelivered") + " = ? WHERE "
+				+ qi("uuid") + " = ? AND " + qi("service") + " = ? AND " + qi("time") + " = ? AND "
+				+ qi("server") + " = ?;";
+
+		try (Connection conn = mysql.getConnectionManager().getConnection();
+				PreparedStatement ps = conn.prepareStatement(sql)) {
+			if (getDbType() == DbType.POSTGRESQL) {
+				ps.setBoolean(1, vote.isBroadcastForwarded());
+				ps.setBoolean(2, vote.isProxyBroadcastHandled());
+				ps.setBoolean(5, vote.isRewardDelivered());
+				ps.setObject(6, UUID.fromString(vote.getUuid()));
+			} else {
+				ps.setInt(1, vote.isBroadcastForwarded() ? 1 : 0);
+				ps.setInt(2, vote.isProxyBroadcastHandled() ? 1 : 0);
+				ps.setInt(5, vote.isRewardDelivered() ? 1 : 0);
+				ps.setString(6, vote.getUuid());
+			}
+			ps.setString(3, vote.encodeBroadcastTargets());
+			ps.setString(4, vote.encodeBroadcastForwardedServers());
+			ps.setString(7, vote.getService());
+			ps.setLong(8, vote.getTime());
+			ps.setString(9, server);
+			ps.executeUpdate();
+		} catch (SQLException | IllegalArgumentException e) {
+			debug(e);
+		}
+	}
+
 	@Override
 	public abstract void logSevere(String msg);
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/ProxyVoteCacheTable.java
@@ -55,6 +55,9 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 					.append(" VARCHAR(100), ").append(qi("service")).append(" VARCHAR(100), ").append(qi("time"))
 					.append(" BIGINT, ").append(qi("realVote")).append(" BOOLEAN, ").append(qi("text"))
 					.append(" TEXT, ").append(qi("broadcastForwarded")).append(" BOOLEAN NOT NULL DEFAULT FALSE, ")
+					.append(qi("proxyBroadcastHandled")).append(" BOOLEAN NOT NULL DEFAULT FALSE, ")
+					.append(qi("broadcastTargets")).append(" TEXT, ").append(qi("broadcastForwardedServers"))
+					.append(" TEXT, ").append(qi("rewardDelivered")).append(" BOOLEAN NOT NULL DEFAULT FALSE, ")
 					.append(qi("server")).append(" VARCHAR(100)").append(");");
 		} else {
 			sb.append("CREATE TABLE IF NOT EXISTS ").append(qi(getTableName())).append(" (").append(qi("id"))
@@ -63,6 +66,9 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 					.append(qi("service")).append(" VARCHAR(100),").append(qi("time")).append(" BIGINT,")
 					.append(qi("realVote")).append(" TINYINT(1),").append(qi("text")).append(" TEXT,")
 					.append(qi("broadcastForwarded")).append(" TINYINT(1) NOT NULL DEFAULT 0,")
+					.append(qi("proxyBroadcastHandled")).append(" TINYINT(1) NOT NULL DEFAULT 0,")
+					.append(qi("broadcastTargets")).append(" TEXT,").append(qi("broadcastForwardedServers"))
+					.append(" TEXT,").append(qi("rewardDelivered")).append(" TINYINT(1) NOT NULL DEFAULT 0,")
 					.append(qi("server")).append(" VARCHAR(100),").append("INDEX idx_server (").append(qi("server"))
 					.append("),").append("INDEX idx_uuid (").append(qi("uuid")).append("),").append("INDEX idx_time (")
 					.append(qi("time")).append(")").append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
@@ -129,7 +135,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		// best-effort migrations (safe for pool size 1; no nested connections)
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissing();
+		ensureProxyBroadcastStateColumns();
 		ensureIndexesOnce();
 	}
 
@@ -143,7 +149,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 
 		alterColumnType("uuid", bestUuidType());
 		addVoteIdColumnIfMissingOnce();
-		addBroadcastForwardedColumnIfMissing();
+		ensureProxyBroadcastStateColumns();
 		ensureIndexesOnce();
 	}
 
@@ -218,7 +224,17 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		}
 	}
 
-	private void addBroadcastForwardedColumnIfMissing() {
+	private void ensureProxyBroadcastStateColumns() {
+		final boolean pg = getDbType() == DbType.POSTGRESQL;
+		final String booleanType = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
+		ensureColumn("broadcastForwarded", booleanType);
+		ensureColumn("proxyBroadcastHandled", booleanType);
+		ensureColumn("broadcastTargets", "TEXT");
+		ensureColumn("broadcastForwardedServers", "TEXT");
+		ensureColumn("rewardDelivered", booleanType);
+	}
+
+	private void ensureColumn(String column, String type) {
 		final boolean pg = getDbType() == DbType.POSTGRESQL;
 		final String schemaFilter = pg ? "table_schema = current_schema()" : "TABLE_SCHEMA = DATABASE()";
 		final String checkSql = "SELECT 1 FROM information_schema.columns WHERE " + schemaFilter
@@ -227,7 +243,7 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(checkSql)) {
 			ps.setString(1, getTableName());
-			ps.setString(2, "broadcastForwarded");
+			ps.setString(2, column);
 
 			try (ResultSet rs = ps.executeQuery()) {
 				if (rs.next()) {
@@ -235,14 +251,12 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 				}
 			}
 
-			final String type = pg ? "BOOLEAN NOT NULL DEFAULT FALSE" : "TINYINT(1) NOT NULL DEFAULT 0";
-			final String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi("broadcastForwarded")
-					+ " " + type + ";";
+			final String alter = "ALTER TABLE " + qi(getTableName()) + " ADD COLUMN " + qi(column) + " " + type + ";";
 			try (Statement st = conn.createStatement()) {
 				st.executeUpdate(alter);
 			}
 		} catch (SQLException e) {
-			logSevere("Failed to add broadcastForwarded column to " + getTableName() + ": " + e.getMessage());
+			logSevere("Failed to add " + column + " column to " + getTableName() + ": " + e.getMessage());
 			debug(e);
 		}
 	}
@@ -258,16 +272,22 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 	 * @param time the vote time
 	 * @param real whether this is a real vote
 	 * @param text the vote text/payload
-	 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+	 * @param broadcastForwarded legacy aggregate forwarded state
+	 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+	 * @param broadcastTargets encoded original broadcast targets
+	 * @param broadcastForwardedServers encoded delivered broadcast targets
+	 * @param rewardDelivered whether the cached reward vote was already delivered
 	 * @param server the server name
 	 */
 	public void insertVote(UUID voteId, String uuid, String playerName, String service, long time, boolean real,
-			String text, boolean broadcastForwarded, String server) {
+			String text, boolean broadcastForwarded, boolean proxyBroadcastHandled, String broadcastTargets,
+			String broadcastForwardedServers, boolean rewardDelivered, String server) {
 
 		String sql = "INSERT INTO " + qi(getTableName()) + " (" + qi("uuid") + ", " + qi("voteid") + ", "
 				+ qi("playerName") + ", " + qi("service") + ", " + qi("time") + ", " + qi("realVote") + ", "
-				+ qi("text") + ", " + qi("broadcastForwarded") + ", " + qi("server")
-				+ ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);";
+				+ qi("text") + ", " + qi("broadcastForwarded") + ", " + qi("proxyBroadcastHandled") + ", "
+				+ qi("broadcastTargets") + ", " + qi("broadcastForwardedServers") + ", " + qi("rewardDelivered")
+				+ ", " + qi("server") + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
 		try (Connection conn = mysql.getConnectionManager().getConnection();
 				PreparedStatement ps = conn.prepareStatement(sql)) {
@@ -292,10 +312,16 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			ps.setString(7, text);
 			if (getDbType() == DbType.POSTGRESQL) {
 				ps.setBoolean(8, broadcastForwarded);
+				ps.setBoolean(9, proxyBroadcastHandled);
+				ps.setBoolean(12, rewardDelivered);
 			} else {
 				ps.setInt(8, broadcastForwarded ? 1 : 0);
+				ps.setInt(9, proxyBroadcastHandled ? 1 : 0);
+				ps.setInt(12, rewardDelivered ? 1 : 0);
 			}
-			ps.setString(9, server);
+			ps.setString(10, broadcastTargets);
+			ps.setString(11, broadcastForwardedServers);
+			ps.setString(13, server);
 
 			ps.executeUpdate();
 		} catch (SQLException | IllegalArgumentException e) {
@@ -497,7 +523,10 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 					VoteRow v = new VoteRow(rs.getInt("id"), rs.getString("voteid"), rs.getString("uuid"),
 							rs.getString("playerName"), rs.getString("service"), rs.getLong("time"),
 							(getDbType() == DbType.POSTGRESQL ? rs.getBoolean("realVote") : rs.getInt("realVote") == 1),
-							rs.getString("text"), rs.getBoolean("broadcastForwarded"), rs.getString("server"));
+							rs.getString("text"), rs.getBoolean("broadcastForwarded"),
+							rs.getBoolean("proxyBroadcastHandled"), rs.getString("broadcastTargets"),
+							rs.getString("broadcastForwardedServers"), rs.getBoolean("rewardDelivered"),
+							rs.getString("server"));
 					list.add(v);
 				}
 			}
@@ -520,6 +549,10 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		private final boolean realVote;
 		private final String text;
 		private final boolean broadcastForwarded;
+		private final boolean proxyBroadcastHandled;
+		private final String broadcastTargets;
+		private final String broadcastForwardedServers;
+		private final boolean rewardDelivered;
 		private final String server;
 
 		/**
@@ -532,11 +565,16 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		 * @param time the vote time
 		 * @param realVote whether this is a real vote
 		 * @param text the vote text
-		 * @param broadcastForwarded whether the proxy already forwarded the broadcast
+		 * @param broadcastForwarded legacy aggregate forwarded state
+		 * @param proxyBroadcastHandled whether standalone proxy routing was selected
+		 * @param broadcastTargets encoded original broadcast targets
+		 * @param broadcastForwardedServers encoded delivered broadcast targets
+		 * @param rewardDelivered whether the cached reward vote was already delivered
 		 * @param server the server name
 		 */
 		public VoteRow(int id, String voteId, String uuid, String playerName, String service, long time,
-				boolean realVote, String text, boolean broadcastForwarded, String server) {
+				boolean realVote, String text, boolean broadcastForwarded, boolean proxyBroadcastHandled,
+				String broadcastTargets, String broadcastForwardedServers, boolean rewardDelivered, String server) {
 			this.id = id;
 			this.voteId = voteId;
 			this.uuid = uuid;
@@ -546,6 +584,10 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 			this.realVote = realVote;
 			this.text = text;
 			this.broadcastForwarded = broadcastForwarded;
+			this.proxyBroadcastHandled = proxyBroadcastHandled;
+			this.broadcastTargets = broadcastTargets;
+			this.broadcastForwardedServers = broadcastForwardedServers;
+			this.rewardDelivered = rewardDelivered;
 			this.server = server;
 		}
 
@@ -619,6 +661,22 @@ public abstract class ProxyVoteCacheTable extends AbstractSqlTable {
 		 */
 		public boolean isBroadcastForwarded() {
 			return broadcastForwarded;
+		}
+
+		public boolean isProxyBroadcastHandled() {
+			return proxyBroadcastHandled;
+		}
+
+		public String getBroadcastTargets() {
+			return broadcastTargets;
+		}
+
+		public String getBroadcastForwardedServers() {
+			return broadcastForwardedServers;
+		}
+
+		public boolean isRewardDelivered() {
+			return rewardDelivered;
 		}
 
 		/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -99,7 +99,7 @@ public abstract class VoteCacheHandler {
 
 		if (useMySQL) {
 			voteCacheTable.insertVote(vote.getVoteId(), vote.getUuid(), vote.getPlayerName(), vote.getService(),
-					vote.getTime(), vote.isRealVote(), vote.getText(), server);
+					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded(), server);
 		} else {
 			// IMPORTANT: index must come from JSON, not from cachedVotes (cache can be out
 			// of sync with JSON)
@@ -176,7 +176,7 @@ public abstract class VoteCacheHandler {
 
 		if (useMySQL) {
 			onlineVoteCacheTable.insertVote(vote.getVoteId(), vote.getUuid(), vote.getPlayerName(), vote.getService(),
-					vote.getTime(), vote.isRealVote(), vote.getText());
+					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded());
 		} else {
 			// IMPORTANT: index must come from JSON, not from cachedOnlineVotes (cache can
 			// be out of sync with JSON)
@@ -354,7 +354,7 @@ public abstract class VoteCacheHandler {
 			voteCacheTable.getAllVotes().forEach(voteRow -> {
 				OfflineBungeeVote vote = new OfflineBungeeVote(voteRow.getVoteId(), voteRow.getPlayerName(),
 						voteRow.getUuid(), voteRow.getService(), voteRow.getTime(), voteRow.isRealVote(),
-						voteRow.getText());
+						voteRow.getText(), voteRow.isBroadcastForwarded());
 				String server = voteRow.getServer();
 				cachedVotes.putIfAbsent(server, new ArrayList<>());
 				cachedVotes.get(server).add(vote);
@@ -364,7 +364,7 @@ public abstract class VoteCacheHandler {
 			onlineVoteCacheTable.getAllVotes().forEach(voteRow -> {
 				OfflineBungeeVote vote = new OfflineBungeeVote(voteRow.getVoteId(), voteRow.getPlayerName(),
 						voteRow.getUuid(), voteRow.getService(), voteRow.getTime(), voteRow.isRealVote(),
-						voteRow.getText());
+						voteRow.getText(), voteRow.isBroadcastForwarded());
 				String player = vote.getUuid();
 				cachedOnlineVotes.putIfAbsent(player, new ArrayList<>());
 				cachedOnlineVotes.get(player).add(vote);
@@ -415,8 +415,11 @@ public abstract class VoteCacheHandler {
 							boolean real = data.has("Real") && data.get("Real").asBoolean();
 							String text = data.has("Text") ? data.get("Text").asString() : "";
 							String voteId = readVoteId(data);
+							boolean broadcastForwarded = data.has("BroadcastForwarded")
+									&& data.get("BroadcastForwarded").asBoolean();
 
-							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text));
+							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text,
+									broadcastForwarded));
 						}
 					}
 					cachedVotes.put(server, votes);
@@ -440,8 +443,11 @@ public abstract class VoteCacheHandler {
 							boolean real = data.has("Real") && data.get("Real").asBoolean();
 							String text = data.has("Text") ? data.get("Text").asString() : "";
 							String voteId = readVoteId(data);
+							boolean broadcastForwarded = data.has("BroadcastForwarded")
+									&& data.get("BroadcastForwarded").asBoolean();
 
-							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text));
+							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text,
+									broadcastForwarded));
 						}
 					}
 					cachedOnlineVotes.put(player, votes);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -499,7 +499,7 @@ public abstract class VoteCacheHandler {
 		if (useMySQL) {
 			boolean stored = timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(),
 					vote.getTime(), vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
-					vote.encodeBroadcastForwardedServers());
+					vote.encodeBroadcastForwardedServers(), vote.getTotals(), vote.isProcessed());
 			if (!stored) {
 				timeChangeQueue.remove(vote);
 			}
@@ -526,16 +526,16 @@ public abstract class VoteCacheHandler {
 	 * Persists changed delivery state for a queued rollover vote.
 	 *
 	 * @param vote queued vote to update
+	 * @return true when the durable state update completed
 	 */
-	public synchronized void updateTimeVote(VoteTimeQueue vote) {
+	public synchronized boolean updateTimeVote(VoteTimeQueue vote) {
 		if (useMySQL) {
-			timedVoteCacheTable.updateTimedVote(vote);
-			return;
+			return timedVoteCacheTable.updateTimedVote(vote);
 		}
 
 		Collection<String> keys = jsonStorage.getTimedVoteCache();
 		if (keys == null) {
-			return;
+			return false;
 		}
 		for (String key : keys) {
 			DataNode data = jsonStorage.getTimedVoteCache(key);
@@ -543,12 +543,17 @@ public abstract class VoteCacheHandler {
 				try {
 					jsonStorage.addTimedVote(Integer.parseInt(key), vote);
 					jsonStorage.save();
+					return true;
 				} catch (NumberFormatException e) {
 					debug1(e);
+					return false;
+				} catch (RuntimeException e) {
+					debug1(e);
+					return false;
 				}
-				return;
 			}
 		}
+		return false;
 	}
 
 	/**
@@ -620,7 +625,8 @@ public abstract class VoteCacheHandler {
 				VoteTimeQueue voteTimeQueue = new VoteTimeQueue(timedVoteRow.getVoteId(), timedVoteRow.getPlayerName(),
 						timedVoteRow.getService(), timedVoteRow.getTime(), timedVoteRow.isProxyBroadcastHandled(),
 						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastTargets()),
-						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastForwardedServers()));
+						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastForwardedServers()),
+						timedVoteRow.getTotals(), timedVoteRow.isProcessed());
 				timedVotes.add(voteTimeQueue);
 			});
 			timeChangeQueue.addAll(timedVotes);
@@ -643,10 +649,12 @@ public abstract class VoteCacheHandler {
 						String broadcastTargets = data.has("BroadcastTargets")
 								? data.get("BroadcastTargets").asString()
 								: "";
+						String totals = data.has("Totals") ? data.get("Totals").asString() : "";
+						boolean processed = data.has("Processed") && data.get("Processed").asBoolean();
 
 						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time, proxyBroadcastHandled,
 								VoteTimeQueue.decodeBroadcastForwardedServers(broadcastTargets),
-								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers)));
+								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers), totals, processed));
 					}
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -120,15 +120,14 @@ public abstract class VoteCacheHandler {
 	 * @param server backend server owning the cached reward
 	 * @param vote cached vote with updated delivery state
 	 */
-	public synchronized void updateServerVote(String server, OfflineBungeeVote vote) {
+	public synchronized boolean updateServerVote(String server, OfflineBungeeVote vote) {
 		if (useMySQL) {
-			voteCacheTable.updateProxyBroadcastState(vote, server);
-			return;
+			return voteCacheTable.updateProxyBroadcastState(vote, server);
 		}
 
 		Collection<String> keys = jsonStorage.getServerVotes(server);
 		if (keys == null) {
-			return;
+			return false;
 		}
 		for (String key : keys) {
 			DataNode data = jsonStorage.getServerVotes(server, key);
@@ -140,12 +139,14 @@ public abstract class VoteCacheHandler {
 				try {
 					jsonStorage.addVote(server, Integer.parseInt(key), vote);
 					jsonStorage.save();
-				} catch (NumberFormatException e) {
+					return true;
+				} catch (RuntimeException e) {
 					debug1(e);
+					return false;
 				}
-				return;
 			}
 		}
+		return false;
 	}
 
 	/**
@@ -242,15 +243,14 @@ public abstract class VoteCacheHandler {
 	 * @param uuid voter cache key
 	 * @param vote cached vote with updated delivery state
 	 */
-	public synchronized void updateOnlineVote(String uuid, OfflineBungeeVote vote) {
+	public synchronized boolean updateOnlineVote(String uuid, OfflineBungeeVote vote) {
 		if (useMySQL) {
-			onlineVoteCacheTable.updateProxyBroadcastState(vote);
-			return;
+			return onlineVoteCacheTable.updateProxyBroadcastState(vote);
 		}
 
 		Collection<String> keys = jsonStorage.getOnlineVotes(uuid);
 		if (keys == null) {
-			return;
+			return false;
 		}
 		for (String key : keys) {
 			DataNode data = jsonStorage.getOnlineVotes(uuid, key);
@@ -262,12 +262,14 @@ public abstract class VoteCacheHandler {
 				try {
 					jsonStorage.addVoteOnline(uuid, Integer.parseInt(key), vote);
 					jsonStorage.save();
-				} catch (NumberFormatException e) {
+					return true;
+				} catch (RuntimeException e) {
 					debug1(e);
+					return false;
 				}
-				return;
 			}
 		}
+		return false;
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -497,7 +497,7 @@ public abstract class VoteCacheHandler {
 		}
 		timeChangeQueue.add(vote);
 		if (useMySQL) {
-			boolean stored = timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(),
+			boolean stored = timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getUuid(), vote.getName(), vote.getService(),
 					vote.getTime(), vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
 					vote.encodeBroadcastForwardedServers(), vote.getTotals(), vote.isProcessed());
 			if (!stored) {
@@ -626,7 +626,7 @@ public abstract class VoteCacheHandler {
 						timedVoteRow.getService(), timedVoteRow.getTime(), timedVoteRow.isProxyBroadcastHandled(),
 						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastTargets()),
 						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastForwardedServers()),
-						timedVoteRow.getTotals(), timedVoteRow.isProcessed());
+						timedVoteRow.getTotals(), timedVoteRow.isProcessed(), timedVoteRow.getUuid());
 				timedVotes.add(voteTimeQueue);
 			});
 			timeChangeQueue.addAll(timedVotes);
@@ -641,6 +641,7 @@ public abstract class VoteCacheHandler {
 						String service = data.has("Service") ? data.get("Service").asString() : "";
 						long time = data.has("Time") ? data.get("Time").asLong() : 0L;
 						UUID voteId = readUuid(data, "VoteId");
+						String uuid = data.has("UUID") ? data.get("UUID").asString() : "";
 						boolean proxyBroadcastHandled = data.has("ProxyBroadcastHandled")
 								&& data.get("ProxyBroadcastHandled").asBoolean();
 						String forwardedServers = data.has("BroadcastForwardedServers")
@@ -654,7 +655,7 @@ public abstract class VoteCacheHandler {
 
 						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time, proxyBroadcastHandled,
 								VoteTimeQueue.decodeBroadcastForwardedServers(broadcastTargets),
-								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers), totals, processed));
+								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers), totals, processed, uuid));
 					}
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -99,7 +99,9 @@ public abstract class VoteCacheHandler {
 
 		if (useMySQL) {
 			voteCacheTable.insertVote(vote.getVoteId(), vote.getUuid(), vote.getPlayerName(), vote.getService(),
-					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded(), server);
+					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded(),
+					vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
+					vote.encodeBroadcastForwardedServers(), vote.isRewardDelivered(), server);
 		} else {
 			// IMPORTANT: index must come from JSON, not from cachedVotes (cache can be out
 			// of sync with JSON)
@@ -176,7 +178,9 @@ public abstract class VoteCacheHandler {
 
 		if (useMySQL) {
 			onlineVoteCacheTable.insertVote(vote.getVoteId(), vote.getUuid(), vote.getPlayerName(), vote.getService(),
-					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded());
+					vote.getTime(), vote.isRealVote(), vote.getText(), vote.isBroadcastForwarded(),
+					vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
+					vote.encodeBroadcastForwardedServers(), vote.isRewardDelivered());
 		} else {
 			// IMPORTANT: index must come from JSON, not from cachedOnlineVotes (cache can
 			// be out of sync with JSON)
@@ -322,7 +326,8 @@ public abstract class VoteCacheHandler {
 			if (!getTimeChangeQueue().isEmpty()) {
 				for (VoteTimeQueue vote : getTimeChangeQueue()) {
 					timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(), vote.getTime(),
-							vote.isProxyBroadcastHandled(), vote.encodeBroadcastForwardedServers());
+							vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
+							vote.encodeBroadcastForwardedServers());
 				}
 			}
 		} else {
@@ -355,7 +360,10 @@ public abstract class VoteCacheHandler {
 			voteCacheTable.getAllVotes().forEach(voteRow -> {
 				OfflineBungeeVote vote = new OfflineBungeeVote(voteRow.getVoteId(), voteRow.getPlayerName(),
 						voteRow.getUuid(), voteRow.getService(), voteRow.getTime(), voteRow.isRealVote(),
-						voteRow.getText(), voteRow.isBroadcastForwarded());
+						voteRow.getText(), voteRow.isBroadcastForwarded(), voteRow.isProxyBroadcastHandled(),
+						VoteTimeQueue.decodeBroadcastForwardedServers(voteRow.getBroadcastTargets()),
+						VoteTimeQueue.decodeBroadcastForwardedServers(voteRow.getBroadcastForwardedServers()),
+						voteRow.isRewardDelivered());
 				String server = voteRow.getServer();
 				cachedVotes.putIfAbsent(server, new ArrayList<>());
 				cachedVotes.get(server).add(vote);
@@ -365,7 +373,10 @@ public abstract class VoteCacheHandler {
 			onlineVoteCacheTable.getAllVotes().forEach(voteRow -> {
 				OfflineBungeeVote vote = new OfflineBungeeVote(voteRow.getVoteId(), voteRow.getPlayerName(),
 						voteRow.getUuid(), voteRow.getService(), voteRow.getTime(), voteRow.isRealVote(),
-						voteRow.getText(), voteRow.isBroadcastForwarded());
+						voteRow.getText(), voteRow.isBroadcastForwarded(), voteRow.isProxyBroadcastHandled(),
+						VoteTimeQueue.decodeBroadcastForwardedServers(voteRow.getBroadcastTargets()),
+						VoteTimeQueue.decodeBroadcastForwardedServers(voteRow.getBroadcastForwardedServers()),
+						voteRow.isRewardDelivered());
 				String player = vote.getUuid();
 				cachedOnlineVotes.putIfAbsent(player, new ArrayList<>());
 				cachedOnlineVotes.get(player).add(vote);
@@ -376,6 +387,7 @@ public abstract class VoteCacheHandler {
 			timedVoteCacheTable.getAllVotes().forEach(timedVoteRow -> {
 				VoteTimeQueue voteTimeQueue = new VoteTimeQueue(timedVoteRow.getVoteId(), timedVoteRow.getPlayerName(),
 						timedVoteRow.getService(), timedVoteRow.getTime(), timedVoteRow.isProxyBroadcastHandled(),
+						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastTargets()),
 						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastForwardedServers()));
 				timedVotes.add(voteTimeQueue);
 			});
@@ -398,8 +410,12 @@ public abstract class VoteCacheHandler {
 						String forwardedServers = data.has("BroadcastForwardedServers")
 								? data.get("BroadcastForwardedServers").asString()
 								: "";
+						String broadcastTargets = data.has("BroadcastTargets")
+								? data.get("BroadcastTargets").asString()
+								: "";
 
 						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time, proxyBroadcastHandled,
+								VoteTimeQueue.decodeBroadcastForwardedServers(broadcastTargets),
 								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers)));
 					}
 				}
@@ -425,9 +441,22 @@ public abstract class VoteCacheHandler {
 							String voteId = readVoteId(data);
 							boolean broadcastForwarded = data.has("BroadcastForwarded")
 									&& data.get("BroadcastForwarded").asBoolean();
+							boolean proxyBroadcastHandled = data.has("ProxyBroadcastHandled")
+									&& data.get("ProxyBroadcastHandled").asBoolean();
+							String broadcastTargets = data.has("BroadcastTargets")
+									? data.get("BroadcastTargets").asString()
+									: "";
+							String broadcastForwardedServers = data.has("BroadcastForwardedServers")
+									? data.get("BroadcastForwardedServers").asString()
+									: "";
+							boolean rewardDelivered = data.has("RewardDelivered")
+									&& data.get("RewardDelivered").asBoolean();
 
 							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text,
-									broadcastForwarded));
+									broadcastForwarded, proxyBroadcastHandled,
+									VoteTimeQueue.decodeBroadcastForwardedServers(broadcastTargets),
+									VoteTimeQueue.decodeBroadcastForwardedServers(broadcastForwardedServers),
+									rewardDelivered));
 						}
 					}
 					cachedVotes.put(server, votes);
@@ -453,9 +482,22 @@ public abstract class VoteCacheHandler {
 							String voteId = readVoteId(data);
 							boolean broadcastForwarded = data.has("BroadcastForwarded")
 									&& data.get("BroadcastForwarded").asBoolean();
+							boolean proxyBroadcastHandled = data.has("ProxyBroadcastHandled")
+									&& data.get("ProxyBroadcastHandled").asBoolean();
+							String broadcastTargets = data.has("BroadcastTargets")
+									? data.get("BroadcastTargets").asString()
+									: "";
+							String broadcastForwardedServers = data.has("BroadcastForwardedServers")
+									? data.get("BroadcastForwardedServers").asString()
+									: "";
+							boolean rewardDelivered = data.has("RewardDelivered")
+									&& data.get("RewardDelivered").asBoolean();
 
 							votes.add(new OfflineBungeeVote(voteId, name, uuid, service, time, real, text,
-									broadcastForwarded));
+									broadcastForwarded, proxyBroadcastHandled,
+									VoteTimeQueue.decodeBroadcastForwardedServers(broadcastTargets),
+									VoteTimeQueue.decodeBroadcastForwardedServers(broadcastForwardedServers),
+									rewardDelivered));
 						}
 					}
 					cachedOnlineVotes.put(player, votes);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -555,20 +555,32 @@ public abstract class VoteCacheHandler {
 	 * Removes a queued rollover vote after its normal processing completes.
 	 *
 	 * @param vote processed queued vote
+	 * @return true when durable storage and the in-memory queue were updated
 	 */
-	public synchronized void removeTimeVote(VoteTimeQueue vote) {
-		timeChangeQueue.remove(vote);
+	public synchronized boolean removeTimeVote(VoteTimeQueue vote) {
 		if (useMySQL) {
-			timedVoteCacheTable.removeVote(vote);
-			return;
+			if (!timedVoteCacheTable.removeVote(vote)) {
+				return false;
+			}
+			timeChangeQueue.remove(vote);
+			return true;
 		}
 
-		jsonStorage.removeTimedVotes();
-		int index = 0;
-		for (VoteTimeQueue queued : timeChangeQueue) {
-			jsonStorage.addTimedVote(index++, queued);
+		ArrayList<VoteTimeQueue> remaining = new ArrayList<>(timeChangeQueue);
+		remaining.remove(vote);
+		try {
+			jsonStorage.removeTimedVotes();
+			int index = 0;
+			for (VoteTimeQueue queued : remaining) {
+				jsonStorage.addTimedVote(index++, queued);
+			}
+			jsonStorage.save();
+			timeChangeQueue.remove(vote);
+			return true;
+		} catch (RuntimeException e) {
+			debug1(e);
+			return false;
 		}
-		jsonStorage.save();
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -200,6 +202,15 @@ public abstract class VoteCacheHandler {
 	}
 
 	/**
+	 * Gets a snapshot of player UUID keys that have voter-keyed cached votes.
+	 *
+	 * @return cached player UUIDs
+	 */
+	public Set<String> getOnlineVoteUUIDs() {
+		return new LinkedHashSet<>(cachedOnlineVotes.keySet());
+	}
+
+	/**
 	 * Adds a vote to the online vote cache for a player.
 	 * @param uuid the player UUID
 	 * @param vote the vote to add
@@ -224,6 +235,42 @@ public abstract class VoteCacheHandler {
 			int idx = jsonStorage.getOnlineVotes(uuid).size();
 			jsonStorage.addVoteOnline(uuid, idx, vote);
 			jsonStorage.save();
+		}
+	}
+
+	/**
+	 * Persists updated delivery state for an existing voter-keyed cached vote.
+	 *
+	 * @param uuid voter cache key
+	 * @param vote cached vote with updated delivery state
+	 */
+	public synchronized void updateOnlineVote(String uuid, OfflineBungeeVote vote) {
+		if (useMySQL) {
+			onlineVoteCacheTable.updateProxyBroadcastState(vote);
+			return;
+		}
+
+		Collection<String> keys = jsonStorage.getOnlineVotes(uuid);
+		if (keys == null) {
+			return;
+		}
+		for (String key : keys) {
+			DataNode data = jsonStorage.getOnlineVotes(uuid, key);
+			if (data == null || !data.isObject() || !data.has("UUID") || !data.has("Service")
+					|| !data.has("Time")) {
+				continue;
+			}
+			if (vote.getUuid().equals(data.get("UUID").asString())
+					&& vote.getService().equals(data.get("Service").asString())
+					&& vote.getTime() == data.get("Time").asLong()) {
+				try {
+					jsonStorage.addVoteOnline(uuid, Integer.parseInt(key), vote);
+					jsonStorage.save();
+				} catch (NumberFormatException e) {
+					debug1(e);
+				}
+				return;
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -321,7 +321,8 @@ public abstract class VoteCacheHandler {
 
 			if (!getTimeChangeQueue().isEmpty()) {
 				for (VoteTimeQueue vote : getTimeChangeQueue()) {
-					timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(), vote.getTime());
+					timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(), vote.getTime(),
+							vote.isProxyBroadcastHandled(), vote.encodeBroadcastForwardedServers());
 				}
 			}
 		} else {
@@ -374,7 +375,8 @@ public abstract class VoteCacheHandler {
 			ArrayList<VoteTimeQueue> timedVotes = new ArrayList<>();
 			timedVoteCacheTable.getAllVotes().forEach(timedVoteRow -> {
 				VoteTimeQueue voteTimeQueue = new VoteTimeQueue(timedVoteRow.getVoteId(), timedVoteRow.getPlayerName(),
-						timedVoteRow.getService(), timedVoteRow.getTime());
+						timedVoteRow.getService(), timedVoteRow.getTime(), timedVoteRow.isProxyBroadcastHandled(),
+						VoteTimeQueue.decodeBroadcastForwardedServers(timedVoteRow.getBroadcastForwardedServers()));
 				timedVotes.add(voteTimeQueue);
 			});
 			timeChangeQueue.addAll(timedVotes);
@@ -391,8 +393,14 @@ public abstract class VoteCacheHandler {
 						String service = data.has("Service") ? data.get("Service").asString() : "";
 						long time = data.has("Time") ? data.get("Time").asLong() : 0L;
 						UUID voteId = readUuid(data, "VoteId");
+						boolean proxyBroadcastHandled = data.has("ProxyBroadcastHandled")
+								&& data.get("ProxyBroadcastHandled").asBoolean();
+						String forwardedServers = data.has("BroadcastForwardedServers")
+								? data.get("BroadcastForwardedServers").asString()
+								: "";
 
-						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time));
+						getTimeChangeQueue().add(new VoteTimeQueue(voteId, name, service, time, proxyBroadcastHandled,
+								VoteTimeQueue.decodeBroadcastForwardedServers(forwardedServers)));
 					}
 				}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -136,9 +136,7 @@ public abstract class VoteCacheHandler {
 					|| !data.has("Time")) {
 				continue;
 			}
-			if (vote.getUuid().equals(data.get("UUID").asString())
-					&& vote.getService().equals(data.get("Service").asString())
-					&& vote.getTime() == data.get("Time").asLong()) {
+			if (matchesStoredVote(data, vote)) {
 				try {
 					jsonStorage.addVote(server, Integer.parseInt(key), vote);
 					jsonStorage.save();
@@ -260,9 +258,7 @@ public abstract class VoteCacheHandler {
 					|| !data.has("Time")) {
 				continue;
 			}
-			if (vote.getUuid().equals(data.get("UUID").asString())
-					&& vote.getService().equals(data.get("Service").asString())
-					&& vote.getTime() == data.get("Time").asLong()) {
+			if (matchesStoredVote(data, vote)) {
 				try {
 					jsonStorage.addVoteOnline(uuid, Integer.parseInt(key), vote);
 					jsonStorage.save();
@@ -271,6 +267,32 @@ public abstract class VoteCacheHandler {
 				}
 				return;
 			}
+		}
+	}
+
+	/**
+	 * Clears voter-keyed reward eligibility while retaining entries that still have
+	 * standalone proxy broadcast targets to deliver.
+	 *
+	 * @param uuid player UUID whose global reward was delivered by another proxy
+	 */
+	public synchronized void clearOnlineVoteRewards(String uuid) {
+		ArrayList<OfflineBungeeVote> votes = cachedOnlineVotes.get(uuid);
+		if (votes == null || votes.isEmpty()) {
+			return;
+		}
+
+		ArrayList<OfflineBungeeVote> retained = new ArrayList<>();
+		for (OfflineBungeeVote vote : votes) {
+			if (vote.isProxyBroadcastHandled() && !vote.isProxyBroadcastComplete()) {
+				vote.setRewardDelivered(true);
+				retained.add(vote);
+			}
+		}
+
+		removeOnlineVotes(uuid);
+		for (OfflineBungeeVote vote : retained) {
+			addOnlineVote(uuid, vote);
 		}
 	}
 
@@ -399,6 +421,16 @@ public abstract class VoteCacheHandler {
 		} catch (IllegalArgumentException ignored) {
 			return null;
 		}
+	}
+
+	private boolean matchesStoredVote(DataNode data, OfflineBungeeVote vote) {
+		String storedVoteId = readVoteId(data);
+		if (vote.getVoteId() != null && storedVoteId != null && !storedVoteId.isEmpty()) {
+			return vote.getVoteId().toString().equals(storedVoteId);
+		}
+		return vote.getUuid().equals(data.get("UUID").asString())
+				&& vote.getService().equals(data.get("Service").asString())
+				&& vote.getTime() == data.get("Time").asLong();
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -297,6 +297,31 @@ public abstract class VoteCacheHandler {
 	}
 
 	/**
+	 * Removes one voter-keyed cached vote by its stable vote identity.
+	 *
+	 * @param uuid voter cache key
+	 * @param removedVote vote to remove
+	 */
+	public synchronized void removeOnlineVote(String uuid, OfflineBungeeVote removedVote) {
+		ArrayList<OfflineBungeeVote> votes = cachedOnlineVotes.get(uuid);
+		if (votes == null || votes.isEmpty()) {
+			return;
+		}
+
+		ArrayList<OfflineBungeeVote> retained = new ArrayList<>();
+		for (OfflineBungeeVote vote : votes) {
+			if (!sameVoteIdentity(vote, removedVote)) {
+				retained.add(vote);
+			}
+		}
+
+		removeOnlineVotes(uuid);
+		for (OfflineBungeeVote vote : retained) {
+			addOnlineVote(uuid, vote);
+		}
+	}
+
+	/**
 	 * Removes all cached online votes for a player.
 	 * @param uuid the player UUID
 	 */
@@ -433,28 +458,30 @@ public abstract class VoteCacheHandler {
 				&& vote.getTime() == data.get("Time").asLong();
 	}
 
+	private boolean sameVoteIdentity(OfflineBungeeVote first, OfflineBungeeVote second) {
+		if (first.getVoteId() != null && second.getVoteId() != null) {
+			return first.getVoteId().equals(second.getVoteId());
+		}
+		return first.getUuid().equals(second.getUuid()) && first.getService().equals(second.getService())
+				&& first.getTime() == second.getTime();
+	}
+
+	private boolean matchesStoredTimeVote(DataNode data, VoteTimeQueue vote) {
+		String storedVoteId = readVoteId(data);
+		if (vote.getVoteId() != null && storedVoteId != null && !storedVoteId.isEmpty()) {
+			return vote.getVoteId().toString().equals(storedVoteId);
+		}
+		return data.has("Name") && data.has("Service") && data.has("Time")
+				&& vote.getName().equals(data.get("Name").asString())
+				&& vote.getService().equals(data.get("Service").asString())
+				&& vote.getTime() == data.get("Time").asLong();
+	}
+
 	/**
 	 * Saves the vote cache to storage.
 	 */
 	public void saveVoteCache() {
-		if (useMySQL) {
-
-			if (!getTimeChangeQueue().isEmpty()) {
-				for (VoteTimeQueue vote : getTimeChangeQueue()) {
-					timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(), vote.getTime(),
-							vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
-							vote.encodeBroadcastForwardedServers());
-				}
-			}
-		} else {
-
-			if (!getTimeChangeQueue().isEmpty()) {
-				int num = 0;
-				for (VoteTimeQueue vote : getTimeChangeQueue()) {
-					jsonStorage.addTimedVote(num, vote);
-					num++;
-				}
-			}
+		if (!useMySQL) {
 			jsonStorage.save();
 		}
 	}
@@ -462,9 +489,86 @@ public abstract class VoteCacheHandler {
 	/**
 	 * Adds a timed vote to the cache queue.
 	 * @param vote the timed vote to add
+	 * @return true when the vote was durably stored
 	 */
-	public void addTimeVoteToCache(VoteTimeQueue vote) {
+	public synchronized boolean addTimeVoteToCache(VoteTimeQueue vote) {
+		if (vote == null) {
+			return false;
+		}
 		timeChangeQueue.add(vote);
+		if (useMySQL) {
+			boolean stored = timedVoteCacheTable.insertTimedVote(vote.getVoteId(), vote.getName(), vote.getService(),
+					vote.getTime(), vote.isProxyBroadcastHandled(), vote.encodeBroadcastTargets(),
+					vote.encodeBroadcastForwardedServers());
+			if (!stored) {
+				timeChangeQueue.remove(vote);
+			}
+			return stored;
+		}
+
+		try {
+			Collection<String> keys = jsonStorage.getTimedVoteCache();
+			int index = 0;
+			while (keys != null && keys.contains(String.valueOf(index))) {
+				index++;
+			}
+			jsonStorage.addTimedVote(index, vote);
+			jsonStorage.save();
+			return true;
+		} catch (RuntimeException e) {
+			timeChangeQueue.remove(vote);
+			debug1(e);
+			return false;
+		}
+	}
+
+	/**
+	 * Persists changed delivery state for a queued rollover vote.
+	 *
+	 * @param vote queued vote to update
+	 */
+	public synchronized void updateTimeVote(VoteTimeQueue vote) {
+		if (useMySQL) {
+			timedVoteCacheTable.updateTimedVote(vote);
+			return;
+		}
+
+		Collection<String> keys = jsonStorage.getTimedVoteCache();
+		if (keys == null) {
+			return;
+		}
+		for (String key : keys) {
+			DataNode data = jsonStorage.getTimedVoteCache(key);
+			if (data != null && data.isObject() && matchesStoredTimeVote(data, vote)) {
+				try {
+					jsonStorage.addTimedVote(Integer.parseInt(key), vote);
+					jsonStorage.save();
+				} catch (NumberFormatException e) {
+					debug1(e);
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Removes a queued rollover vote after its normal processing completes.
+	 *
+	 * @param vote processed queued vote
+	 */
+	public synchronized void removeTimeVote(VoteTimeQueue vote) {
+		timeChangeQueue.remove(vote);
+		if (useMySQL) {
+			timedVoteCacheTable.removeVote(vote);
+			return;
+		}
+
+		jsonStorage.removeTimedVotes();
+		int index = 0;
+		for (VoteTimeQueue queued : timeChangeQueue) {
+			jsonStorage.addTimedVote(index++, queued);
+		}
+		jsonStorage.save();
 	}
 
 	/**
@@ -508,8 +612,6 @@ public abstract class VoteCacheHandler {
 				timedVotes.add(voteTimeQueue);
 			});
 			timeChangeQueue.addAll(timedVotes);
-
-			timedVoteCacheTable.clearTable();
 
 		} else {
 			try {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/cache/VoteCacheHandler.java
@@ -3,6 +3,7 @@ package com.bencodez.votingplugin.proxy.cache;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
@@ -108,6 +109,42 @@ public abstract class VoteCacheHandler {
 			int idx = jsonStorage.getServerVotes(server).size();
 			jsonStorage.addVote(server, idx, vote);
 			jsonStorage.save();
+		}
+	}
+
+	/**
+	 * Persists updated delivery state for an existing server-cached vote.
+	 *
+	 * @param server backend server owning the cached reward
+	 * @param vote cached vote with updated delivery state
+	 */
+	public synchronized void updateServerVote(String server, OfflineBungeeVote vote) {
+		if (useMySQL) {
+			voteCacheTable.updateProxyBroadcastState(vote, server);
+			return;
+		}
+
+		Collection<String> keys = jsonStorage.getServerVotes(server);
+		if (keys == null) {
+			return;
+		}
+		for (String key : keys) {
+			DataNode data = jsonStorage.getServerVotes(server, key);
+			if (data == null || !data.isObject() || !data.has("UUID") || !data.has("Service")
+					|| !data.has("Time")) {
+				continue;
+			}
+			if (vote.getUuid().equals(data.get("UUID").asString())
+					&& vote.getService().equals(data.get("Service").asString())
+					&& vote.getTime() == data.get("Time").asLong()) {
+				try {
+					jsonStorage.addVote(server, Integer.parseInt(key), vote);
+					jsonStorage.save();
+				} catch (NumberFormatException e) {
+					debug1(e);
+				}
+				return;
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -32,6 +32,8 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 				String.valueOf(num), "VoteId");
 		setPath(voteTimedQueue.isProxyBroadcastHandled(), "TimedVoteCache", String.valueOf(num),
 				"ProxyBroadcastHandled");
+		setPath(voteTimedQueue.getTotals(), "TimedVoteCache", String.valueOf(num), "Totals");
+		setPath(voteTimedQueue.isProcessed(), "TimedVoteCache", String.valueOf(num), "Processed");
 		setPath(voteTimedQueue.encodeBroadcastTargets(), "TimedVoteCache", String.valueOf(num), "BroadcastTargets");
 		setPath(voteTimedQueue.encodeBroadcastForwardedServers(), "TimedVoteCache", String.valueOf(num),
 				"BroadcastForwardedServers");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -41,6 +41,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.isRealVote(), "VoteCache", server, String.valueOf(num), "Real");
 		setPath(voteData.getText(), "VoteCache", server, String.valueOf(num), "Text");
 		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "VoteCache", server, String.valueOf(num), "VoteId");
+		setPath(voteData.isBroadcastForwarded(), "VoteCache", server, String.valueOf(num), "BroadcastForwarded");
 	}
 
 	@Override
@@ -52,6 +53,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.isRealVote(), "OnlineCache", player, String.valueOf(num), "Real");
 		setPath(voteData.getText(), "OnlineCache", player, String.valueOf(num), "Text");
 		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "OnlineCache", player, String.valueOf(num), "VoteId");
+		setPath(voteData.isBroadcastForwarded(), "OnlineCache", player, String.valueOf(num), "BroadcastForwarded");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -30,6 +30,10 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteTimedQueue.getTime(), "TimedVoteCache", String.valueOf(num), "Time");
 		setPath(voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString(), "TimedVoteCache",
 				String.valueOf(num), "VoteId");
+		setPath(voteTimedQueue.isProxyBroadcastHandled(), "TimedVoteCache", String.valueOf(num),
+				"ProxyBroadcastHandled");
+		setPath(voteTimedQueue.encodeBroadcastForwardedServers(), "TimedVoteCache", String.valueOf(num),
+				"BroadcastForwardedServers");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -32,6 +32,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 				String.valueOf(num), "VoteId");
 		setPath(voteTimedQueue.isProxyBroadcastHandled(), "TimedVoteCache", String.valueOf(num),
 				"ProxyBroadcastHandled");
+		setPath(voteTimedQueue.encodeBroadcastTargets(), "TimedVoteCache", String.valueOf(num), "BroadcastTargets");
 		setPath(voteTimedQueue.encodeBroadcastForwardedServers(), "TimedVoteCache", String.valueOf(num),
 				"BroadcastForwardedServers");
 	}
@@ -46,6 +47,12 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.getText(), "VoteCache", server, String.valueOf(num), "Text");
 		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "VoteCache", server, String.valueOf(num), "VoteId");
 		setPath(voteData.isBroadcastForwarded(), "VoteCache", server, String.valueOf(num), "BroadcastForwarded");
+		setPath(voteData.isProxyBroadcastHandled(), "VoteCache", server, String.valueOf(num),
+				"ProxyBroadcastHandled");
+		setPath(voteData.encodeBroadcastTargets(), "VoteCache", server, String.valueOf(num), "BroadcastTargets");
+		setPath(voteData.encodeBroadcastForwardedServers(), "VoteCache", server, String.valueOf(num),
+				"BroadcastForwardedServers");
+		setPath(voteData.isRewardDelivered(), "VoteCache", server, String.valueOf(num), "RewardDelivered");
 	}
 
 	@Override
@@ -58,6 +65,12 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteData.getText(), "OnlineCache", player, String.valueOf(num), "Text");
 		setPath(voteData.getVoteId() != null ? voteData.getVoteId().toString() : null, "OnlineCache", player, String.valueOf(num), "VoteId");
 		setPath(voteData.isBroadcastForwarded(), "OnlineCache", player, String.valueOf(num), "BroadcastForwarded");
+		setPath(voteData.isProxyBroadcastHandled(), "OnlineCache", player, String.valueOf(num),
+				"ProxyBroadcastHandled");
+		setPath(voteData.encodeBroadcastTargets(), "OnlineCache", player, String.valueOf(num), "BroadcastTargets");
+		setPath(voteData.encodeBroadcastForwardedServers(), "OnlineCache", player, String.valueOf(num),
+				"BroadcastForwardedServers");
+		setPath(voteData.isRewardDelivered(), "OnlineCache", player, String.valueOf(num), "RewardDelivered");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -30,6 +30,7 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 		setPath(voteTimedQueue.getTime(), "TimedVoteCache", String.valueOf(num), "Time");
 		setPath(voteTimedQueue.getVoteId() == null ? null : voteTimedQueue.getVoteId().toString(), "TimedVoteCache",
 				String.valueOf(num), "VoteId");
+		setPath(voteTimedQueue.getUuid(), "TimedVoteCache", String.valueOf(num), "UUID");
 		setPath(voteTimedQueue.isProxyBroadcastHandled(), "TimedVoteCache", String.valueOf(num),
 				"ProxyBroadcastHandled");
 		setPath(voteTimedQueue.getTotals(), "TimedVoteCache", String.valueOf(num), "Totals");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityJsonVoteCache.java
@@ -122,6 +122,11 @@ public class VelocityJsonVoteCache extends VelocityJSONFile implements IVoteCach
 	}
 
 	@Override
+	public void removeTimedVotes() {
+		remove("TimedVoteCache");
+	}
+
+	@Override
 	public int getVotePartyCache(String server) {
 		return getNode("VoteParty", "Cache", server).getInt(0);
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
@@ -778,12 +778,12 @@ public class VotingPluginVelocity {
 			}
 
 			@Override
-			public void sendPluginMessageData(String serverName, String channelName, byte[] data, boolean queue) {
+			public boolean sendPluginMessageData(String serverName, String channelName, byte[] data, boolean queue) {
 				if (!server.getServer(serverName).isPresent()) {
-					return;
+					return false;
 				}
 				RegisteredServer send = server.getServer(serverName).get();
-				send.sendPluginMessage(channel, data);
+				return send.sendPluginMessage(channel, data);
 			}
 
 			@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
@@ -924,10 +924,9 @@ public class VotingPluginVelocity {
 
 	private void scheduleTasks() {
 		voteCheckTask = server.getScheduler().buildTask(this, () -> {
+			getVotingPluginProxy().retryPendingOnlineBroadcasts();
 			if (getVotingPluginProxy().getGlobalDataHandler() == null
 					|| !getVotingPluginProxy().getGlobalDataHandler().isTimeChangedHappened()) {
-				getVotingPluginProxy().retryPendingOnlineBroadcasts();
-
 				for (String srv : getVotingPluginProxy().getVoteCacheHandler().getCachedVotesServers()) {
 					getVotingPluginProxy().checkCachedVotes(srv);
 				}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VotingPluginVelocity.java
@@ -926,6 +926,7 @@ public class VotingPluginVelocity {
 		voteCheckTask = server.getScheduler().buildTask(this, () -> {
 			if (getVotingPluginProxy().getGlobalDataHandler() == null
 					|| !getVotingPluginProxy().getGlobalDataHandler().isTimeChangedHappened()) {
+				getVotingPluginProxy().retryPendingOnlineBroadcasts();
 
 				for (String srv : getVotingPluginProxy().getVoteCacheHandler().getCachedVotesServers()) {
 					getVotingPluginProxy().checkCachedVotes(srv);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -28,6 +28,9 @@ public class VoteTimeQueue {
 	private UUID voteId;
 	@Getter
 	@Setter
+	private String uuid;
+	@Getter
+	@Setter
 	private boolean proxyBroadcastHandled;
 	@Getter
 	@Setter
@@ -48,7 +51,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(String name, String service, long time) {
-		this(null, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false);
+		this(null, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false, "");
 	}
 
 	/**
@@ -60,7 +63,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
-		this(voteId, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false);
+		this(voteId, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false, "");
 	}
 
 	/**
@@ -76,7 +79,7 @@ public class VoteTimeQueue {
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastForwardedServers) {
 		this(voteId, name, service, time, proxyBroadcastHandled, Collections.emptySet(), broadcastForwardedServers, "",
-				false);
+				false, "");
 	}
 
 	/**
@@ -93,7 +96,7 @@ public class VoteTimeQueue {
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastTargets, Set<String> broadcastForwardedServers) {
 		this(voteId, name, service, time, proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers, "",
-				false);
+				false, "");
 	}
 
 	/**
@@ -111,7 +114,15 @@ public class VoteTimeQueue {
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastTargets, Set<String> broadcastForwardedServers, String totals, boolean processed) {
+		this(voteId, name, service, time, proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers, totals,
+				processed, "");
+	}
+
+	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
+			Set<String> broadcastTargets, Set<String> broadcastForwardedServers, String totals, boolean processed,
+			String uuid) {
 		this.voteId = voteId;
+		this.uuid = uuid == null ? "" : uuid;
 		this.name = name;
 		this.service = service;
 		this.time = time;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -1,5 +1,10 @@
 package com.bencodez.votingplugin.timequeue;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import lombok.Getter;
@@ -21,6 +26,11 @@ public class VoteTimeQueue {
 	@Getter
 	@Setter
 	private UUID voteId;
+	@Getter
+	@Setter
+	private boolean proxyBroadcastHandled;
+	@Getter
+	private Set<String> broadcastForwardedServers;
 
 	/**
 	 * Creates a legacy-compatible queued vote without an identifier.
@@ -30,7 +40,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(String name, String service, long time) {
-		this(null, name, service, time);
+		this(null, name, service, time, false, Collections.emptySet());
 	}
 
 	/**
@@ -42,9 +52,71 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
+		this(voteId, name, service, time, false, Collections.emptySet());
+	}
+
+	/**
+	 * Creates a queued vote with standalone proxy broadcast delivery state.
+	 *
+	 * @param voteId unique vote identifier
+	 * @param name player name
+	 * @param service service site
+	 * @param time vote timestamp
+	 * @param proxyBroadcastHandled whether standalone forwarding was handled before queueing
+	 * @param broadcastForwardedServers backend servers that received the standalone broadcast
+	 */
+	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
+			Set<String> broadcastForwardedServers) {
 		this.voteId = voteId;
 		this.name = name;
 		this.service = service;
 		this.time = time;
+		this.proxyBroadcastHandled = proxyBroadcastHandled;
+		this.broadcastForwardedServers = new LinkedHashSet<>();
+		if (broadcastForwardedServers != null) {
+			this.broadcastForwardedServers.addAll(broadcastForwardedServers);
+		}
+	}
+
+	/**
+	 * Encodes forwarded server names for JSON and SQL cache storage.
+	 *
+	 * @return encoded server set
+	 */
+	public String encodeBroadcastForwardedServers() {
+		Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+		StringBuilder encoded = new StringBuilder();
+		for (String server : broadcastForwardedServers) {
+			if (server == null || server.isEmpty()) {
+				continue;
+			}
+			if (encoded.length() > 0) {
+				encoded.append(',');
+			}
+			encoded.append(encoder.encodeToString(server.getBytes(StandardCharsets.UTF_8)));
+		}
+		return encoded.toString();
+	}
+
+	/**
+	 * Decodes forwarded server names from JSON or SQL cache storage.
+	 *
+	 * @param encoded encoded server set
+	 * @return decoded server names
+	 */
+	public static Set<String> decodeBroadcastForwardedServers(String encoded) {
+		Set<String> servers = new LinkedHashSet<>();
+		if (encoded == null || encoded.isEmpty()) {
+			return servers;
+		}
+		Base64.Decoder decoder = Base64.getUrlDecoder();
+		for (String value : encoded.split(",")) {
+			try {
+				servers.add(new String(decoder.decode(value), StandardCharsets.UTF_8));
+			} catch (IllegalArgumentException ignored) {
+				// Ignore malformed cache entries and keep the broadcast pending.
+			}
+		}
+		return servers;
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -39,6 +39,9 @@ public class VoteTimeQueue {
 	@Setter
 	private boolean processed;
 	@Getter
+	@Setter
+	private boolean deliveryStateDirty;
+	@Getter
 	private Set<String> broadcastTargets;
 	@Getter
 	private Set<String> broadcastForwardedServers;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -30,6 +30,12 @@ public class VoteTimeQueue {
 	@Setter
 	private boolean proxyBroadcastHandled;
 	@Getter
+	@Setter
+	private String totals;
+	@Getter
+	@Setter
+	private boolean processed;
+	@Getter
 	private Set<String> broadcastTargets;
 	@Getter
 	private Set<String> broadcastForwardedServers;
@@ -42,7 +48,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(String name, String service, long time) {
-		this(null, name, service, time, false, Collections.emptySet(), Collections.emptySet());
+		this(null, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false);
 	}
 
 	/**
@@ -54,7 +60,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
-		this(voteId, name, service, time, false, Collections.emptySet(), Collections.emptySet());
+		this(voteId, name, service, time, false, Collections.emptySet(), Collections.emptySet(), "", false);
 	}
 
 	/**
@@ -69,7 +75,8 @@ public class VoteTimeQueue {
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastForwardedServers) {
-		this(voteId, name, service, time, proxyBroadcastHandled, Collections.emptySet(), broadcastForwardedServers);
+		this(voteId, name, service, time, proxyBroadcastHandled, Collections.emptySet(), broadcastForwardedServers, "",
+				false);
 	}
 
 	/**
@@ -85,11 +92,32 @@ public class VoteTimeQueue {
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastTargets, Set<String> broadcastForwardedServers) {
+		this(voteId, name, service, time, proxyBroadcastHandled, broadcastTargets, broadcastForwardedServers, "",
+				false);
+	}
+
+	/**
+	 * Creates a queued vote with all durable replay state.
+	 *
+	 * @param voteId unique vote identifier
+	 * @param name player name
+	 * @param service service site
+	 * @param time vote timestamp
+	 * @param proxyBroadcastHandled whether standalone forwarding was handled before queueing
+	 * @param broadcastTargets original backend broadcast targets
+	 * @param broadcastForwardedServers backend servers that received the standalone broadcast
+	 * @param totals incoming multi-proxy totals snapshot
+	 * @param processed whether normal replay processing completed
+	 */
+	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
+			Set<String> broadcastTargets, Set<String> broadcastForwardedServers, String totals, boolean processed) {
 		this.voteId = voteId;
 		this.name = name;
 		this.service = service;
 		this.time = time;
 		this.proxyBroadcastHandled = proxyBroadcastHandled;
+		this.totals = totals == null ? "" : totals;
+		this.processed = processed;
 		this.broadcastTargets = new LinkedHashSet<>();
 		if (broadcastTargets != null) {
 			this.broadcastTargets.addAll(broadcastTargets);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/VoteTimeQueue.java
@@ -30,6 +30,8 @@ public class VoteTimeQueue {
 	@Setter
 	private boolean proxyBroadcastHandled;
 	@Getter
+	private Set<String> broadcastTargets;
+	@Getter
 	private Set<String> broadcastForwardedServers;
 
 	/**
@@ -40,7 +42,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(String name, String service, long time) {
-		this(null, name, service, time, false, Collections.emptySet());
+		this(null, name, service, time, false, Collections.emptySet(), Collections.emptySet());
 	}
 
 	/**
@@ -52,7 +54,7 @@ public class VoteTimeQueue {
 	 * @param time vote timestamp
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time) {
-		this(voteId, name, service, time, false, Collections.emptySet());
+		this(voteId, name, service, time, false, Collections.emptySet(), Collections.emptySet());
 	}
 
 	/**
@@ -67,15 +69,44 @@ public class VoteTimeQueue {
 	 */
 	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
 			Set<String> broadcastForwardedServers) {
+		this(voteId, name, service, time, proxyBroadcastHandled, Collections.emptySet(), broadcastForwardedServers);
+	}
+
+	/**
+	 * Creates a queued vote with the original proxy broadcast routing state.
+	 *
+	 * @param voteId unique vote identifier
+	 * @param name player name
+	 * @param service service site
+	 * @param time vote timestamp
+	 * @param proxyBroadcastHandled whether standalone forwarding was handled before queueing
+	 * @param broadcastTargets original backend broadcast targets
+	 * @param broadcastForwardedServers backend servers that received the standalone broadcast
+	 */
+	public VoteTimeQueue(UUID voteId, String name, String service, long time, boolean proxyBroadcastHandled,
+			Set<String> broadcastTargets, Set<String> broadcastForwardedServers) {
 		this.voteId = voteId;
 		this.name = name;
 		this.service = service;
 		this.time = time;
 		this.proxyBroadcastHandled = proxyBroadcastHandled;
+		this.broadcastTargets = new LinkedHashSet<>();
+		if (broadcastTargets != null) {
+			this.broadcastTargets.addAll(broadcastTargets);
+		}
 		this.broadcastForwardedServers = new LinkedHashSet<>();
 		if (broadcastForwardedServers != null) {
 			this.broadcastForwardedServers.addAll(broadcastForwardedServers);
 		}
+	}
+
+	/**
+	 * Encodes original broadcast targets for JSON and SQL cache storage.
+	 *
+	 * @return encoded target set
+	 */
+	public String encodeBroadcastTargets() {
+		return encodeBroadcastServers(broadcastTargets);
 	}
 
 	/**
@@ -84,9 +115,22 @@ public class VoteTimeQueue {
 	 * @return encoded server set
 	 */
 	public String encodeBroadcastForwardedServers() {
+		return encodeBroadcastServers(broadcastForwardedServers);
+	}
+
+	/**
+	 * Encodes backend server names for cache storage.
+	 *
+	 * @param servers server names to encode
+	 * @return encoded server set
+	 */
+	public static String encodeBroadcastServers(Set<String> servers) {
 		Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
 		StringBuilder encoded = new StringBuilder();
-		for (String server : broadcastForwardedServers) {
+		if (servers == null) {
+			return "";
+		}
+		for (String server : servers) {
 			if (server == null || server.isEmpty()) {
 				continue;
 			}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyBroadcastDeciderTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyBroadcastDeciderTest.java
@@ -1,0 +1,50 @@
+package com.bencodez.votingplugin.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
+import com.bencodez.votingplugin.proxy.broadcast.ProxyBroadcastDecider;
+
+public class ProxyBroadcastDeciderTest {
+
+	@Test
+	void forwardModeUsesImmediateDeliveryWhenTheVotingPlayerIsOffline() {
+		VotingPluginProxyConfig config = mock(VotingPluginProxyConfig.class);
+		when(config.getProxyBroadcastEnabled()).thenReturn(true);
+		when(config.getProxyBroadcastOfflineMode()).thenReturn("FORWARD");
+		when(config.getProxyBroadcastScopeMode()).thenReturn("ALL_SERVERS");
+
+		Set<String> servers = new LinkedHashSet<>(Arrays.asList("Server1", "Server2"));
+		ProxyBroadcastDecider decider = new ProxyBroadcastDecider(() -> config, () -> servers, server -> true,
+				server -> false);
+
+		assertTrue(decider.usesImmediateForwarding());
+		assertEquals(servers, decider.resolveTargets(false, null));
+	}
+
+	@Test
+	void queuedAndDisabledBroadcastsDoNotUseImmediateDelivery() {
+		VotingPluginProxyConfig config = mock(VotingPluginProxyConfig.class);
+		when(config.getProxyBroadcastEnabled()).thenReturn(true);
+		when(config.getProxyBroadcastOfflineMode()).thenReturn("QUEUE");
+
+		ProxyBroadcastDecider decider = new ProxyBroadcastDecider(() -> config, LinkedHashSet::new, server -> true,
+				server -> false);
+
+		assertFalse(decider.usesImmediateForwarding());
+
+		when(config.getProxyBroadcastEnabled()).thenReturn(false);
+		when(config.getProxyBroadcastOfflineMode()).thenReturn("FORWARD");
+		assertFalse(decider.usesImmediateForwarding());
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyBroadcastDeciderTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/ProxyBroadcastDeciderTest.java
@@ -28,7 +28,8 @@ public class ProxyBroadcastDeciderTest {
 		ProxyBroadcastDecider decider = new ProxyBroadcastDecider(() -> config, () -> servers, server -> true,
 				server -> false);
 
-		assertTrue(decider.usesImmediateForwarding());
+		assertTrue(decider.usesImmediateForwarding(false));
+		assertFalse(decider.usesImmediateForwarding(true));
 		assertEquals(servers, decider.resolveTargets(false, null));
 	}
 
@@ -41,10 +42,10 @@ public class ProxyBroadcastDeciderTest {
 		ProxyBroadcastDecider decider = new ProxyBroadcastDecider(() -> config, LinkedHashSet::new, server -> true,
 				server -> false);
 
-		assertFalse(decider.usesImmediateForwarding());
+		assertFalse(decider.usesImmediateForwarding(false));
 
 		when(config.getProxyBroadcastEnabled()).thenReturn(false);
 		when(config.getProxyBroadcastOfflineMode()).thenReturn("FORWARD");
-		assertFalse(decider.usesImmediateForwarding());
+		assertFalse(decider.usesImmediateForwarding(false));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -151,16 +151,31 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	@Test
-	public void timedVoteIdIsPassedToJsonStorage() {
+	public void timedVoteIsPersistedImmediatelyWithItsId() {
 		UUID voteId = UUID.randomUUID();
 		VoteTimeQueue queued = new VoteTimeQueue(voteId, "Player", "Service", 100L);
 		handler.addTimeVoteToCache(queued);
 
-		handler.saveVoteCache();
-
 		verify(storage).addTimedVote(eq(0), same(queued));
 		verify(storage).save();
 		assertEquals(voteId, handler.getTimeChangeQueue().element().getVoteId());
+	}
+
+	@Test
+	public void timedVoteDeliveryStateIsUpdatedByVoteId() {
+		UUID voteId = UUID.randomUUID();
+		DataNode stored = mock(DataNode.class);
+		when(stored.isObject()).thenReturn(true);
+		stubString(stored, "VoteId", voteId.toString());
+		when(storage.getTimedVoteCache()).thenReturn(List.of("2"));
+		when(storage.getTimedVoteCache("2")).thenReturn(stored);
+		VoteTimeQueue queued = new VoteTimeQueue(voteId, "Player", "Service", 100L, true,
+				Set.of("Server1"), Set.of("Server1"));
+
+		handler.updateTimeVote(queued);
+
+		verify(storage).addTimedVote(2, queued);
+		verify(storage).save();
 	}
 
 	@Test
@@ -280,6 +295,19 @@ public class VoteCacheHandlerVoteIdTest {
 		assertEquals(List.of(pending), handler.getOnlineVotes("player-uuid"));
 		assertTrue(pending.isRewardDelivered());
 		assertTrue(pending.needsBroadcastOn("Survival"));
+	}
+
+	@Test
+	public void completedOnlineVoteRemovalKeepsCollidingVoteId() {
+		UUID removedId = UUID.randomUUID();
+		OfflineBungeeVote removed = vote(removedId, 100L);
+		OfflineBungeeVote retained = vote(UUID.randomUUID(), 100L);
+		handler.addOnlineVote("player-uuid", removed);
+		handler.addOnlineVote("player-uuid", retained);
+
+		handler.removeOnlineVote("player-uuid", removed);
+
+		assertEquals(List.of(retained), handler.getOnlineVotes("player-uuid"));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -214,6 +214,24 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	@Test
+	public void updatedOnlineBroadcastStateIsPersistedInPlace() {
+		DataNode voteNode = mock(DataNode.class);
+		when(storage.getOnlineVotes("player-uuid")).thenReturn(List.of("3"));
+		when(storage.getOnlineVotes("player-uuid", "3")).thenReturn(voteNode);
+		when(voteNode.isObject()).thenReturn(true);
+		stubString(voteNode, "UUID", "player-uuid");
+		stubString(voteNode, "Service", "Service");
+		stubLong(voteNode, "Time", 100L);
+
+		OfflineBungeeVote vote = new OfflineBungeeVote(UUID.randomUUID(), "Player", "player-uuid", "Service", 100L,
+				true, "totals", true, true, Set.of("Server1"), Set.of("Server1"), false);
+		handler.updateOnlineVote("player-uuid", vote);
+
+		verify(storage).addVoteOnline("player-uuid", 3, vote);
+		verify(storage).save();
+	}
+
+	@Test
 	public void timedVoteBroadcastStateLoadsFromJsonCache() {
 		IVoteCache stored = mock(IVoteCache.class);
 		DataNode timedNode = mock(DataNode.class);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -1,7 +1,9 @@
 package com.bencodez.votingplugin.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -126,6 +128,26 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	@Test
+	public void legacyJsonCacheEntryStillNeedsItsBroadcast() {
+		UUID voteId = UUID.randomUUID();
+		handler = handlerForStoredVote("VoteId", voteId);
+
+		handler.load();
+
+		assertFalse(handler.getVotes("server").get(0).isBroadcastForwarded());
+	}
+
+	@Test
+	public void forwardedBroadcastStateLoadsFromJsonCache() {
+		UUID voteId = UUID.randomUUID();
+		handler = handlerForStoredVote("VoteId", voteId, true);
+
+		handler.load();
+
+		assertTrue(handler.getVotes("server").get(0).isBroadcastForwarded());
+	}
+
+	@Test
 	public void timedVoteIdIsPassedToJsonStorage() {
 		UUID voteId = UUID.randomUUID();
 		VoteTimeQueue queued = new VoteTimeQueue(voteId, "Player", "Service", 100L);
@@ -144,6 +166,10 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	private VoteCacheHandler handlerForStoredVote(String idKey, UUID voteId) {
+		return handlerForStoredVote(idKey, voteId, null);
+	}
+
+	private VoteCacheHandler handlerForStoredVote(String idKey, UUID voteId, Boolean broadcastForwarded) {
 		IVoteCache stored = mock(IVoteCache.class);
 		DataNode voteNode = mock(DataNode.class);
 		when(stored.getTimedVoteCache()).thenReturn(Collections.emptyList());
@@ -160,6 +186,9 @@ public class VoteCacheHandlerVoteIdTest {
 		stubBoolean(voteNode, "Real", true);
 		stubString(voteNode, "Text", "totals");
 		stubString(voteNode, idKey, voteId.toString());
+		if (broadcastForwarded != null) {
+			stubBoolean(voteNode, "BroadcastForwarded", broadcastForwarded.booleanValue());
+		}
 		if ("VoteID".equals(idKey)) {
 			when(voteNode.has("VoteId")).thenReturn(false);
 		}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -196,6 +196,24 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	@Test
+	public void updatedServerBroadcastStateIsPersistedInPlace() {
+		DataNode voteNode = mock(DataNode.class);
+		when(storage.getServerVotes("server")).thenReturn(List.of("4"));
+		when(storage.getServerVotes("server", "4")).thenReturn(voteNode);
+		when(voteNode.isObject()).thenReturn(true);
+		stubString(voteNode, "UUID", "player-uuid");
+		stubString(voteNode, "Service", "Service");
+		stubLong(voteNode, "Time", 100L);
+
+		OfflineBungeeVote vote = new OfflineBungeeVote(UUID.randomUUID(), "Player", "player-uuid", "Service", 100L,
+				true, "totals", true, true, Set.of("Server1"), Set.of("Server1"), false);
+		handler.updateServerVote("server", vote);
+
+		verify(storage).addVote("server", 4, vote);
+		verify(storage).save();
+	}
+
+	@Test
 	public void timedVoteBroadcastStateLoadsFromJsonCache() {
 		IVoteCache stored = mock(IVoteCache.class);
 		DataNode timedNode = mock(DataNode.class);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -353,6 +353,10 @@ public class VoteCacheHandlerVoteIdTest {
 		stubString(timedNode, "BroadcastForwardedServers",
 				new VoteTimeQueue(voteId, "Player", "Service", 100L, true, Set.of("Server1"))
 						.encodeBroadcastForwardedServers());
+		String totals = new com.bencodez.votingplugin.proxy.VoteTotalsSnapshot(10, 2, 2, 1, 4, 0, 20, 2)
+				.toStorageString();
+		stubString(timedNode, "Totals", totals);
+		stubBoolean(timedNode, "Processed", true);
 
 		handler = newHandler(stored);
 		handler.load();
@@ -362,6 +366,8 @@ public class VoteCacheHandlerVoteIdTest {
 		assertTrue(loaded.isProxyBroadcastHandled());
 		assertEquals(Set.of("Server1", "Server2"), loaded.getBroadcastTargets());
 		assertEquals(Set.of("Server1"), loaded.getBroadcastForwardedServers());
+		assertEquals(totals, loaded.getTotals());
+		assertTrue(loaded.isProcessed());
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -12,7 +12,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -162,7 +164,49 @@ public class VoteCacheHandlerVoteIdTest {
 
 	@Test
 	public void legacyTimedVoteConstructorHasNoId() {
-		assertNull(new VoteTimeQueue("Player", "Service", 100L).getVoteId());
+		VoteTimeQueue vote = new VoteTimeQueue("Player", "Service", 100L);
+
+		assertNull(vote.getVoteId());
+		assertFalse(vote.isProxyBroadcastHandled());
+		assertTrue(vote.getBroadcastForwardedServers().isEmpty());
+	}
+
+	@Test
+	public void timedVoteBroadcastStateRoundTripsThroughStorageEncoding() {
+		Set<String> servers = new LinkedHashSet<>(List.of("Server1", "Server,Two", "Server Three"));
+		VoteTimeQueue vote = new VoteTimeQueue(UUID.randomUUID(), "Player", "Service", 100L, true, servers);
+
+		assertEquals(servers,
+				VoteTimeQueue.decodeBroadcastForwardedServers(vote.encodeBroadcastForwardedServers()));
+	}
+
+	@Test
+	public void timedVoteBroadcastStateLoadsFromJsonCache() {
+		IVoteCache stored = mock(IVoteCache.class);
+		DataNode timedNode = mock(DataNode.class);
+		when(stored.getTimedVoteCache()).thenReturn(List.of("0"));
+		when(stored.getTimedVoteCache("0")).thenReturn(timedNode);
+		when(stored.getServers()).thenReturn(Collections.emptyList());
+		when(stored.getPlayers()).thenReturn(Collections.emptyList());
+		when(timedNode.isObject()).thenReturn(true);
+
+		UUID voteId = UUID.randomUUID();
+		stubString(timedNode, "Name", "Player");
+		stubString(timedNode, "Service", "Service");
+		stubLong(timedNode, "Time", 100L);
+		stubString(timedNode, "VoteId", voteId.toString());
+		stubBoolean(timedNode, "ProxyBroadcastHandled", true);
+		stubString(timedNode, "BroadcastForwardedServers",
+				new VoteTimeQueue(voteId, "Player", "Service", 100L, true, Set.of("Server1"))
+						.encodeBroadcastForwardedServers());
+
+		handler = newHandler(stored);
+		handler.load();
+
+		VoteTimeQueue loaded = handler.getTimeChangeQueue().element();
+		assertEquals(voteId, loaded.getVoteId());
+		assertTrue(loaded.isProxyBroadcastHandled());
+		assertEquals(Set.of("Server1"), loaded.getBroadcastForwardedServers());
 	}
 
 	private VoteCacheHandler handlerForStoredVote(String idKey, UUID voteId) {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -168,16 +168,31 @@ public class VoteCacheHandlerVoteIdTest {
 
 		assertNull(vote.getVoteId());
 		assertFalse(vote.isProxyBroadcastHandled());
+		assertTrue(vote.getBroadcastTargets().isEmpty());
 		assertTrue(vote.getBroadcastForwardedServers().isEmpty());
 	}
 
 	@Test
 	public void timedVoteBroadcastStateRoundTripsThroughStorageEncoding() {
-		Set<String> servers = new LinkedHashSet<>(List.of("Server1", "Server,Two", "Server Three"));
-		VoteTimeQueue vote = new VoteTimeQueue(UUID.randomUUID(), "Player", "Service", 100L, true, servers);
+		Set<String> targets = new LinkedHashSet<>(List.of("Server1", "Server,Two", "Server Three"));
+		Set<String> forwarded = Set.of("Server1");
+		VoteTimeQueue vote = new VoteTimeQueue(UUID.randomUUID(), "Player", "Service", 100L, true, targets,
+				forwarded);
 
-		assertEquals(servers,
+		assertEquals(targets, VoteTimeQueue.decodeBroadcastForwardedServers(vote.encodeBroadcastTargets()));
+		assertEquals(forwarded,
 				VoteTimeQueue.decodeBroadcastForwardedServers(vote.encodeBroadcastForwardedServers()));
+	}
+
+	@Test
+	public void cachedBroadcastStateSuppressesNonTargetsAndDeliveredTargets() {
+		OfflineBungeeVote vote = new OfflineBungeeVote(UUID.randomUUID(), "Player", "player-uuid", "Service", 100L,
+				true, "totals", false, true, Set.of("Lobby", "Survival"), Set.of("Lobby"), false);
+
+		assertFalse(vote.needsBroadcastOn("Lobby"));
+		assertTrue(vote.needsBroadcastOn("Survival"));
+		assertFalse(vote.needsBroadcastOn("Creative"));
+		assertFalse(vote.isProxyBroadcastComplete());
 	}
 
 	@Test
@@ -196,6 +211,8 @@ public class VoteCacheHandlerVoteIdTest {
 		stubLong(timedNode, "Time", 100L);
 		stubString(timedNode, "VoteId", voteId.toString());
 		stubBoolean(timedNode, "ProxyBroadcastHandled", true);
+		stubString(timedNode, "BroadcastTargets",
+				VoteTimeQueue.encodeBroadcastServers(Set.of("Server1", "Server2")));
 		stubString(timedNode, "BroadcastForwardedServers",
 				new VoteTimeQueue(voteId, "Player", "Service", 100L, true, Set.of("Server1"))
 						.encodeBroadcastForwardedServers());
@@ -206,7 +223,43 @@ public class VoteCacheHandlerVoteIdTest {
 		VoteTimeQueue loaded = handler.getTimeChangeQueue().element();
 		assertEquals(voteId, loaded.getVoteId());
 		assertTrue(loaded.isProxyBroadcastHandled());
+		assertEquals(Set.of("Server1", "Server2"), loaded.getBroadcastTargets());
 		assertEquals(Set.of("Server1"), loaded.getBroadcastForwardedServers());
+	}
+
+	@Test
+	public void onlineVoteBroadcastTargetsAndRewardStateLoadFromJsonCache() {
+		IVoteCache stored = mock(IVoteCache.class);
+		DataNode voteNode = mock(DataNode.class);
+		when(stored.getTimedVoteCache()).thenReturn(Collections.emptyList());
+		when(stored.getServers()).thenReturn(Collections.emptyList());
+		when(stored.getPlayers()).thenReturn(List.of("player-uuid"));
+		when(stored.getOnlineVotes("player-uuid")).thenReturn(List.of("0"));
+		when(stored.getOnlineVotes("player-uuid", "0")).thenReturn(voteNode);
+		when(voteNode.isObject()).thenReturn(true);
+
+		UUID voteId = UUID.randomUUID();
+		stubString(voteNode, "Name", "Player");
+		stubString(voteNode, "UUID", "player-uuid");
+		stubString(voteNode, "Service", "Service");
+		stubLong(voteNode, "Time", 100L);
+		stubBoolean(voteNode, "Real", true);
+		stubString(voteNode, "Text", "totals");
+		stubString(voteNode, "VoteId", voteId.toString());
+		stubBoolean(voteNode, "ProxyBroadcastHandled", true);
+		stubString(voteNode, "BroadcastTargets", VoteTimeQueue.encodeBroadcastServers(Set.of("Lobby", "Survival")));
+		stubString(voteNode, "BroadcastForwardedServers", VoteTimeQueue.encodeBroadcastServers(Set.of("Lobby")));
+		stubBoolean(voteNode, "RewardDelivered", true);
+
+		handler = newHandler(stored);
+		handler.load();
+
+		OfflineBungeeVote loaded = handler.getOnlineVotes("player-uuid").get(0);
+		assertTrue(loaded.isProxyBroadcastHandled());
+		assertEquals(Set.of("Lobby", "Survival"), loaded.getBroadcastTargets());
+		assertEquals(Set.of("Lobby"), loaded.getBroadcastForwardedServers());
+		assertTrue(loaded.isRewardDelivered());
+		assertTrue(loaded.needsBroadcastOn("Survival"));
 	}
 
 	private VoteCacheHandler handlerForStoredVote(String idKey, UUID voteId) {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -176,6 +177,27 @@ public class VoteCacheHandlerVoteIdTest {
 
 		verify(storage).addTimedVote(2, queued);
 		verify(storage).save();
+	}
+
+	@Test
+	public void timedVoteIsRemovedFromMemoryOnlyAfterJsonSaveSucceeds() {
+		VoteTimeQueue queued = new VoteTimeQueue(UUID.randomUUID(), "Player", "Service", 100L);
+		assertTrue(handler.addTimeVoteToCache(queued));
+
+		assertTrue(handler.removeTimeVote(queued));
+
+		assertTrue(handler.getTimeChangeQueue().isEmpty());
+	}
+
+	@Test
+	public void timedVoteRemainsQueuedWhenJsonDeleteCannotBeSaved() {
+		VoteTimeQueue queued = new VoteTimeQueue(UUID.randomUUID(), "Player", "Service", 100L);
+		assertTrue(handler.addTimeVoteToCache(queued));
+		doThrow(new RuntimeException("save failed")).when(storage).save();
+
+		assertFalse(handler.removeTimeVote(queued));
+
+		assertTrue(handler.getTimeChangeQueue().contains(queued));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteCacheHandlerVoteIdTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -232,6 +233,56 @@ public class VoteCacheHandlerVoteIdTest {
 	}
 
 	@Test
+	public void serverBroadcastStateUpdateUsesVoteIdWhenTimestampsCollide() {
+		UUID voteId = UUID.randomUUID();
+		DataNode matching = storedVoteNode(voteId, 100L);
+		DataNode other = storedVoteNode(UUID.randomUUID(), 100L);
+		when(storage.getServerVotes("server")).thenReturn(List.of("4", "5"));
+		when(storage.getServerVotes("server", "4")).thenReturn(other);
+		when(storage.getServerVotes("server", "5")).thenReturn(matching);
+
+		OfflineBungeeVote vote = new OfflineBungeeVote(voteId, "Player", "player-uuid", "Service", 100L, true,
+				"totals", true, true, Set.of("Server1"), Set.of("Server1"), false);
+		handler.updateServerVote("server", vote);
+
+		verify(storage, never()).addVote("server", 4, vote);
+		verify(storage).addVote("server", 5, vote);
+	}
+
+	@Test
+	public void onlineBroadcastStateUpdateUsesVoteIdWhenTimestampsCollide() {
+		UUID voteId = UUID.randomUUID();
+		DataNode matching = storedVoteNode(voteId, 100L);
+		DataNode other = storedVoteNode(UUID.randomUUID(), 100L);
+		when(storage.getOnlineVotes("player-uuid")).thenReturn(List.of("3", "7"));
+		when(storage.getOnlineVotes("player-uuid", "3")).thenReturn(other);
+		when(storage.getOnlineVotes("player-uuid", "7")).thenReturn(matching);
+
+		OfflineBungeeVote vote = new OfflineBungeeVote(voteId, "Player", "player-uuid", "Service", 100L, true,
+				"totals", true, true, Set.of("Server1"), Set.of("Server1"), false);
+		handler.updateOnlineVote("player-uuid", vote);
+
+		verify(storage, never()).addVoteOnline("player-uuid", 3, vote);
+		verify(storage).addVoteOnline("player-uuid", 7, vote);
+	}
+
+	@Test
+	public void globalRewardClearRetainsOnlyIncompleteForwardBroadcasts() {
+		OfflineBungeeVote pending = new OfflineBungeeVote(UUID.randomUUID(), "Player", "player-uuid", "Service",
+				100L, true, "totals", false, true, Set.of("Lobby", "Survival"), Set.of("Lobby"), false);
+		OfflineBungeeVote complete = new OfflineBungeeVote(UUID.randomUUID(), "Player", "player-uuid", "Service",
+				101L, true, "totals", true, true, Set.of("Lobby"), Set.of("Lobby"), false);
+		handler.addOnlineVote("player-uuid", pending);
+		handler.addOnlineVote("player-uuid", complete);
+
+		handler.clearOnlineVoteRewards("player-uuid");
+
+		assertEquals(List.of(pending), handler.getOnlineVotes("player-uuid"));
+		assertTrue(pending.isRewardDelivered());
+		assertTrue(pending.needsBroadcastOn("Survival"));
+	}
+
+	@Test
 	public void timedVoteBroadcastStateLoadsFromJsonCache() {
 		IVoteCache stored = mock(IVoteCache.class);
 		DataNode timedNode = mock(DataNode.class);
@@ -348,6 +399,16 @@ public class VoteCacheHandlerVoteIdTest {
 		when(parent.has(key)).thenReturn(true);
 		when(parent.get(key)).thenReturn(child);
 		when(child.asBoolean()).thenReturn(value);
+	}
+
+	private static DataNode storedVoteNode(UUID voteId, long time) {
+		DataNode voteNode = mock(DataNode.class);
+		when(voteNode.isObject()).thenReturn(true);
+		stubString(voteNode, "UUID", "player-uuid");
+		stubString(voteNode, "Service", "Service");
+		stubLong(voteNode, "Time", time);
+		stubString(voteNode, "VoteId", voteId.toString());
+		return voteNode;
 	}
 
 	private static void runConcurrently(Runnable first, Runnable second) throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
@@ -24,6 +24,18 @@ import com.bencodez.votingplugin.proxy.VoteTotalsSnapshot;
 public class VoteTotalsSnapshotStorageTest {
 
 	@Test
+	public void projectedTotalsReplaceBroadcastPlaceholdersWithoutChangingStorage() {
+		VoteTotalsSnapshot data = new VoteTotalsSnapshot(1234, 45, 12, 3, 9876, 8, 20, 45);
+
+		String rendered = data.applyBroadcastPlaceholders(
+				"%AllTimeTotal%/%VotingPlugin_total_monthly%/%VotingPlugin_total_weekly%/"
+						+ "%VotingPlugin_total_daily%/%VotingPlugin_points_format%");
+
+		assertEquals("1234/45/12/3/9,876", rendered);
+		assertEquals("v2//1234//45//12//3//9876//8//20//45", data.toStorageString());
+	}
+
+	@Test
 	public void constructor_toStorageString_roundTripsThroughParseStorage_v2() {
 		UUID voteId = UUID.randomUUID();
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
@@ -46,6 +46,16 @@ public class VoteTotalsSnapshotStorageTest {
 	}
 
 	@Test
+	public void projectedVotePartyValuesReplaceStandaloneBroadcastPlaceholders() {
+		VoteTotalsSnapshot data = new VoteTotalsSnapshot(100, 45, 12, 3, 9, 8, 20, 2);
+
+		String rendered = data.applyBroadcastPlaceholders("%VotingPlugin_BungeeVotePartyVotesCurrent%/"
+				+ "%VotingPlugin_BungeeVotePartyVotesNeeded%/%VotingPlugin_BungeeVotePartyVotesRequired%");
+
+		assertEquals("8/12/20", rendered);
+	}
+
+	@Test
 	public void constructor_toStorageString_roundTripsThroughParseStorage_v2() {
 		UUID voteId = UUID.randomUUID();
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VoteTotalsSnapshotStorageTest.java
@@ -36,6 +36,16 @@ public class VoteTotalsSnapshotStorageTest {
 	}
 
 	@Test
+	public void datedMonthlyTotalIsUsedForPrimaryMonthlyPlaceholders() {
+		VoteTotalsSnapshot data = new VoteTotalsSnapshot(100, 45, 12, 3, 9, 0, 20, 2);
+
+		String rendered = data.applyBroadcastPlaceholders(
+				"%MonthTotal%/%VotingPlugin_total%/%VotingPlugin_total_monthly%", true);
+
+		assertEquals("45/2/2", rendered);
+	}
+
+	@Test
 	public void constructor_toStorageString_roundTripsThroughParseStorage_v2() {
 		UUID voteId = UUID.randomUUID();
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -122,7 +122,7 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
-	void rejectedVoteStopsBeforeGlobalDataQueueOrOfflineBroadcast() {
+	void rolloverCompletesBeforeVoteDataLoadsAndRejectedVoteDoesNotBroadcast() {
 		votingPluginProxy.setPlayerOnline(false);
 		Mockito.when(votingPluginProxy.getConfig().getBungeeManageTotals()).thenReturn(true);
 		Mockito.when(votingPluginProxy.getConfig().getGlobalDataEnabled()).thenReturn(true);
@@ -130,6 +130,7 @@ public class VotingPluginProxyTest {
 		Mockito.when(votingPluginProxy.getConfig().getProxyBroadcastOfflineMode()).thenReturn("FORWARD");
 		Mockito.when(proxyMySQL.containsKeyQuery(Mockito.anyString())).thenReturn(true);
 		Mockito.when(proxyMySQL.getExactQuery(Mockito.any())).thenReturn(new java.util.ArrayList<>());
+		Mockito.when(globalDataHandler.isTimeChangedHappened()).thenReturn(true, false);
 
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
 		Mockito.doReturn(false).when(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.anyString(),
@@ -137,9 +138,13 @@ public class VotingPluginProxyTest {
 
 		spyProxy.vote("Player", "Service", true, true, 0, null, null);
 
-		verify(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.eq("Player"), Mockito.eq("Service"), Mockito.any(),
-				Mockito.eq(true));
-		verify(globalDataHandler, never()).isTimeChangedHappened();
+		org.mockito.InOrder order = Mockito.inOrder(globalDataHandler, proxyMySQL, spyProxy);
+		order.verify(globalDataHandler).isTimeChangedHappened();
+		order.verify(globalDataHandler).checkForFinishedTimeChanges();
+		order.verify(globalDataHandler).isTimeChangedHappened();
+		order.verify(proxyMySQL).getExactQuery(Mockito.any());
+		order.verify(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.eq("Player"), Mockito.eq("Service"),
+				Mockito.any(), Mockito.eq(true));
 		verify(spyProxy, never()).sendPluginMessageData(Mockito.anyString(), Mockito.anyString(), Mockito.any(),
 				Mockito.anyBoolean());
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ import org.mockito.MockitoAnnotations;
 import com.bencodez.advancedcore.bungeeapi.globaldata.GlobalDataHandlerProxy;
 import com.bencodez.votingplugin.proxy.ProxyMysqlUserTable;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
-import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
 import com.bencodez.votingplugin.proxy.VotingPluginWire;
 import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyHandler;
 
@@ -30,9 +28,6 @@ public class VotingPluginProxyTest {
 
 	@Mock
 	private ProxyMysqlUserTable proxyMySQL;
-
-	@Mock
-	private VotingPluginProxyConfig config;
 
 	@Mock
 	private GlobalDataHandlerProxy globalDataHandler;
@@ -47,13 +42,6 @@ public class VotingPluginProxyTest {
 		votingPluginProxy.setGlobalDataHandler(globalDataHandler);
 		votingPluginProxy.setMultiProxyHandler(multiProxyHandler);
 
-		// Mocking config methods
-		when(config.getVotePartyEnabled()).thenReturn(true);
-		when(config.getVotePartyVotesRequired()).thenReturn(5);
-		when(config.getVotePartyIncreaseVotesRequired()).thenReturn(5);
-		when(config.getBungeeManageTotals()).thenReturn(true);
-		when(config.getPluginMessageEncryption()).thenReturn(false);
-		when(config.getDebug()).thenReturn(false);
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -169,19 +169,21 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
-	void failedRolloverReplayRemainsQueued() {
+	void terminalRolloverReplayIsRemovedBeforeLaterEntries() {
 		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
 		java.util.Queue<VoteTimeQueue> queue = new java.util.concurrent.ConcurrentLinkedQueue<>();
-		queue.add(new VoteTimeQueue(java.util.UUID.randomUUID(), "Player", "Invalid\\Service", 100L));
+		VoteTimeQueue invalid = new VoteTimeQueue(java.util.UUID.randomUUID(), "Player", "Invalid\\Service", 100L);
+		queue.add(invalid);
 		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
+		Mockito.when(voteCache.removeTimeVote(invalid)).thenAnswer(invocation -> queue.remove(invalid));
 
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
 		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
 
 		spyProxy.processQueue();
 
-		assertEquals(1, queue.size());
-		verify(voteCache, never()).removeTimeVote(Mockito.any());
+		assertTrue(queue.isEmpty());
+		verify(voteCache).removeTimeVote(invalid);
 	}
 
 	@Test
@@ -278,6 +280,24 @@ public class VotingPluginProxyTest {
 		assertTrue(vote.isProxyBroadcastComplete());
 		assertEquals(java.util.Set.of("Server1", "Server2"), vote.getBroadcastForwardedServers());
 		verify(voteCache).updateOnlineVote("voter-uuid", vote);
+	}
+
+	@Test
+	void timedBroadcastRetriesWhileRolloverIsStillActive() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		VoteTimeQueue vote = new VoteTimeQueue(java.util.UUID.randomUUID(), "OfflineVoter", "Service", 100L, true,
+				java.util.Set.of("Server1"), java.util.Collections.emptySet(), "totals", false, "voter-uuid");
+		java.util.Queue<VoteTimeQueue> queue = new java.util.concurrent.ConcurrentLinkedQueue<>();
+		queue.add(vote);
+		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
+		Mockito.when(votingPluginProxy.getConfig().getBlockedServers()).thenReturn(java.util.Collections.emptyList());
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+		spyProxy.retryPendingTimeBroadcastsForTest("Server1");
+
+		assertEquals(java.util.Set.of("Server1"), vote.getBroadcastForwardedServers());
+		verify(voteCache).updateTimeVote(vote);
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -233,6 +233,7 @@ public class VotingPluginProxyTest {
 		Mockito.when(voteCache.hasVotes("Server1")).thenReturn(true);
 		Mockito.when(voteCache.getVotes("Server1"))
 				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+		Mockito.when(voteCache.updateServerVote("Server1", vote)).thenReturn(true);
 
 		votingPluginProxy.setPlayerOnline(false);
 		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
@@ -259,6 +260,7 @@ public class VotingPluginProxyTest {
 		Mockito.when(voteCache.getOnlineVoteUUIDs()).thenReturn(java.util.Set.of("voter-uuid"));
 		Mockito.when(voteCache.getOnlineVotes("voter-uuid"))
 				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+		Mockito.when(voteCache.updateOnlineVote("voter-uuid", vote)).thenReturn(true);
 
 		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
 		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
@@ -283,6 +285,7 @@ public class VotingPluginProxyTest {
 		Mockito.when(voteCache.getOnlineVoteUUIDs()).thenReturn(java.util.Set.of("voter-uuid"));
 		Mockito.when(voteCache.getOnlineVotes("voter-uuid"))
 				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+		Mockito.when(voteCache.updateOnlineVote("voter-uuid", vote)).thenReturn(true);
 
 		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
 		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
@@ -329,6 +332,34 @@ public class VotingPluginProxyTest {
 		assertTrue(spyProxy.persistTimeVoteDeliveryForTest(vote));
 		assertFalse(vote.isDeliveryStateDirty());
 		verify(voteCache, Mockito.times(2)).updateTimeVote(vote);
+	}
+
+	@Test
+	void cachedDeliveryStatePersistenceRetriesForServerAndOnlineCaches() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		OfflineBungeeVote serverVote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "Player", "uuid",
+				"Service", 100L, true, "totals");
+		OfflineBungeeVote onlineVote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "Player", "uuid",
+				"Service", 101L, true, "totals");
+		Mockito.when(voteCache.updateServerVote("Server1", serverVote)).thenReturn(false, true);
+		Mockito.when(voteCache.updateOnlineVote("uuid", onlineVote)).thenReturn(false, true);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+
+		assertFalse(spyProxy.persistServerVoteDeliveryForTest("Server1", serverVote));
+		assertTrue(serverVote.isDeliveryStateDirty());
+		assertTrue(spyProxy.persistServerVoteDeliveryForTest("Server1", serverVote));
+		assertFalse(serverVote.isDeliveryStateDirty());
+		assertFalse(spyProxy.persistOnlineVoteDeliveryForTest("uuid", onlineVote));
+		assertTrue(onlineVote.isDeliveryStateDirty());
+		assertTrue(spyProxy.persistOnlineVoteDeliveryForTest("uuid", onlineVote));
+		assertFalse(onlineVote.isDeliveryStateDirty());
+	}
+
+	@Test
+	void standaloneForwardingRequiresProxySideVoteValidation() {
+		assertTrue(votingPluginProxy.canForwardStandaloneBroadcastForTest(true));
+		assertFalse(votingPluginProxy.canForwardStandaloneBroadcastForTest(false));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -185,6 +185,29 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void durablyProcessedRolloverVoteIsDeletedWithoutReplay() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		java.util.Queue<VoteTimeQueue> queue = new java.util.concurrent.ConcurrentLinkedQueue<>();
+		VoteTimeQueue processed = new VoteTimeQueue(java.util.UUID.randomUUID(), "Player", "Invalid\\Service", 100L,
+				false, java.util.Collections.emptySet(), java.util.Collections.emptySet(), "totals", true);
+		queue.add(processed);
+		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
+		Mockito.when(voteCache.removeTimeVote(processed)).thenAnswer(invocation -> {
+			queue.remove(processed);
+			return true;
+		});
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+
+		spyProxy.processQueue();
+
+		assertTrue(queue.isEmpty());
+		verify(spyProxy, never()).getUUID(Mockito.anyString());
+		verify(voteCache).removeTimeVote(processed);
+	}
+
+	@Test
 	void pendingServerBroadcastRetriesBeforeOfflineRewardDelivery() {
 		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
 		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "Player", "player-uuid",
@@ -231,6 +254,29 @@ public class VotingPluginProxyTest {
 		assertTrue(vote.isProxyBroadcastComplete());
 		assertTrue(vote.isBroadcastForwarded());
 		assertFalse(vote.isRewardDelivered());
+		verify(voteCache).updateOnlineVote("voter-uuid", vote);
+	}
+
+	@Test
+	void periodicRetryDeliversBrokerBackedOnlineCacheWithoutVoterLogin() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "OfflineVoter", "voter-uuid",
+				"Service", 100L, true, "totals", false, true, java.util.Set.of("Server1", "Server2"),
+				java.util.Collections.emptySet(), false);
+		Mockito.when(voteCache.getOnlineVoteUUIDs()).thenReturn(java.util.Set.of("voter-uuid"));
+		Mockito.when(voteCache.getOnlineVotes("voter-uuid"))
+				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
+				.thenReturn(java.util.Collections.emptyList());
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+		spyProxy.retryPendingOnlineBroadcasts();
+
+		assertTrue(vote.isProxyBroadcastComplete());
+		assertEquals(java.util.Set.of("Server1", "Server2"), vote.getBroadcastForwardedServers());
 		verify(voteCache).updateOnlineVote("voter-uuid", vote);
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -317,6 +317,21 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void failedTimedDeliveryStatePersistenceRemainsDirtyUntilRetrySucceeds() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		VoteTimeQueue vote = new VoteTimeQueue(java.util.UUID.randomUUID(), "OfflineVoter", "Service", 100L);
+		Mockito.when(voteCache.updateTimeVote(vote)).thenReturn(false, true);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+
+		assertFalse(spyProxy.persistTimeVoteDeliveryForTest(vote));
+		assertTrue(vote.isDeliveryStateDirty());
+		assertTrue(spyProxy.persistTimeVoteDeliveryForTest(vote));
+		assertFalse(vote.isDeliveryStateDirty());
+		verify(voteCache, Mockito.times(2)).updateTimeVote(vote);
+	}
+
+	@Test
 	void completedBroadcastOnlyOnlineVoteIsRemovedAfterRetry() {
 		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
 		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "OfflineVoter", "voter-uuid",

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import com.bencodez.advancedcore.bungeeapi.globaldata.GlobalDataHandlerProxy;
+import com.bencodez.simpleapi.servercomm.mysql.MySqlMessenger;
 import com.bencodez.votingplugin.proxy.BungeeMethod;
 import com.bencodez.votingplugin.proxy.OfflineBungeeVote;
 import com.bencodez.votingplugin.proxy.ProxyMysqlUserTable;
@@ -109,6 +110,18 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void standaloneMysqlBroadcastReportsTransportFailure() throws Exception {
+		MySqlMessenger messenger = Mockito.mock(MySqlMessenger.class);
+		Mockito.doThrow(new java.sql.SQLException("send failed")).when(messenger)
+				.sendToBackend(Mockito.eq("Server1"), Mockito.any());
+		votingPluginProxy.setMethod(BungeeMethod.MYSQL);
+		votingPluginProxy.setProxyMysqlMessenger(messenger);
+
+		assertFalse(votingPluginProxy.sendProxyBroadcastImmediately("Server1",
+				VotingPluginWire.voteBroadcast("uuid", "Player", "Service", 100L, "", false)));
+	}
+
+	@Test
 	void rejectedVoteStopsBeforeGlobalDataQueueOrOfflineBroadcast() {
 		votingPluginProxy.setPlayerOnline(false);
 		Mockito.when(votingPluginProxy.getConfig().getBungeeManageTotals()).thenReturn(true);
@@ -174,5 +187,29 @@ public class VotingPluginProxyTest {
 		assertTrue(vote.isBroadcastForwarded());
 		assertFalse(vote.isRewardDelivered());
 		verify(voteCache).updateServerVote("Server1", vote);
+	}
+
+	@Test
+	void pendingOnlineBroadcastRetriesWhenTargetGainsAnyCarrier() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "OfflineVoter", "voter-uuid",
+				"Service", 100L, true, "totals", false, true, java.util.Set.of("Server1"),
+				java.util.Collections.emptySet(), false);
+		Mockito.when(voteCache.getOnlineVoteUUIDs()).thenReturn(java.util.Set.of("voter-uuid"));
+		Mockito.when(voteCache.getOnlineVotes("voter-uuid"))
+				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
+				.thenReturn(java.util.Collections.emptyList());
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+		spyProxy.retryPendingOnlineBroadcastsForTest("Server1");
+
+		assertTrue(vote.isProxyBroadcastComplete());
+		assertTrue(vote.isBroadcastForwarded());
+		assertFalse(vote.isRewardDelivered());
+		verify(voteCache).updateOnlineVote("voter-uuid", vote);
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -103,4 +103,25 @@ public class VotingPluginProxyTest {
 		assertTrue(votingPluginProxy.sendPluginMessageImmediately("Server1",
 				VotingPluginWire.voteBroadcast("uuid", "Player", "Service", 100L, "", false)));
 	}
+
+	@Test
+	void rejectedVoteStopsBeforeGlobalDataQueueOrOfflineBroadcast() {
+		votingPluginProxy.setPlayerOnline(false);
+		Mockito.when(votingPluginProxy.getConfig().getBungeeManageTotals()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getGlobalDataEnabled()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getProxyBroadcastEnabled()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getProxyBroadcastOfflineMode()).thenReturn("FORWARD");
+		Mockito.when(proxyMySQL.containsKeyQuery(Mockito.anyString())).thenReturn(true);
+		Mockito.when(proxyMySQL.getExactQuery(Mockito.any())).thenReturn(new java.util.ArrayList<>());
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(false).when(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+
+		spyProxy.vote("Player", "Service", true, true, 0, null, null);
+
+		verify(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.eq("Service"), Mockito.any());
+		verify(globalDataHandler, never()).isTimeChangedHappened();
+		verify(spyProxy, never()).sendPluginMessageData(Mockito.anyString(), Mockito.anyString(), Mockito.any(),
+				Mockito.anyBoolean());
+	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -217,4 +217,27 @@ public class VotingPluginProxyTest {
 		assertFalse(vote.isRewardDelivered());
 		verify(voteCache).updateOnlineVote("voter-uuid", vote);
 	}
+
+	@Test
+	void completedBroadcastOnlyOnlineVoteIsRemovedAfterRetry() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "OfflineVoter", "voter-uuid",
+				"Service", 100L, true, "totals", false, true, java.util.Set.of("Server1"),
+				java.util.Collections.emptySet(), true);
+		Mockito.when(voteCache.getOnlineVoteUUIDs()).thenReturn(java.util.Set.of("voter-uuid"));
+		Mockito.when(voteCache.getOnlineVotes("voter-uuid"))
+				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
+				.thenReturn(java.util.Collections.emptyList());
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+		spyProxy.retryPendingOnlineBroadcastsForTest("Server1");
+
+		assertTrue(vote.isProxyBroadcastComplete());
+		verify(voteCache).removeOnlineVote("voter-uuid", vote);
+		verify(voteCache, never()).updateOnlineVote("voter-uuid", vote);
+	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -2,6 +2,7 @@
 package com.bencodez.votingplugin.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -19,6 +20,7 @@ import com.bencodez.advancedcore.bungeeapi.globaldata.GlobalDataHandlerProxy;
 import com.bencodez.votingplugin.proxy.ProxyMysqlUserTable;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
+import com.bencodez.votingplugin.proxy.VotingPluginWire;
 import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyHandler;
 
 public class VotingPluginProxyTest {
@@ -101,5 +103,16 @@ public class VotingPluginProxyTest {
 			assertEquals(0, spyProxy.getVotePartyVotes(), username);
 			assertTrue(spyProxy.getWarnings().stream().anyMatch(warning -> warning.contains("Rejected vote")), username);
 		}
+	}
+
+	@Test
+	void immediatePluginMessageReportsActualDeliveryResult() {
+		votingPluginProxy.setPluginMessageDeliveryResult(false);
+		assertFalse(votingPluginProxy.sendPluginMessageImmediately("Server1",
+				VotingPluginWire.voteBroadcast("uuid", "Player", "Service", 100L, "", false)));
+
+		votingPluginProxy.setPluginMessageDeliveryResult(true);
+		assertTrue(votingPluginProxy.sendPluginMessageImmediately("Server1",
+				VotingPluginWire.voteBroadcast("uuid", "Player", "Service", 100L, "", false)));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -169,6 +169,22 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void failedRolloverReplayRemainsQueued() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		java.util.Queue<VoteTimeQueue> queue = new java.util.concurrent.ConcurrentLinkedQueue<>();
+		queue.add(new VoteTimeQueue(java.util.UUID.randomUUID(), "Player", "Invalid\\Service", 100L));
+		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+
+		spyProxy.processQueue();
+
+		assertEquals(1, queue.size());
+		verify(voteCache, never()).removeTimeVote(Mockito.any());
+	}
+
+	@Test
 	void pendingServerBroadcastRetriesBeforeOfflineRewardDelivery() {
 		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
 		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "Player", "player-uuid",

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -80,6 +80,21 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void rolloverProjectionIncludesQueuedVotesAndVotePartyThresholds() {
+		Mockito.when(votingPluginProxy.getConfig().getVotePartyEnabled()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getVotePartyIncreaseVotesRequired()).thenReturn(5);
+		votingPluginProxy.setVotePartyVotes(8);
+		votingPluginProxy.setCurrentVotePartyVotesRequired(10);
+
+		int[] projected = votingPluginProxy.getProjectedVotePartyStateForTest(3);
+
+		assertEquals(1, projected[0]);
+		assertEquals(15, projected[1]);
+		assertEquals(8, votingPluginProxy.getVotePartyVotes());
+		assertEquals(10, votingPluginProxy.getCurrentVotePartyVotesRequired());
+	}
+
+	@Test
 	void invalidVoteStopsBeforeAnyPersistentRewardCacheOrForwardingState() {
 		for (String username : new String[] { "MchtNameOver16xxx", "../MchtTraversal", "Mcht/Slash", "Mcht\\Slash",
 				"Mcht Space", "Mcht\tTab", "Mcht\u00E9Unicode" }) {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -16,10 +16,14 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import com.bencodez.advancedcore.bungeeapi.globaldata.GlobalDataHandlerProxy;
+import com.bencodez.votingplugin.proxy.BungeeMethod;
+import com.bencodez.votingplugin.proxy.OfflineBungeeVote;
 import com.bencodez.votingplugin.proxy.ProxyMysqlUserTable;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginWire;
+import com.bencodez.votingplugin.proxy.cache.VoteCacheHandler;
 import com.bencodez.votingplugin.proxy.multiproxy.MultiProxyHandler;
+import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 
 public class VotingPluginProxyTest {
 
@@ -115,13 +119,60 @@ public class VotingPluginProxyTest {
 		Mockito.when(proxyMySQL.getExactQuery(Mockito.any())).thenReturn(new java.util.ArrayList<>());
 
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
-		Mockito.doReturn(false).when(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.anyString(), Mockito.any());
+		Mockito.doReturn(false).when(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString(), Mockito.any(), Mockito.anyBoolean());
 
 		spyProxy.vote("Player", "Service", true, true, 0, null, null);
 
-		verify(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.eq("Service"), Mockito.any());
+		verify(spyProxy).checkVoteDelay(Mockito.anyString(), Mockito.eq("Player"), Mockito.eq("Service"), Mockito.any(),
+				Mockito.eq(true));
 		verify(globalDataHandler, never()).isTimeChangedHappened();
 		verify(spyProxy, never()).sendPluginMessageData(Mockito.anyString(), Mockito.anyString(), Mockito.any(),
 				Mockito.anyBoolean());
+	}
+
+	@Test
+	void acceptedTimeChangeVoteReservesItsDelaySlot() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		java.util.Queue<VoteTimeQueue> queue = new java.util.concurrent.ConcurrentLinkedQueue<>();
+		queue.add(new VoteTimeQueue(java.util.UUID.randomUUID(), "Player", "Service", System.currentTimeMillis()));
+		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
+		Mockito.when(voteCache.getVotes(Mockito.anyString())).thenReturn(new java.util.ArrayList<>());
+
+		Mockito.when(votingPluginProxy.getConfig().getWaitUntilVoteDelaySites()).thenReturn(java.util.List.of("Site"));
+		Mockito.when(votingPluginProxy.getConfig().getWaitUntilVoteDelayService("Site")).thenReturn("Service");
+		Mockito.when(votingPluginProxy.getConfig().getWaitUntilVoteDelayVoteDelay("Site")).thenReturn(1);
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+
+		assertFalse(spyProxy.checkVoteDelay("player-uuid", "Player", "Service", new java.util.ArrayList<>(), true));
+		assertTrue(spyProxy.checkVoteDelay("player-uuid", "Player", "Service", new java.util.ArrayList<>(), false));
+	}
+
+	@Test
+	void pendingServerBroadcastRetriesBeforeOfflineRewardDelivery() {
+		VoteCacheHandler voteCache = Mockito.mock(VoteCacheHandler.class);
+		OfflineBungeeVote vote = new OfflineBungeeVote(java.util.UUID.randomUUID(), "Player", "player-uuid",
+				"Service", 100L, true, "totals", false, true, java.util.Set.of("Server1"),
+				java.util.Collections.emptySet(), false);
+		Mockito.when(voteCache.hasVotes("Server1")).thenReturn(true);
+		Mockito.when(voteCache.getVotes("Server1"))
+				.thenReturn(new java.util.ArrayList<>(java.util.List.of(vote)));
+
+		votingPluginProxy.setPlayerOnline(false);
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+		Mockito.when(votingPluginProxy.getConfig().getBlockedServers())
+				.thenReturn(java.util.Collections.emptyList());
+		Mockito.when(votingPluginProxy.getConfig().getWaitForUserOnline()).thenReturn(true);
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();
+		spyProxy.checkCachedVotes("Server1");
+
+		assertTrue(vote.isProxyBroadcastComplete());
+		assertTrue(vote.isBroadcastForwarded());
+		assertFalse(vote.isRewardDelivered());
+		verify(voteCache).updateServerVote("Server1", vote);
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -291,6 +291,7 @@ public class VotingPluginProxyTest {
 		queue.add(vote);
 		Mockito.when(voteCache.getTimeChangeQueue()).thenReturn(queue);
 		Mockito.when(votingPluginProxy.getConfig().getBlockedServers()).thenReturn(java.util.Collections.emptyList());
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
 
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
 		Mockito.doReturn(voteCache).when(spyProxy).getVoteCacheHandler();

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -199,6 +199,10 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		retryPendingTimeBroadcasts(server);
 	}
 
+	public int[] getProjectedVotePartyStateForTest(int acceptedVotes) {
+		return getProjectedVotePartyState(acceptedVotes);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -187,6 +187,14 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		return sendPluginMessageServerNow(server, envelope);
 	}
 
+	public boolean sendProxyBroadcastImmediately(String server, JsonEnvelope envelope) {
+		return sendProxyBroadcastEnvelopeNow(server, envelope);
+	}
+
+	public void retryPendingOnlineBroadcastsForTest(String server) {
+		retryPendingOnlineBroadcasts(server);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -18,14 +18,8 @@ import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
 
 public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 	private final List<String> warnings = new ArrayList<>();
-	private final VotingPluginProxyConfig config = Mockito.mock(VotingPluginProxyConfig.class);
+	private VotingPluginProxyConfig config;
 	private boolean pluginMessageDeliveryResult = true;
-
-	public VotingPluginProxyTestImpl() {
-		Mockito.when(config.getPluginMessageEncryption()).thenReturn(false);
-		Mockito.when(config.getPluginMessageChannel()).thenReturn("votingplugin:main");
-		Mockito.when(config.getDebug()).thenReturn(false);
-	}
 
 	public List<String> getWarnings() {
 		return warnings;
@@ -48,6 +42,12 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 
 	@Override
 	public VotingPluginProxyConfig getConfig() {
+		if (config == null) {
+			config = Mockito.mock(VotingPluginProxyConfig.class);
+			Mockito.when(config.getPluginMessageEncryption()).thenReturn(false);
+			Mockito.when(config.getPluginMessageChannel()).thenReturn("votingplugin:main");
+			Mockito.when(config.getDebug()).thenReturn(false);
+		}
 		return config;
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -12,11 +12,20 @@ import java.util.concurrent.ScheduledExecutorService;
 import org.mockito.Mockito;
 
 import com.bencodez.simpleapi.sql.mysql.config.MysqlConfig;
+import com.bencodez.simpleapi.servercomm.codec.JsonEnvelope;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
 
 public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 	private final List<String> warnings = new ArrayList<>();
+	private final VotingPluginProxyConfig config = Mockito.mock(VotingPluginProxyConfig.class);
+	private boolean pluginMessageDeliveryResult = true;
+
+	public VotingPluginProxyTestImpl() {
+		Mockito.when(config.getPluginMessageEncryption()).thenReturn(false);
+		Mockito.when(config.getPluginMessageChannel()).thenReturn("votingplugin:main");
+		Mockito.when(config.getDebug()).thenReturn(false);
+	}
 
 	public List<String> getWarnings() {
 		return warnings;
@@ -39,7 +48,7 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 
 	@Override
 	public VotingPluginProxyConfig getConfig() {
-		return Mockito.mock(VotingPluginProxyConfig.class);
+		return config;
 	}
 
 	@Override
@@ -161,9 +170,16 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 	}
 
 	@Override
-	public void sendPluginMessageData(String server, String channel, byte[] data, boolean queue) {
-		// TODO Auto-generated method stub
+	public boolean sendPluginMessageData(String server, String channel, byte[] data, boolean queue) {
+		return pluginMessageDeliveryResult;
+	}
 
+	public void setPluginMessageDeliveryResult(boolean pluginMessageDeliveryResult) {
+		this.pluginMessageDeliveryResult = pluginMessageDeliveryResult;
+	}
+
+	public boolean sendPluginMessageImmediately(String server, JsonEnvelope envelope) {
+		return sendPluginMessageServerNow(server, envelope);
 	}
 
 	@Override

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -195,6 +195,10 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		retryPendingOnlineBroadcasts(server);
 	}
 
+	public void retryPendingTimeBroadcastsForTest(String server) {
+		retryPendingTimeBroadcasts(server);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 
 import com.bencodez.simpleapi.sql.mysql.config.MysqlConfig;
 import com.bencodez.simpleapi.servercomm.codec.JsonEnvelope;
+import com.bencodez.votingplugin.proxy.OfflineBungeeVote;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
 import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
@@ -206,6 +207,18 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 
 	public boolean persistTimeVoteDeliveryForTest(VoteTimeQueue vote) {
 		return persistTimeVoteDelivery(vote);
+	}
+
+	public boolean persistServerVoteDeliveryForTest(String server, OfflineBungeeVote vote) {
+		return persistServerVoteDelivery(server, vote);
+	}
+
+	public boolean persistOnlineVoteDeliveryForTest(String uuid, OfflineBungeeVote vote) {
+		return persistOnlineVoteDelivery(uuid, vote);
+	}
+
+	public boolean canForwardStandaloneBroadcastForTest(boolean managesTotals) {
+		return canForwardStandaloneBroadcast(managesTotals);
 	}
 
 	@Override

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -15,6 +15,7 @@ import com.bencodez.simpleapi.sql.mysql.config.MysqlConfig;
 import com.bencodez.simpleapi.servercomm.codec.JsonEnvelope;
 import com.bencodez.votingplugin.proxy.VotingPluginProxy;
 import com.bencodez.votingplugin.proxy.VotingPluginProxyConfig;
+import com.bencodez.votingplugin.timequeue.VoteTimeQueue;
 
 public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 	private final List<String> warnings = new ArrayList<>();

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -203,6 +203,10 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		return getProjectedVotePartyState(acceptedVotes);
 	}
 
+	public boolean persistTimeVoteDeliveryForTest(VoteTimeQueue vote) {
+		return persistTimeVoteDelivery(vote);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -20,6 +20,7 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 	private final List<String> warnings = new ArrayList<>();
 	private VotingPluginProxyConfig config;
 	private boolean pluginMessageDeliveryResult = true;
+	private boolean playerOnline = true;
 
 	public List<String> getWarnings() {
 		return warnings;
@@ -108,7 +109,11 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 
 	@Override
 	public boolean isPlayerOnline(String playerName) {
-		return true;
+		return playerOnline;
+	}
+
+	public void setPlayerOnline(boolean playerOnline) {
+		this.playerOnline = playerOnline;
 	}
 
 	@Override

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginWireTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginWireTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.votingplugin.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.UUID;
@@ -53,5 +54,13 @@ public class VotingPluginWireTest {
 		assertEquals(uuid, rejected.uuid);
 		assertEquals("Service", rejected.service);
 		assertEquals(true, rejected.wasOnline);
+	}
+
+	@Test
+	public void voteBroadcastPreservesTheOriginalOfflineState() {
+		JsonEnvelope envelope = VotingPluginWire.voteBroadcast(UUID.randomUUID().toString(), "Player", "Service",
+				100L, "totals", false);
+
+		assertFalse(Boolean.parseBoolean(envelope.getFields().get(VotingPluginWire.K_WAS_ONLINE)));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/broadcast/BroadcastHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/broadcast/BroadcastHandlerTest.java
@@ -30,6 +30,7 @@ import com.bencodez.votingplugin.broadcast.BroadcastFormat;
 import com.bencodez.votingplugin.broadcast.BroadcastHandler;
 import com.bencodez.votingplugin.broadcast.BroadcastSettings;
 import com.bencodez.votingplugin.broadcast.VoteBroadcastType;
+import com.bencodez.votingplugin.proxy.VoteTotalsSnapshot;
 
 public class BroadcastHandlerTest {
 
@@ -144,6 +145,33 @@ public class BroadcastHandlerTest {
 		verify(console).sendMessage(org.mockito.ArgumentMatchers.<String>argThat(
 				message -> message.contains("HEADER") && message.contains("Ben") && message.contains("2")
 						&& message.contains("SiteA") && message.contains("SiteB") && message.contains("batch")));
+	}
+
+	@Test
+	public void batchUsesStoredTotalsWhenNewestVoteHasNoSnapshot() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class);
+		BukkitScheduler scheduler = mock(BukkitScheduler.class);
+		BukkitTask task = mock(BukkitTask.class);
+		stubBukkitAndConsole();
+		bukkitStatic.when(Bukkit::getScheduler).thenReturn(scheduler);
+		AtomicReference<Runnable> scheduled = new AtomicReference<Runnable>();
+		when(scheduler.runTaskLater(eq(plugin), any(Runnable.class), anyLong())).thenAnswer(invocation -> {
+			scheduled.set(invocation.getArgument(1));
+			return task;
+		});
+		BroadcastSettings settings = new BroadcastSettings(VoteBroadcastType.BATCH_WINDOW_PER_PLAYER,
+				ParsedDuration.parse("1s"), 10,
+				new BroadcastFormat("SINGLE", "HEADER %AllTimeTotal%", " - %site%"));
+		BroadcastHandler handler = new BroadcastHandler(plugin, settings, ZoneId.systemDefault());
+		UUID uuid = UUID.randomUUID();
+
+		handler.broadcastVote(uuid, "Ben", "Forwarded", false,
+				new VoteTotalsSnapshot(999, 1, 1, 1, 1, 1, 10, 1));
+		handler.broadcastVote(uuid, "Ben", "Stored", true, null);
+		scheduled.get().run();
+
+		verify(console).sendMessage(org.mockito.ArgumentMatchers.<String>argThat(
+				message -> message.contains("HEADER") && message.contains("%AllTimeTotal%")));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- forward accepted offline vote broadcasts immediately when `ProxyBroadcast.OfflineMode` is `FORWARD`
- preserve original broadcast targets, per-backend delivery, reward delivery, and queued routing state across JSON and SQL caches
- retry server-cache and voter-keyed online-cache broadcasts whenever a target backend gains a plugin-message carrier
- record delivery only after transport confirmation: plugin-message acceptance, MySQL insert success, MQTT publish success, Redis subscriber acknowledgement, or socket connect/write completion
- suppress cached non-target broadcasts and never recompute the original offline scope from the player's later login location
- complete GlobalData rollover callbacks before loading totals, reserve accepted queued votes before forwarding, and validate vote delay before any announcement

## Root cause

`WaitForUserOnline: true` coupled reward delivery to proxy broadcast timing. Aggregate forwarded state then lost the distinction between original targets, successful targets, pending targets, non-target reward servers, and reward delivery.

The GlobalData path also loaded acceptance/totals state across rollover callbacks, allowing announcements without a reserved delay slot and stale pre-reset totals to be written back after rollover completion.

## User impact

With `OfflineMode: FORWARD`, an accepted offline vote is announced immediately to every reachable backend in the configured scope while its reward may remain queued until the voter joins.

Successful targets are not retried, failed targets remain pending and retry when transport becomes available, non-target cached rewards cannot rebroadcast the vote, and reward delivery happens at most once. Legacy cache entries retain their previous pending-broadcast behavior.

## Validation

- Java 21 Maven build and all 181 tests passed in [GitHub Actions](https://github.com/BenCodez/VotingPlugin/actions/runs/31266889043)
- parsed all modified Java sources successfully
- repository whitespace checks passed
- verified every published branch tree exactly matched the validated local tree
- addressed all 15 review findings and started a fresh Codex review on the latest head

## AI disclosure

This PR was created with assistance from OpenAI Codex.