### PR TITLE
Release plugin.yml command aliases when disabled

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -2852,6 +2852,33 @@ public class CommandLoader {
 	}
 
 	/**
+	 * Removes optional commands declared in plugin.yml when aliases are disabled.
+	 */
+	private void unregisterOptionalPluginYMLCommands() {
+		try {
+			CommandMap commandMap = getCommandMap();
+			for (String commandName : plugin.getDescription().getCommands().keySet()) {
+				if (commandName.equalsIgnoreCase("vote") || commandName.equalsIgnoreCase("adminvote")
+						|| commandName.equalsIgnoreCase("av")) {
+					continue;
+				}
+				PluginCommand command = plugin.getCommand(commandName);
+				if (command != null) {
+					command.unregister(commandMap);
+				}
+			}
+		} catch (Exception e) {
+			plugin.getLogger().warning("Unable to unregister disabled command aliases: " + e.getMessage());
+		}
+	}
+
+	/** Gets Bukkit's command map without depending on a CraftBukkit package name. */
+	private CommandMap getCommandMap() throws ReflectiveOperationException {
+		java.lang.reflect.Method method = plugin.getServer().getClass().getMethod("getCommandMap");
+		return (CommandMap) method.invoke(plugin.getServer());
+	}
+
+	/**
 	 * Load commands.
 	 */
 	public void loadCommands() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -20,6 +20,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.CommandMap;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -2686,6 +2687,11 @@ public class CommandLoader {
 	public void loadAliases() {
 		commands = new HashMap<>();
 		aliasCommandNames.clear();
+
+		// Bukkit registers plugin.yml commands before this loader runs.
+		if (!plugin.getConfigFile().isLoadCommandAliases()) {
+			unregisterOptionalPluginYMLCommands();
+		}
 
 		// If false: still wire permissions, but don't wire alias executors/tab
 		// completers.

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -2891,7 +2891,26 @@ public class CommandLoader {
 		@SuppressWarnings("unchecked")
 		Map<String, org.bukkit.command.Command> knownCommands =
 				(Map<String, org.bukkit.command.Command>) field.get(commandMap);
+		Set<String> removedLabels = new HashSet<>();
+		for (Map.Entry<String, org.bukkit.command.Command> entry : knownCommands.entrySet()) {
+			if (entry.getValue() == command) {
+				removedLabels.add(entry.getKey());
+			}
+		}
 		knownCommands.entrySet().removeIf(entry -> entry.getValue() == command);
+		for (String label : removedLabels) {
+			if (knownCommands.containsKey(label)) {
+				continue;
+			}
+			for (Map.Entry<String, org.bukkit.command.Command> entry : knownCommands.entrySet()) {
+				String fallback = entry.getKey();
+				int separator = fallback.indexOf(':');
+				if (separator > 0 && fallback.substring(separator + 1).equalsIgnoreCase(label)) {
+					knownCommands.put(label, entry.getValue());
+					break;
+				}
+			}
+		}
 	}
 
 	/** Gets Bukkit's command map without depending on a CraftBukkit package name. */

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -2875,7 +2875,18 @@ public class CommandLoader {
 	/** Removes the command and all labels that still point to it from Bukkit's map. */
 	private void unregisterCommand(CommandMap commandMap, PluginCommand command) throws ReflectiveOperationException {
 		command.unregister(commandMap);
-		java.lang.reflect.Field field = commandMap.getClass().getDeclaredField("knownCommands");
+		java.lang.reflect.Field field = null;
+		Class<?> commandMapClass = commandMap.getClass();
+		while (commandMapClass != null && field == null) {
+			try {
+				field = commandMapClass.getDeclaredField("knownCommands");
+			} catch (NoSuchFieldException ignored) {
+				commandMapClass = commandMapClass.getSuperclass();
+			}
+		}
+		if (field == null) {
+			throw new NoSuchFieldException("knownCommands");
+		}
 		field.setAccessible(true);
 		@SuppressWarnings("unchecked")
 		Map<String, org.bukkit.command.Command> knownCommands =

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -2864,12 +2864,23 @@ public class CommandLoader {
 				}
 				PluginCommand command = plugin.getCommand(commandName);
 				if (command != null) {
-					command.unregister(commandMap);
+					unregisterCommand(commandMap, command);
 				}
 			}
 		} catch (Exception e) {
 			plugin.getLogger().warning("Unable to unregister disabled command aliases: " + e.getMessage());
 		}
+	}
+
+	/** Removes the command and all labels that still point to it from Bukkit's map. */
+	private void unregisterCommand(CommandMap commandMap, PluginCommand command) throws ReflectiveOperationException {
+		command.unregister(commandMap);
+		java.lang.reflect.Field field = commandMap.getClass().getDeclaredField("knownCommands");
+		field.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, org.bukkit.command.Command> knownCommands =
+				(Map<String, org.bukkit.command.Command>) field.get(commandMap);
+		knownCommands.entrySet().removeIf(entry -> entry.getValue() == command);
 	}
 
 	/** Gets Bukkit's command map without depending on a CraftBukkit package name. */


### PR DESCRIPTION
When LoadCommandAliases is false, unregister optional plugin.yml command entries and their aliases while keeping /vote, /adminvote, and /av registered. This prevents disabled VotingPlugin names from remaining reserved by Bukkit.

Validation: git diff --check passed locally; Maven was unavailable in the execution environment.