### PR TITLE
Automatically recover deleted Discord leaderboard messages

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/Config.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/Config.java
@@ -85,6 +85,10 @@ public class Config extends YMLFile {
 	@Getter
 	private boolean discordSRVTopVoterAllTimeNewMessageOnUpdate = false;
 
+	@ConfigDataBoolean(path = "DiscordSRV.TopVoter.AutoRecoverMessageOnFailure")
+	@Getter
+	private boolean discordSRVTopVoterAutoRecoverMessageOnFailure = true;
+
 	@ConfigDataBoolean(path = "DiscordSRV.TopVoter.Monthly.NewMessageOnUpdate")
 	@Getter
 	private boolean discordSRVTopVoterMonthlyNewMessageOnUpdate = false;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
@@ -240,6 +240,7 @@ public class DiscordHandler {
 			synchronized (recoveringTopVoters) {
 				topVoterMessageIds.put(top, 0L);
 			}
+			plugin.getServerData().setTopVoterMessageId(top, 0L);
 			channel.sendMessageEmbeds(eb.build()).queue(msg -> {
 				long newId = msg.getIdLong();
 				synchronized (recoveringTopVoters) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
@@ -237,8 +237,9 @@ public class DiscordHandler {
 			}
 			plugin.getLogger().warning("Discord Top Voters " + top + " message " + existingId
 					+ " no longer exists; clearing the stored ID and posting a replacement.");
-			topVoterMessageIds.put(top, 0L);
-			plugin.getServerData().setTopVoterMessageId(top, 0L);
+			synchronized (recoveringTopVoters) {
+				topVoterMessageIds.put(top, 0L);
+			}
 			channel.sendMessageEmbeds(eb.build()).queue(msg -> {
 				long newId = msg.getIdLong();
 				synchronized (recoveringTopVoters) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
@@ -25,6 +25,8 @@ import github.scarsz.discordsrv.api.events.DiscordReadyEvent;
 import github.scarsz.discordsrv.dependencies.jda.api.EmbedBuilder;
 import github.scarsz.discordsrv.dependencies.jda.api.JDA;
 import github.scarsz.discordsrv.dependencies.jda.api.entities.TextChannel;
+import github.scarsz.discordsrv.dependencies.jda.api.requests.ErrorResponse;
+import github.scarsz.discordsrv.dependencies.jda.api.exceptions.ErrorResponseException;
 import github.scarsz.discordsrv.util.DiscordUtil;
 import lombok.Getter;
 
@@ -201,8 +203,37 @@ public class DiscordHandler {
 		} else {
 			channel.editMessageEmbedsById(existingId, eb.build()).queue(
 					m -> plugin.debug("Edited Top Voters " + top + " (ID: " + existingId + ")"),
-					err -> plugin.getLogger().warning("Error editing Top Voters " + top + ": " + err.getMessage()));
+					err -> handleMessageUpdateFailure(top, channel, eb, existingId, err));
 		}
+	}
+
+	/**
+	 * Handles a failed update of a stored leaderboard message.
+	 *
+	 * Discord message IDs become invalid when a message is deleted. Treat that
+	 * condition as recoverable so one deleted message cannot permanently stop
+	 * leaderboard updates.
+	 */
+	private void handleMessageUpdateFailure(TopVoter top, TextChannel channel, EmbedBuilder eb, long existingId,
+			Throwable error) {
+		if (plugin.getConfigFile().isDiscordSRVTopVoterAutoRecoverMessageOnFailure()
+				&& error instanceof ErrorResponseException
+				&& ((ErrorResponseException) error).getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
+			plugin.getLogger().warning("Discord Top Voters " + top + " message " + existingId
+					+ " no longer exists; clearing the stored ID and posting a replacement.");
+			topVoterMessageIds.put(top, 0L);
+			plugin.getServerData().setTopVoterMessageId(top, 0L);
+			channel.sendMessageEmbeds(eb.build()).queue(msg -> {
+				long newId = msg.getIdLong();
+				topVoterMessageIds.put(top, newId);
+				plugin.getServerData().setTopVoterMessageId(top, newId);
+				plugin.debug("Recovered Top Voters " + top + " with replacement message (ID: " + newId + ")");
+			}, sendError -> plugin.getLogger().warning("Error recovering Top Voters " + top + ": "
+					+ sendError.getMessage()));
+			return;
+		}
+
+		plugin.getLogger().warning("Error editing Top Voters " + top + ": " + error.getMessage());
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
@@ -3,8 +3,10 @@ package com.bencodez.votingplugin.discord;
 import java.awt.Color;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -38,6 +40,7 @@ public class DiscordHandler {
 	private final VotingPluginMain plugin;
 	@Getter
 	private final HashMap<TopVoter, Long> topVoterMessageIds = new HashMap<TopVoter, Long>();
+	private final Set<TopVoter> recoveringTopVoters = new HashSet<>();
 	private final AtomicBoolean discordReady = new AtomicBoolean(false);
 
 	/**
@@ -191,6 +194,12 @@ public class DiscordHandler {
 		}
 
 		long existingId = topVoterMessageIds.getOrDefault(top, 0L);
+		synchronized (recoveringTopVoters) {
+		if (recoveringTopVoters.contains(top)) {
+			plugin.debug("Skipping Discord Top Voter update while recovery is in progress: " + top);
+			return;
+		}
+		}
 
 		if (existingId <= 0 || newMessage) {
 			channel.sendMessageEmbeds(eb.build()).queue(msg -> {
@@ -219,6 +228,12 @@ public class DiscordHandler {
 		if (plugin.getConfigFile().isDiscordSRVTopVoterAutoRecoverMessageOnFailure()
 				&& error instanceof ErrorResponseException
 				&& ((ErrorResponseException) error).getErrorResponse() == ErrorResponse.UNKNOWN_MESSAGE) {
+			synchronized (recoveringTopVoters) {
+				if (topVoterMessageIds.getOrDefault(top, 0L) != existingId || !recoveringTopVoters.add(top)) {
+					plugin.debug("Skipping stale Discord Top Voter recovery because another update handled: " + top);
+					return;
+				}
+			}
 			plugin.getLogger().warning("Discord Top Voters " + top + " message " + existingId
 					+ " no longer exists; clearing the stored ID and posting a replacement.");
 			topVoterMessageIds.put(top, 0L);
@@ -227,9 +242,12 @@ public class DiscordHandler {
 				long newId = msg.getIdLong();
 				topVoterMessageIds.put(top, newId);
 				plugin.getServerData().setTopVoterMessageId(top, newId);
+				recoveringTopVoters.remove(top);
 				plugin.debug("Recovered Top Voters " + top + " with replacement message (ID: " + newId + ")");
-			}, sendError -> plugin.getLogger().warning("Error recovering Top Voters " + top + ": "
-					+ sendError.getMessage()));
+			}, sendError -> {
+				recoveringTopVoters.remove(top);
+				plugin.getLogger().warning("Error recovering Top Voters " + top + ": " + sendError.getMessage());
+			});
 			return;
 		}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/discord/DiscordHandler.java
@@ -193,12 +193,13 @@ public class DiscordHandler {
 			return;
 		}
 
-		long existingId = topVoterMessageIds.getOrDefault(top, 0L);
+		long existingId;
 		synchronized (recoveringTopVoters) {
-		if (recoveringTopVoters.contains(top)) {
-			plugin.debug("Skipping Discord Top Voter update while recovery is in progress: " + top);
-			return;
-		}
+			if (recoveringTopVoters.contains(top)) {
+				plugin.debug("Skipping Discord Top Voter update while recovery is in progress: " + top);
+				return;
+			}
+			existingId = topVoterMessageIds.getOrDefault(top, 0L);
 		}
 
 		if (existingId <= 0 || newMessage) {
@@ -240,12 +241,16 @@ public class DiscordHandler {
 			plugin.getServerData().setTopVoterMessageId(top, 0L);
 			channel.sendMessageEmbeds(eb.build()).queue(msg -> {
 				long newId = msg.getIdLong();
-				topVoterMessageIds.put(top, newId);
-				plugin.getServerData().setTopVoterMessageId(top, newId);
-				recoveringTopVoters.remove(top);
+				synchronized (recoveringTopVoters) {
+					topVoterMessageIds.put(top, newId);
+					plugin.getServerData().setTopVoterMessageId(top, newId);
+					recoveringTopVoters.remove(top);
+				}
 				plugin.debug("Recovered Top Voters " + top + " with replacement message (ID: " + newId + ")");
 			}, sendError -> {
-				recoveringTopVoters.remove(top);
+				synchronized (recoveringTopVoters) {
+					recoveringTopVoters.remove(top);
+				}
 				plugin.getLogger().warning("Error recovering Top Voters " + top + ": " + sendError.getMessage());
 			});
 			return;

--- a/VotingPlugin/src/main/resources/Config.yml
+++ b/VotingPlugin/src/main/resources/Config.yml
@@ -663,6 +663,10 @@ DiscordSRV:
 
   # Show live top voter counts in discord
   TopVoter:
+    # If true, automatically post a replacement when the stored Discord
+    # leaderboard message no longer exists.
+    AutoRecoverMessageOnFailure: true
+
     AllTime:
       # If true, will send top voter messages to discord
       # Will send a message show top 10 voters


### PR DESCRIPTION
## What changed

- Add `DiscordSRV.TopVoter.AutoRecoverMessageOnFailure`, enabled by default.
- Detect Discord's `UNKNOWN_MESSAGE` response when updating a stored top-voter message.
- Clear the stale in-memory and persisted message IDs.
- Automatically post and persist a replacement leaderboard message.

## Why

A deleted leaderboard message or a channel change can leave VotingPlugin retrying the same invalid message ID indefinitely. This makes the Discord integration recover automatically while preserving the existing manual/configurable behavior.

## Validation

- `git diff --check` passed.
- Maven compile could not run because Maven is not installed in the execution environment.

The separate `LoadCommandAliases` issue is intentionally not included: Bukkit registers every command declared in `plugin.yml` before VotingPlugin code executes and needs a separate dynamic-registration design.