### PR TITLE
Clean up generated command comments

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandAdminVote.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandAdminVote.java
@@ -8,30 +8,14 @@ import com.bencodez.advancedcore.api.command.CommandHandler;
 import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.votingplugin.VotingPluginMain;
 
-// TODO: Auto-generated Javadoc
-/**
- * The Class CommandAdminVote.
- */
 public class CommandAdminVote implements CommandExecutor {
 
 	private VotingPluginMain plugin;
 
-	/**
-	 * Constructs a new CommandAdminVote instance.
-	 *
-	 * @param plugin the main plugin instance
-	 */
 	public CommandAdminVote(VotingPluginMain plugin) {
 		this.plugin = plugin;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.bukkit.command.CommandExecutor#onCommand(org.bukkit.command.
-	 * CommandSender , org.bukkit.command.Command, java.lang.String,
-	 * java.lang.String[])
-	 */
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 		for (CommandHandler commandHandler : plugin.getAdminVoteCommand()) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandAliases.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandAliases.java
@@ -11,38 +11,19 @@ import com.bencodez.simpleapi.array.ArrayUtils;
 import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.votingplugin.VotingPluginMain;
 
-// TODO: Auto-generated Javadoc
-/**
- * The Class CommandAliases.
- */
 public class CommandAliases implements CommandExecutor {
 
 	private boolean adminCommand;
 
-	/** The cmd handle. */
 	private CommandHandler cmdHandle;
 
-	/** The plugin. */
 	private VotingPluginMain plugin = VotingPluginMain.plugin;
 
-	/**
-	 * Constructs a new CommandAliases instance.
-	 *
-	 * @param cmdHandle the command handler
-	 * @param adminCommand whether this is an admin command
-	 */
 	public CommandAliases(CommandHandler cmdHandle, boolean adminCommand) {
 		this.cmdHandle = cmdHandle;
 		this.adminCommand = adminCommand;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.bukkit.command.CommandExecutor#onCommand(org.bukkit.command.
-	 * CommandSender , org.bukkit.command.Command, java.lang.String,
-	 * java.lang.String[])
-	 */
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 
@@ -88,12 +69,6 @@ public class CommandAliases implements CommandExecutor {
 				}
 			}
 		}
-
-		/*
-		 * for (String arg : cmdHandle.getArgs()[0].split("&")) { argsNew.set(0, arg);
-		 * if (cmdHandle.runCommand(sender, Utils.getInstance().convertArray(argsNew)))
-		 * { plugin.debug( "cmd found, ran cmd"); return true; } }
-		 */
 
 		// invalid command
 		if (adminCommand) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandVote.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/executers/CommandVote.java
@@ -8,49 +8,23 @@ import com.bencodez.advancedcore.api.command.CommandHandler;
 import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.votingplugin.VotingPluginMain;
 
-// TODO: Auto-generated Javadoc
-/**
- * The Class CommandVote.
- */
 public class CommandVote implements CommandExecutor {
 
-	/** The instance. */
 	private static CommandVote instance = new CommandVote();
 
-	/** The plugin. */
 	private static VotingPluginMain plugin;
 
-	/**
-	 * Gets the single instance of CommandVote.
-	 *
-	 * @return single instance of CommandVote
-	 */
 	public static CommandVote getInstance() {
 		return instance;
 	}
 
-	/**
-	 * Instantiates a new command vote.
-	 */
 	private CommandVote() {
 	}
 
-	/**
-	 * Instantiates a new command vote.
-	 *
-	 * @param plugin the plugin
-	 */
 	public CommandVote(VotingPluginMain plugin) {
 		CommandVote.plugin = plugin;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.bukkit.command.CommandExecutor#onCommand(org.bukkit.command.
-	 * CommandSender , org.bukkit.command.Command, java.lang.String,
-	 * java.lang.String[])
-	 */
 	@Override
 	public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/tabcompleter/VoteTabCompleter.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/tabcompleter/VoteTabCompleter.java
@@ -14,22 +14,10 @@ import com.bencodez.advancedcore.api.command.AdvancedCoreTabCompleteHandler;
 import com.bencodez.simpleapi.messages.MessageAPI;
 import com.bencodez.votingplugin.VotingPluginMain;
 
-// TODO: Auto-generated Javadoc
-/**
- * The Class VoteTabCompleter.
- */
 public class VoteTabCompleter implements TabCompleter {
 
-	/** The plugin. */
 	VotingPluginMain plugin = VotingPluginMain.plugin;
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see org.bukkit.command.TabCompleter#onTabComplete(org.bukkit.command.
-	 * CommandSender, org.bukkit.command.Command, java.lang.String,
-	 * java.lang.String[])
-	 */
 	@Override
 	public List<String> onTabComplete(CommandSender sender, Command cmd, String alias, String[] args) {
 


### PR DESCRIPTION
Removes stale IDE-generated and redundant comments from the command execution path without changing behavior.

Cleanup includes:
- `TODO: Auto-generated Javadoc` markers
- `The Class ...` boilerplate
- generated `non-Javadoc` blocks
- trivial field/constructor comments that only restate the code
- an obsolete commented-out implementation block in `CommandAliases`

No executable behavior is intentionally changed.