### PR TITLE
Validate legacy standalone login envelopes

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -1582,15 +1582,15 @@ public abstract class VotingPluginProxy {
 		boolean accepted = false;
 		String deliveryServer = server;
 		if (legacy) {
-			// Preserve the original login contract for cached rewards. In
-			// PLUGINMESSAGING mode the player-facing proxy is authoritative for online
-			// state and backend presence messages are disabled entirely.
-			accepted = true;
 			if (method == BungeeMethod.PLUGINMESSAGING) {
 				String proxyServer = getCurrentPlayerServer(player);
-				if (proxyServer != null && !proxyServer.isBlank()) {
+				accepted = isLegacyLoginDestinationAuthoritative(player, uuid, proxyServer);
+				if (accepted) {
 					deliveryServer = proxyServer;
 				}
+			} else if (method != null && method.supportsBackendPresence()
+					&& isPresenceServerValid(server, VotingPluginWire.SUB_LOGIN)) {
+				accepted = isLegacyLoginDestinationAuthoritative(player, uuid, server);
 			}
 		} else if (method != null && method.supportsBackendPresence() && event.connectionId != null
 				&& isPresenceServerValid(server, VotingPluginWire.SUB_LOGIN)
@@ -1615,6 +1615,52 @@ public abstract class VotingPluginProxy {
 			login(player, uuid, deliveryServer);
 		} else {
 			debug("Ignored invalid or stale login envelope: " + message.getFields());
+		}
+	}
+
+	/**
+	 * Validates a legacy login against an authority independent of the envelope.
+	 * Player-facing proxies use their native live route and UUID. A dedicated
+	 * voting proxy has no native player session, so it requires an exact modern
+	 * presence match for the claimed destination.
+	 */
+	private boolean isLegacyLoginDestinationAuthoritative(String player, String uuid, String server) {
+		if (server == null || server.isBlank()) {
+			return false;
+		}
+
+		UUID claimedUuid;
+		try {
+			claimedUuid = UUID.fromString(uuid.trim());
+		} catch (RuntimeException e) {
+			return false;
+		}
+
+		if (isDedicatedVotingProxyEnabled()) {
+			PlayerPresence presence = backendPlayerPresenceTracker.getPlayer(player).orElse(null);
+			return presence != null && presence.getServer().equalsIgnoreCase(server)
+					&& (!getConfig().getOnlineMode() || presence.getUuid().equals(claimedUuid));
+		}
+
+		if (!isPlayerOnline(player)) {
+			return false;
+		}
+		String proxyServer = getCurrentPlayerServer(player);
+		if (proxyServer == null || !proxyServer.equalsIgnoreCase(server)) {
+			return false;
+		}
+		if (!getConfig().getOnlineMode()) {
+			return true;
+		}
+
+		String authoritativeUuid = getUUID(player);
+		if (authoritativeUuid == null || authoritativeUuid.isBlank()) {
+			return false;
+		}
+		try {
+			return claimedUuid.equals(UUID.fromString(authoritativeUuid.trim()));
+		} catch (IllegalArgumentException e) {
+			return false;
 		}
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/VotingPluginProxyTest.java
@@ -125,10 +125,12 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
-	void pluginMessagingLegacyLoginUsesTheProxyCurrentServer() {
+	void pluginMessagingLegacyLoginUsesTheProxyCurrentServerAndUuid() {
 		String uuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
 		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(uuid).when(spyProxy).getUUID("Player");
 		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
 		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "claimed-backend"));
@@ -137,15 +139,136 @@ public class VotingPluginProxyTest {
 	}
 
 	@Test
-	void standaloneTransportLegacyLoginKeepsOriginalCompatibilityPath() {
+	void pluginMessagingLegacyLoginRejectsMismatchedUuid() {
+		String authoritativeUuid = java.util.UUID.randomUUID().toString();
+		String claimedUuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.PLUGINMESSAGING);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(authoritativeUuid).when(spyProxy).getUUID("Player");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", claimedUuid, "Server1"));
+
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+	}
+
+	@Test
+	void standaloneTransportLegacyLoginUsesProxyAuthoritativeRoute() {
 		String uuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(uuid).when(spyProxy).getUUID("Player");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "Server1"));
+
+		verify(spyProxy).login("Player", uuid, "Server1");
+	}
+
+	@Test
+	void standaloneTransportLegacyLoginRejectsUnknownServer() {
+		String uuid = java.util.UUID.randomUUID().toString();
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(false).when(spyProxy).isServerValid("unknown-server");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "unknown-server"));
+
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+	}
+
+	@Test
+	void standaloneTransportLegacyLoginAcceptsModernToLegacyHandoffUsingProxyRoute() {
+		java.util.UUID playerUuid = java.util.UUID.randomUUID();
+		java.util.UUID incarnation = java.util.UUID.randomUUID();
+		long now = System.currentTimeMillis();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().backendStarted("Server1", incarnation,
+				1000L, 1000L, now));
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().playerOnline("Player",
+				playerUuid.toString(), "Server1", java.util.UUID.randomUUID(), incarnation, 1000L, 1100L,
+				now));
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn("Server2").when(spyProxy).getCurrentPlayerServer("Player");
+		Mockito.doReturn(playerUuid.toString()).when(spyProxy).getUUID("Player");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(
+				VotingPluginWire.login("Player", playerUuid.toString(), "Server2"));
+
+		verify(spyProxy).login("Player", playerUuid.toString(), "Server2");
+	}
+
+	@Test
+	void standaloneTransportLegacyLoginRejectsClaimNotMatchingProxyRoute() {
+		String uuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(uuid).when(spyProxy).getUUID("Player");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "Server2"));
+
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+	}
+
+	@Test
+	void standaloneTransportLegacyLoginRejectsNameUuidMismatch() {
+		String aliceUuid = java.util.UUID.randomUUID().toString();
+		String bobUuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		Mockito.doReturn(aliceUuid).when(spyProxy).getUUID("Alice");
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Alice", bobUuid, "Server1"));
+
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+	}
+
+	@Test
+	void dedicatedProxyLegacyLoginRequiresConfirmedDestinationPresence() {
+		java.util.UUID playerUuid = java.util.UUID.randomUUID();
+		java.util.UUID incarnation = java.util.UUID.randomUUID();
+		long now = System.currentTimeMillis();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
+		votingPluginProxy.setMethod(BungeeMethod.MQTT);
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().backendStarted("Server1", incarnation,
+				1000L, 1000L, now));
+		assertTrue(votingPluginProxy.getBackendPlayerPresenceTracker().playerOnline("Player",
+				playerUuid.toString(), "Server1", java.util.UUID.randomUUID(), incarnation, 1000L, 1100L,
+				now));
+		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
+		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(
+				VotingPluginWire.login("Player", playerUuid.toString(), "Server2"));
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
+
+		spyProxy.handleLoginMessageForTest(
+				VotingPluginWire.login("Player", playerUuid.toString(), "Server1"));
+		verify(spyProxy).login("Player", playerUuid.toString(), "Server1");
+	}
+
+	@Test
+	void dedicatedProxyLegacyLoginRejectsUnknownIdentity() {
+		String uuid = java.util.UUID.randomUUID().toString();
+		Mockito.when(votingPluginProxy.getConfig().getOnlineMode()).thenReturn(true);
+		Mockito.when(votingPluginProxy.getConfig().getDedicatedVotingProxy()).thenReturn(true);
 		votingPluginProxy.setMethod(BungeeMethod.MQTT);
 		VotingPluginProxyTestImpl spyProxy = Mockito.spy(votingPluginProxy);
 		doNothing().when(spyProxy).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 
-		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "survival"));
+		spyProxy.handleLoginMessageForTest(VotingPluginWire.login("Player", uuid, "Server1"));
 
-		verify(spyProxy).login("Player", uuid, "survival");
+		verify(spyProxy, never()).login(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Validate every legacy login against an authority independent of the envelope.
- On player-facing proxies, require the player to be online on the claimed/current backend and require the envelope UUID to match the proxy's live UUID in online mode.
- On dedicated voting proxies, require an exact modern presence match for the claimed player, UUID, and destination server.
- Continue requiring standalone MQTT, Redis, MySQL, and socket envelopes to name a configured backend.
- Preserve the existing generation-fenced extended-presence path unchanged.

## Security impact

This closes the validated Codex Security finding **“Legacy login envelopes bypass presence validation”**:
https://chatgpt.com/codex/cloud/security/findings/67ce1cfbc0c08191842d0918ce0c9cb8?sev=critical%2Chigh

Legacy envelopes can no longer select a destination or cached-vote UUID merely by supplying those values. Player-facing proxies derive authority from their native live session. Dedicated proxies fail closed unless modern presence independently confirms the destination.

## Review follow-up

The modern-source to legacy-destination race is handled without a delayed pending claim: the player-facing proxy's current route takes precedence over stale backend presence, so a legitimate transfer is accepted immediately once the proxy shows the destination. A queued spoofed destination cannot become valid merely because the old source later logs out.

## Regression coverage

- `PLUGINMESSAGING` uses the proxy-authoritative server and UUID.
- `PLUGINMESSAGING` rejects a mismatched UUID.
- Standalone legacy login accepts a configured server matching the live proxy route.
- Unknown configured-server claims are rejected.
- A modern-source to legacy-destination transfer succeeds while tracker state still names the old source.
- A claimed server that differs from the live proxy route is rejected.
- Player-name/UUID mismatches are rejected.
- Dedicated proxies reject unconfirmed destinations and unknown identities, while accepting exact confirmed presence.
- Existing extended generation-fenced presence behavior remains unchanged.

## Validation

- `mvn -B -f VotingPlugin/pom.xml package` passed on the final tree before the single clean commit was published.
- Java CI with Maven #407 passed on final head `7dadd1d812`.

AI disclosure: This pull request was created with assistance from ChatGPT.