### PR TITLE
Preserve send-to-all routing in dedicated mode

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -2953,7 +2953,7 @@ public abstract class VotingPluginProxy {
 			// ===========================
 			// Send vote(s) to backend(s)
 			// ===========================
-			if (getConfig().getSendVotesToAllServers()) {
+			if (shouldSendVoteToAllServers()) {
 				for (String s : getAllAvailableServers()) {
 
 					boolean forceCache = getConfig().getWaitForUserOnline()
@@ -3092,6 +3092,15 @@ public abstract class VotingPluginProxy {
 			e.printStackTrace();
 			return QueuedVoteResult.RETRY;
 		}
+	}
+
+	/**
+	 * Keeps vote fan-out independent from dedicated-presence routing and backend
+	 * reward-storage settings. The proxy obeys SendVotesToAllServers exactly as
+	 * configured; each backend applies its own reward behavior on receipt.
+	 */
+	protected boolean shouldSendVoteToAllServers() {
+		return getConfig().getSendVotesToAllServers();
 	}
 
 	private static final class PendingPresenceHandoff {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -192,6 +192,17 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
+	void dedicatedVotingProxyPreservesSendVotesToAllServersSetting() {
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		Mockito.when(votingPluginProxy.getConfig().getSendVotesToAllServers()).thenReturn(true);
+		assertTrue(votingPluginProxy.shouldSendVoteToAllServersForTest());
+
+		Mockito.when(votingPluginProxy.getConfig().getSendVotesToAllServers()).thenReturn(false);
+		assertFalse(votingPluginProxy.shouldSendVoteToAllServersForTest());
+	}
+
+	@Test
 	void dedicatedSnapshotDrainsCachedVotesForConfirmedPlayers() {
 		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
 		votingPluginProxy.setMethod(BungeeMethod.MQTT);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTestImpl.java
@@ -269,6 +269,10 @@ public class VotingPluginProxyTestImpl extends VotingPluginProxy {
 		processDedicatedSnapshotLogins(server, handoffPlayers);
 	}
 
+	public boolean shouldSendVoteToAllServersForTest() {
+		return shouldSendVoteToAllServers();
+	}
+
 	@Override
 	public void setVoteCacheLastUpdated() {
 		// TODO Auto-generated method stub


### PR DESCRIPTION
## Summary

- preserve `SendVotesToAllServers` exactly as configured when `DedicatedVotingProxy` is enabled
- make the routing policy explicit: dedicated presence changes only the source of player/server state, not vote fan-out
- keep backend reward behavior and existing `PerServerRewards` storage handling independent of proxy routing
- add a regression test covering both enabled and disabled fan-out in dedicated mode

## Validation

- `git diff --check`: passed
- GitHub Java CI will validate the branch

AI disclosure: This content was written with assistance from ChatGPT.