### PR TITLE
Add dedicated voting proxy routing

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -1965,11 +1965,11 @@ public abstract class VotingPluginProxy {
 			});
 		}
 		for (PendingPresenceHandoff handoff : completed) {
-			completedPlayers.add(handoff.playerUuid);
 			PlayerPresence presence = backendPlayerPresenceTracker.getPlayer(handoff.playerUuid).orElse(null);
 			if (presence != null && presence.getServer().equalsIgnoreCase(handoff.server)
 					&& presence.getConnectionId().equals(handoff.connectionId)) {
 				login(handoff.playerName, handoff.uuid, handoff.server);
+				completedPlayers.add(handoff.playerUuid);
 			}
 			releaseDestinationClaim(handoff);
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -1519,8 +1519,9 @@ public abstract class VotingPluginProxy {
 					}
 				} else if (backendPlayerPresenceTracker.getPendingSnapshotRequestId(snapshot.server, now) == null) {
 					pendingBackendRecoverySnapshots.remove(presenceServerKey(snapshot.server));
-					completePendingPresenceHandoffs(snapshot.requestId, snapshot.server,
+					Set<UUID> handoffPlayers = completePendingPresenceHandoffs(snapshot.requestId, snapshot.server,
 							snapshot.backendIncarnationId, snapshot.backendStartedAt, now);
+					processDedicatedSnapshotLogins(snapshot.server, handoffPlayers);
 				}
 			}
 		});
@@ -1944,9 +1945,10 @@ public abstract class VotingPluginProxy {
 				&& now >= handoff.createdAt && now - handoff.createdAt <= PRESENCE_HANDOFF_TIMEOUT_MILLIS;
 	}
 
-	private void completePendingPresenceHandoffs(UUID requestId, String server, UUID backendIncarnationId,
+	private Set<UUID> completePendingPresenceHandoffs(UUID requestId, String server, UUID backendIncarnationId,
 			long backendStartedAt, long now) {
 		List<PendingPresenceHandoff> completed = new ArrayList<>();
+		Set<UUID> completedPlayers = new LinkedHashSet<>();
 		synchronized (pendingPresenceHandoffs) {
 			prunePendingPresenceHandoffs(now);
 			pendingPresenceHandoffs.entrySet().removeIf(entry -> {
@@ -1963,12 +1965,32 @@ public abstract class VotingPluginProxy {
 			});
 		}
 		for (PendingPresenceHandoff handoff : completed) {
+			completedPlayers.add(handoff.playerUuid);
 			PlayerPresence presence = backendPlayerPresenceTracker.getPlayer(handoff.playerUuid).orElse(null);
 			if (presence != null && presence.getServer().equalsIgnoreCase(handoff.server)
 					&& presence.getConnectionId().equals(handoff.connectionId)) {
 				login(handoff.playerName, handoff.uuid, handoff.server);
 			}
 			releaseDestinationClaim(handoff);
+		}
+		return completedPlayers;
+	}
+
+	/**
+	 * Drains voter-keyed cached rewards when a complete recovery snapshot first
+	 * confirms a player on a dedicated voting proxy. Cross-backend handoffs are
+	 * already processed by their token-bound completion path and are excluded to
+	 * avoid a second login callback.
+	 */
+	protected void processDedicatedSnapshotLogins(String server, Set<UUID> handoffPlayers) {
+		if (!isDedicatedVotingProxyEnabled() || server == null || server.isBlank()) {
+			return;
+		}
+		Set<UUID> excluded = handoffPlayers == null ? Collections.emptySet() : handoffPlayers;
+		for (PlayerPresence presence : backendPlayerPresenceTracker.getOnlinePlayers()) {
+			if (presence.getServer().equalsIgnoreCase(server) && !excluded.contains(presence.getUuid())) {
+				login(presence.getPlayerName(), presence.getUuid().toString(), presence.getServer());
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -563,7 +563,7 @@ public abstract class VotingPluginProxy {
 	public synchronized void checkCachedVotes(String server) {
 		int delay = 1;
 		if (isServerValid(server)) {
-			if (isSomeoneOnlineServer(server)) {
+			if (isSomeoneOnlineServerForVoteRouting(server)) {
 				if (getVoteCacheHandler().hasVotes(server) && !getConfig().getBlockedServers().contains(server)) {
 					ArrayList<OfflineBungeeVote> c = getVoteCacheHandler().getVotes(server);
 					ArrayList<OfflineBungeeVote> removed = new ArrayList<>();
@@ -588,10 +588,10 @@ public abstract class VotingPluginProxy {
 
 							boolean toSend = true;
 							if (getConfig().getWaitForUserOnline()) {
-								if (!isPlayerOnline(cache.getPlayerName())) {
+								if (!isPlayerOnlineForVoteRouting(cache.getPlayerName())) {
 									toSend = false;
-								} else if (isPlayerOnline(cache.getPlayerName())
-										&& !getCurrentPlayerServer(cache.getPlayerName()).equals(server)) {
+								} else if (isPlayerOnlineForVoteRouting(cache.getPlayerName())
+										&& !getCurrentPlayerServerForVoteRouting(cache.getPlayerName()).equals(server)) {
 									toSend = false;
 								}
 							}
@@ -599,8 +599,8 @@ public abstract class VotingPluginProxy {
 								boolean broadcastHere = cache.needsBroadcastOn(server);
 								if (!cache.isProxyBroadcastHandled() && broadcastHere
 										&& getConfig().getProxyBroadcastEnabled()) {
-									boolean playerOnline = isPlayerOnline(cache.getPlayerName());
-									String playerServer = playerOnline ? getCurrentPlayerServer(cache.getPlayerName())
+									boolean playerOnline = isPlayerOnlineForVoteRouting(cache.getPlayerName());
+									String playerServer = playerOnline ? getCurrentPlayerServerForVoteRouting(cache.getPlayerName())
 											: null;
 
 									Set<String> targets = proxyBroadcastDecider.resolveTargets(playerOnline,
@@ -636,11 +636,11 @@ public abstract class VotingPluginProxy {
 
 	public synchronized void checkOnlineVotes(String player, String uuid, String server) {
 		int delay = 1;
-		if (isPlayerOnline(player) && getVoteCacheHandler().hasOnlineVotes(uuid)) {
+		if (isPlayerOnlineForVoteRouting(player) && getVoteCacheHandler().hasOnlineVotes(uuid)) {
 			ArrayList<OfflineBungeeVote> c = getVoteCacheHandler().getOnlineVotes(uuid);
 			if (!c.isEmpty()) {
 				if (server == null) {
-					server = getCurrentPlayerServer(player);
+					server = getCurrentPlayerServerForVoteRouting(player);
 				}
 				if (!getConfig().getBlockedServers().contains(server)) {
 					int num = 1;
@@ -663,7 +663,7 @@ public abstract class VotingPluginProxy {
 						boolean broadcastHere = cache.needsBroadcastOn(server);
 						if (!cache.isProxyBroadcastHandled() && broadcastHere
 								&& getConfig().getProxyBroadcastEnabled()) {
-							String playerServer = (server != null) ? server : getCurrentPlayerServer(player);
+							String playerServer = (server != null) ? server : getCurrentPlayerServerForVoteRouting(player);
 
 							Set<String> targets = proxyBroadcastDecider.resolveTargets(true, playerServer);
 							broadcastHere = proxyBroadcastDecider.shouldBroadcast(server, targets);
@@ -997,6 +997,26 @@ public abstract class VotingPluginProxy {
 
 	public abstract String getCurrentPlayerServer(String player);
 
+	/**
+	 * Resolves a player's server for vote routing. A dedicated voting proxy has no
+	 * local players, so it uses the backend presence tracker instead.
+	 */
+	protected String getCurrentPlayerServerForVoteRouting(String player) {
+		if (isDedicatedVotingProxyEnabled()) {
+			return backendPlayerPresenceTracker.getPlayer(player).map(presence -> presence.getServer()).orElse(null);
+		}
+		return getCurrentPlayerServer(player);
+	}
+
+	/**
+	 * Dedicated routing is intentionally unavailable on plugin messaging: that
+	 * transport is attached to a player-facing proxy and does not carry backend
+	 * presence snapshots.
+	 */
+	protected boolean isDedicatedVotingProxyEnabled() {
+		return getConfig().getDedicatedVotingProxy() && method != null && method.supportsBackendPresence();
+	}
+
 	public abstract File getDataFolderPlugin();
 
 	public String getMonthTotalsWithDatePath() {
@@ -1122,9 +1142,27 @@ public abstract class VotingPluginProxy {
 
 	public abstract boolean isPlayerOnline(String playerName);
 
+	/**
+	 * Checks online state for vote routing, using backend presence only when this
+	 * proxy is explicitly configured as the dedicated voting proxy.
+	 */
+	protected boolean isPlayerOnlineForVoteRouting(String playerName) {
+		return isDedicatedVotingProxyEnabled() ? backendPlayerPresenceTracker.getPlayer(playerName).isPresent()
+				: isPlayerOnline(playerName);
+	}
+
 	public abstract boolean isServerValid(String server);
 
 	public abstract boolean isSomeoneOnlineServer(String server);
+
+	protected boolean isSomeoneOnlineServerForVoteRouting(String server) {
+		if (!isDedicatedVotingProxyEnabled()) {
+			return isSomeoneOnlineServer(server);
+		}
+		com.bencodez.votingplugin.proxy.presence.BackendPresenceStatus status = backendPlayerPresenceTracker
+				.getBackendStatus(server);
+		return status != null && status.isAvailable() && status.getPlayerCount() > 0;
+	}
 
 	public abstract boolean isVoteCacheIgnoreTime();
 
@@ -1154,6 +1192,7 @@ public abstract class VotingPluginProxy {
 		if (getMethod() == null) {
 			method = BungeeMethod.PLUGINMESSAGING;
 		}
+		warnUnsupportedDedicatedVotingProxyMode();
 		uuidPlayerNameCache = getProxyMySQL().getRowsUUIDNameQuery();
 
 		bungeeTimeChecker.setTimeChangeFailSafeBypass(getConfig().getTimeChangeFailSafeBypass());
@@ -2133,7 +2172,7 @@ public abstract class VotingPluginProxy {
 		if (getConfig().getOnlineMode()) {
 			addNonVotedPlayer(uuid, playerName);
 		}
-		if (isPlayerOnline(playerName)) {
+		if (isPlayerOnlineForVoteRouting(playerName)) {
 			if (getConfig().getGlobalDataEnabled()) {
 				if (getGlobalDataHandler().isTimeChangedHappened()) {
 					getGlobalDataHandler().checkForFinishedTimeChanges();
@@ -2296,10 +2335,18 @@ public abstract class VotingPluginProxy {
 		if (getMethod() == null) {
 			method = BungeeMethod.PLUGINMESSAGING;
 		}
+		warnUnsupportedDedicatedVotingProxyMode();
 
 		setCurrentVotePartyVotesRequired(
 				getConfig().getVotePartyVotesRequired() + getVoteCacheVotePartyIncreaseVotesRequired());
 		loadMultiProxySupport();
+	}
+
+	private void warnUnsupportedDedicatedVotingProxyMode() {
+		if (getConfig().getDedicatedVotingProxy() && (method == null || !method.supportsBackendPresence())) {
+			logSevere("DedicatedVotingProxy requires MYSQL, REDIS, MQTT, or SOCKETS; PLUGINMESSAGING is disabled for "
+					+ "dedicated-proxy routing. Falling back to normal proxy routing.");
+		}
 	}
 
 	public abstract void runAsync(Runnable run);
@@ -2468,7 +2515,7 @@ public abstract class VotingPluginProxy {
 	}
 
 	public void sendVoteParty(String server) {
-		if (isSomeoneOnlineServer(server)) {
+		if (isSomeoneOnlineServerForVoteRouting(server)) {
 			globalMessageProxyHandler.sendMessage(server, 1, VotingPluginWire.votePartyBungee());
 		}
 	}
@@ -2495,7 +2542,7 @@ public abstract class VotingPluginProxy {
 
 	public void status() {
 		for (String s : getAllAvailableServers()) {
-			if (!isSomeoneOnlineServer(s)) {
+			if (!isSomeoneOnlineServerForVoteRouting(s)) {
 				log("No players on server " + s + " to send test status message, please retest with someone online");
 			} else {
 				log("Sending request for status message on " + s);
@@ -2730,8 +2777,8 @@ public abstract class VotingPluginProxy {
 			player = getProperName(uuid, player);
 
 			// Cache online state/server once (IMPORTANT for broadcast logic correctness)
-			final boolean playerOnline = isPlayerOnline(player);
-			final String playerServer = playerOnline ? getCurrentPlayerServer(player) : null;
+			final boolean playerOnline = isPlayerOnlineForVoteRouting(player);
+			final String playerServer = playerOnline ? getCurrentPlayerServerForVoteRouting(player) : null;
 			long time = queueTime != 0 ? queueTime
 					: LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
 
@@ -2884,7 +2931,10 @@ public abstract class VotingPluginProxy {
 			// ===========================
 			// Send vote(s) to backend(s)
 			// ===========================
-			if (getConfig().getSendVotesToAllServers()) {
+			// A dedicated voting proxy has no player-facing proxy state. Its confirmed
+			// backend presence selects one destination, so never fan a vote out merely
+			// because a legacy configuration still has SendVotesToAllServers enabled.
+			if (getConfig().getSendVotesToAllServers() && !isDedicatedVotingProxyEnabled()) {
 				for (String s : getAllAvailableServers()) {
 
 					boolean forceCache = getConfig().getWaitForUserOnline()
@@ -2894,7 +2944,7 @@ public abstract class VotingPluginProxy {
 						debug("Forcing vote to cache for server " + s);
 					}
 
-					if ((!isSomeoneOnlineServer(s) && method.requiresPlayerOnline()) || forceCache) {
+					if ((!isSomeoneOnlineServerForVoteRouting(s) && method.requiresPlayerOnline()) || forceCache) {
 						voteStatus = VoteLogStatus.CACHED;
 						boolean broadcastForwarded = standaloneProxyBroadcast
 								&& broadcastForwardedServers.containsAll(proxyBroadcastTargets);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -2931,10 +2931,7 @@ public abstract class VotingPluginProxy {
 			// ===========================
 			// Send vote(s) to backend(s)
 			// ===========================
-			// A dedicated voting proxy has no player-facing proxy state. Its confirmed
-			// backend presence selects one destination, so never fan a vote out merely
-			// because a legacy configuration still has SendVotesToAllServers enabled.
-			if (getConfig().getSendVotesToAllServers() && !isDedicatedVotingProxyEnabled()) {
+			if (getConfig().getSendVotesToAllServers()) {
 				for (String s : getAllAvailableServers()) {
 
 					boolean forceCache = getConfig().getWaitForUserOnline()

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxyConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxyConfig.java
@@ -400,6 +400,13 @@ public interface VotingPluginProxyConfig {
 	public boolean getSendVotesToAllServers();
 
 	/**
+	 * Gets whether this is the dedicated voting proxy for a multi-proxy network.
+	 *
+	 * @return true when backend-reported presence should drive vote routing
+	 */
+	public boolean getDedicatedVotingProxy();
+
+	/**
 	 * Gets the configuration for a specific Spigot server.
 	 *
 	 * @param s the server name

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
@@ -267,6 +267,11 @@ public class BungeeConfig implements VotingPluginProxyConfig {
 	}
 
 	@Override
+	public boolean getDedicatedVotingProxy() {
+		return getData().getBoolean("DedicatedVotingProxy", false);
+	}
+
+	@Override
 	public Map<String, Object> getSpigotServerConfiguration(String s) {
 		return configToMap(getData().getSection("SpigotServers." + s));
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
@@ -270,6 +270,11 @@ public class VelocityConfig extends VelocityYMLFile implements VotingPluginProxy
 	}
 
 	@Override
+	public boolean getDedicatedVotingProxy() {
+		return getBoolean(getNode("DedicatedVotingProxy"), false);
+	}
+
+	@Override
 	public Map<String, Object> getSpigotServerConfiguration(String s) {
 		return configToMap(getNode("SpigotServers", s));
 	}

--- a/VotingPlugin/src/main/resources/bungeeconfig.yml
+++ b/VotingPlugin/src/main/resources/bungeeconfig.yml
@@ -231,6 +231,11 @@ Debug: false
 # Have a reward on each server
 # If false, will send to online server only
 SendVotesToAllServers: true
+# Enable only on a single dedicated voting proxy when regional proxies do not
+# run VotingPlugin. Requires a non-PLUGINMESSAGING BungeeMethod; online player
+# routing then uses backend presence reported through the global message system.
+# Unknown players are treated as offline and follow the existing vote cache path.
+DedicatedVotingProxy: false
 # List of servers the plugin won't send the vote to
 # Uses names from bungeecoord config, only needed for non SOCKETS setup
 BlockedServers:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -192,6 +192,25 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void dedicatedSnapshotDrainsCachedVotesForConfirmedPlayers() {
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		long now = System.currentTimeMillis();
+		java.util.UUID incarnation = java.util.UUID.randomUUID();
+		java.util.UUID playerUuid = java.util.UUID.randomUUID();
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().backendStarted("Server2", incarnation,
+				1000L, 1000L, now));
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().playerOnline("Player", playerUuid.toString(),
+				"Server2", java.util.UUID.randomUUID(), incarnation, 1000L, 1100L, now));
+
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+		spyProxy.processDedicatedSnapshotLoginsForTest("Server2", java.util.Collections.emptySet());
+
+		verify(spyProxy).login("Player", playerUuid.toString(), "Server2");
+	}
+
+	@Test
 	void handoffBlockedBySnapshotCooldownIsRetried() {
 		votingPluginProxy.setMethod(BungeeMethod.MQTT);
 		com.bencodez.simpleapi.servercomm.global.GlobalMessageProxyHandler messageHandler = Mockito

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -164,6 +164,34 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void dedicatedVotingProxyRoutesUsingConfirmedBackendPresence() {
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		long now = System.currentTimeMillis();
+		java.util.UUID incarnation = java.util.UUID.randomUUID();
+		java.util.UUID playerUuid = java.util.UUID.randomUUID();
+
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().backendStarted("Server2", incarnation,
+				1000L, 1000L, now));
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().playerOnline("Player", playerUuid.toString(),
+				"Server2", java.util.UUID.randomUUID(), incarnation, 1000L, 1100L, now));
+
+		assertTrue(votingPluginProxy.isPlayerOnlineForVoteRoutingForTest("Player"));
+		assertEquals("Server2", votingPluginProxy.getCurrentPlayerServerForVoteRoutingForTest("Player"));
+		assertTrue(votingPluginProxy.isSomeoneOnlineServerForVoteRoutingForTest("Server2"));
+		assertFalse(votingPluginProxy.isPlayerOnlineForVoteRoutingForTest("Unknown"));
+	}
+
+	@Test
+	void dedicatedVotingProxyDoesNotUsePluginMessagingPresence() {
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+
+		assertTrue(votingPluginProxy.isPlayerOnlineForVoteRoutingForTest("Player"));
+		assertEquals("Server1", votingPluginProxy.getCurrentPlayerServerForVoteRoutingForTest("Player"));
+	}
+
+	@Test
 	void handoffBlockedBySnapshotCooldownIsRetried() {
 		votingPluginProxy.setMethod(BungeeMethod.MQTT);
 		com.bencodez.simpleapi.servercomm.global.GlobalMessageProxyHandler messageHandler = Mockito

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -253,6 +253,18 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		return canForwardStandaloneBroadcast(managesTotals);
 	}
 
+	public boolean isPlayerOnlineForVoteRoutingForTest(String player) {
+		return isPlayerOnlineForVoteRouting(player);
+	}
+
+	public String getCurrentPlayerServerForVoteRoutingForTest(String player) {
+		return getCurrentPlayerServerForVoteRouting(player);
+	}
+
+	public boolean isSomeoneOnlineServerForVoteRoutingForTest(String server) {
+		return isSomeoneOnlineServerForVoteRouting(server);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -265,6 +265,10 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		return isSomeoneOnlineServerForVoteRouting(server);
 	}
 
+	public void processDedicatedSnapshotLoginsForTest(String server, Set<UUID> handoffPlayers) {
+		processDedicatedSnapshotLogins(server, handoffPlayers);
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub


### PR DESCRIPTION
## Summary

- add an opt-in `DedicatedVotingProxy` proxy setting for one central voting proxy when regional proxies do not run VotingPlugin
- use backend presence confirmed by PR #1550 wherever normal proxy routing needs online-player/current-server state
- preserve normal `SendVotesToAllServers` behavior in dedicated mode: when enabled, votes still reach every backend; when disabled, a confirmed online player routes to their backend and unknown/offline players use the existing cache path
- after a complete startup/recovery snapshot, drain voter-keyed cached rewards for each newly confirmed player
- retain normal routing unchanged when the toggle is off
- reject dedicated presence routing on `PLUGINMESSAGING`; it falls back to normal proxy routing and logs the misconfiguration
- use backend presence for cached-vote delivery, VoteParty delivery, and status checks in dedicated mode
- add Bungee and Velocity configuration accessors plus routing-policy regression coverage

## Configuration

On the dedicated voting proxy only:

```yaml
DedicatedVotingProxy: true
BungeeMethod: MQTT # or MYSQL, REDIS, SOCKETS
```

Regional proxies should not run VotingPlugin. Backends use the same non-`PLUGINMESSAGING` global-message transport and their configured `Server` name.

## Validation

- `git diff --check`: passed
- [GitHub Java 21 Maven CI](https://github.com/BenCodez/VotingPlugin/actions/runs/31976581240): passed
- targeted Maven compile/tests could not be run locally because Maven is not installed in this workspace

AI disclosure: This content was written with assistance from ChatGPT.