### PR TITLE
Reduce unnecessary Maven repository lookups

### DIFF
--- a/VotingPlugin/pom.xml
+++ b/VotingPlugin/pom.xml
@@ -206,20 +206,25 @@
     </build>
     <repositories>
         <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>maven-central</id>
-            <url>https://oss.sonatype.org/content/groups/public</url>
-        </repository>
-        <repository>
-            <id>bungeecord-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>velocity</id>
             <url>https://nexus.velocitypowered.com/repository/maven-public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>bencodez repo</id>
@@ -236,10 +241,16 @@
             <id>placeholderapi</id>
             <url>
                 https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>scarsz</id>
             <url>https://nexus.scarsz.me/content/groups/public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
## Summary
- replace the obsolete `oss.sonatype.org/content/groups/public` pseudo-central repository with real Maven Central and put it first
- remove the remaining `oss.sonatype.org` BungeeCord snapshot repository
- make the Spigot repository snapshot-only so normal release dependencies are not probed there
- disable snapshot resolution for Velocity, PlaceholderAPI, and Scarsz
- keep BenCodez snapshot resolution available for `advancedcore`

## Why
Both Jenkins and GitHub Actions stalled during Maven dependency resolution, which rules out a Jenkins-only failure.

The GitHub Actions log showed the Spigot snapshot resolving successfully, then Maven repeatedly probing custom repositories for ordinary release dependencies such as Guava, Gson, BungeeCord transitive artifacts, and Netty. The captured run eventually stopped while requesting `io.netty:netty-parent:4.2.3.Final` from the legacy `oss.sonatype.org` BungeeCord repository.

This change narrows each repository to the artifact type it actually needs and lets normal release dependencies resolve from Maven Central first. It does not assume the original Jenkins network was healthy; it removes avoidable dependency on unrelated/legacy repositories that can stall otherwise valid builds.

AdvancedCore had completed successfully shortly before the VotingPlugin stalls, including uploads to the BenCodez Nexus, so the BenCodez repository itself was responding during the incident.