### PR TITLE
Prevent disabled vote sites from being auto-enabled

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
@@ -119,6 +119,27 @@ public class VoteSiteManager {
 			}
 		}
 
+		if (!checkEnabled) {
+			ArrayList<String> configuredSites = plugin.getConfigVoteSites().getVoteSitesNames(false);
+			if (configuredSites != null) {
+				for (String url : urls) {
+					if (url == null) {
+						return null;
+					}
+
+					for (String siteName : configuredSites) {
+						String serviceSite = plugin.getConfigVoteSites().getServiceSite(siteName);
+						String displayName = plugin.getConfigVoteSites().getDisplayName(siteName);
+						if (siteName.equalsIgnoreCase(url)
+								|| (serviceSite != null && serviceSite.equalsIgnoreCase(url))
+								|| (displayName != null && displayName.equalsIgnoreCase(url))) {
+							return siteName;
+						}
+					}
+				}
+			}
+		}
+
 		for (String url : urls) {
 			return url;
 		}
@@ -214,6 +235,18 @@ public class VoteSiteManager {
 	 */
 	public boolean hasVoteSite(String site) {
 		String siteName = getVoteSiteName(false, site);
+		if (siteName == null) {
+			return false;
+		}
+
+		ArrayList<String> configuredSites = plugin.getConfigVoteSites().getVoteSitesNames(false);
+		if (configuredSites != null) {
+			for (String configuredSite : configuredSites) {
+				if (configuredSite.equalsIgnoreCase(siteName)) {
+					return true;
+				}
+			}
+		}
 
 		for (VoteSite voteSite : getVoteSites()) {
 			if (voteSite.getKey().equalsIgnoreCase(siteName)) {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteManagerTest.java
@@ -217,6 +217,22 @@ public class VoteSiteManagerTest {
 	}
 
 	@Test
+	public void testDisabledConfiguredVoteSiteIsNotAutoCreated() {
+		when(configFile.isAutoCreateVoteSites()).thenReturn(true);
+		when(voteSitesConfig.getVoteSitesNames(false))
+				.thenReturn(new ArrayList<String>(Arrays.asList("DisabledSite")));
+		when(voteSitesConfig.getServiceSite("DisabledSite")).thenReturn("disabled.example.com");
+		when(voteSitesConfig.getDisplayName("DisabledSite")).thenReturn("Disabled Site");
+
+		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>()));
+
+		assertEquals("DisabledSite", manager.getVoteSiteName(false, "disabled.example.com"));
+		assertTrue(manager.hasVoteSite("disabled.example.com"));
+		assertNull(manager.getVoteSite("disabled.example.com", true));
+		verify(voteSitesConfig, never()).tryGenerateVoteSite(anyString());
+	}
+
+	@Test
 	public void testIsVoteSiteTrueWhenKeyPresent() {
 		VoteSite site = new VoteSite(plugin, "site.test");
 		manager.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>(Arrays.asList(site))));


### PR DESCRIPTION
### Motivation
- A recent refactor made name/existence checks consult only the in-memory loaded `voteSites` list (which contains only enabled sites), causing disabled but configured vote sites to appear missing and be auto-created/re-enabled when `AutoCreateVoteSites` is on.
- The goal is to ensure disabled configured sites are recognized as configured (so they are not auto-created or re-enabled) while preserving runtime behavior that keeps disabled sites unloaded for processing.

### Description
- Restore configuration-backed lookup when resolving names with `checkEnabled=false` by falling back to `ConfigVoteSites.getVoteSitesNames(false)` and matching configured key, `ServiceSite`, or display name (changes in `VoteSiteManager.getVoteSiteName`).
- Update `VoteSiteManager.hasVoteSite` to consult configured site keys before checking the runtime `voteSites` list to avoid treating disabled-but-configured sites as missing.
- Preserve runtime-only behavior for `getVoteSite(...)` and reward processing so disabled configured sites remain unloaded and cannot be processed unless explicitly enabled.
- Add a regression unit test `testDisabledConfiguredVoteSiteIsNotAutoCreated` to assert that a disabled configured site is recognized (name resolution and existence) but not loaded for processing and is not auto-generated.

### Testing
- Ran `git diff --check` and repository status checks against the change (no whitespace or obvious diff issues).
- Added unit test `VoteSiteManagerTest.testDisabledConfiguredVoteSiteIsNotAutoCreated` to cover the regression; the test is included in the commit.
- Attempted to run `mvn -Dtest=VoteSiteManagerTest test` but automated execution failed in this environment due to external dependency resolution failing (Maven Central returned HTTP 403 for `maven-resources-plugin:3.3.1`), so the test could not be executed here.

AI disclosure: This pull request was created with assistance from OpenAI Codex and reviewed by BenCodez.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a769b5ca4b48327a9e478c51906c4c5)