### PR TITLE
Split VoteSiteManager responsibilities

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteFactory.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteFactory.java
@@ -1,0 +1,39 @@
+package com.bencodez.votingplugin.votesites;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
+
+/**
+ * Handles vote-site creation and config generation.
+ */
+public class VoteSiteFactory {
+
+	private final VotingPluginMain plugin;
+	private final VoteSiteResolver resolver;
+	private final VoteSiteValidator validator;
+
+	public VoteSiteFactory(VotingPluginMain plugin, VoteSiteResolver resolver, VoteSiteValidator validator) {
+		this.plugin = plugin;
+		this.resolver = resolver;
+		this.validator = validator;
+	}
+
+	public VoteSite createIfAllowed(String siteName) {
+		if (!plugin.getConfigFile().isAutoCreateVoteSites() || resolver.hasVoteSite(siteName)
+				|| resolver.hasConfiguredVoteSite(siteName)) {
+			return null;
+		}
+
+		if (!ServiceSiteValidator.isValid(siteName)) {
+			plugin.getLogger().warning("Unable to auto-create vote site with unsupported name '"
+					+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
+			return null;
+		}
+
+		if (!plugin.getConfigVoteSites().tryGenerateVoteSite(siteName)) {
+			return null;
+		}
+
+		return new VoteSite(plugin, validator.normalizeVoteSiteKey(siteName));
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
@@ -7,29 +7,31 @@ import java.util.List;
 import com.bencodez.votingplugin.VotingPluginMain;
 
 import lombok.Getter;
-import lombok.Setter;
 
 public class VoteSiteManager {
 
 	@Getter
-	@Setter
 	private VotingPluginMain plugin;
 
 	@Getter
 	private final VoteSiteRegistry registry;
 
 	@Getter
-	private final VoteSiteValidator validator;
+	private VoteSiteValidator validator;
 
 	@Getter
-	private final VoteSiteResolver resolver;
+	private VoteSiteResolver resolver;
 
 	@Getter
-	private final VoteSiteFactory factory;
+	private VoteSiteFactory factory;
 
 	public VoteSiteManager(VotingPluginMain plugin) {
-		this.plugin = plugin;
 		registry = new VoteSiteRegistry();
+		setPlugin(plugin);
+	}
+
+	public void setPlugin(VotingPluginMain plugin) {
+		this.plugin = plugin;
 		validator = new VoteSiteValidator(plugin);
 		resolver = new VoteSiteResolver(plugin, registry, validator);
 		factory = new VoteSiteFactory(plugin, resolver, validator);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteManager.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.bencodez.votingplugin.VotingPluginMain;
-import com.bencodez.votingplugin.util.ServiceSiteValidator;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -17,11 +16,23 @@ public class VoteSiteManager {
 	private VotingPluginMain plugin;
 
 	@Getter
-	@Setter
-	private List<VoteSite> voteSites = Collections.synchronizedList(new ArrayList<VoteSite>());
+	private final VoteSiteRegistry registry;
+
+	@Getter
+	private final VoteSiteValidator validator;
+
+	@Getter
+	private final VoteSiteResolver resolver;
+
+	@Getter
+	private final VoteSiteFactory factory;
 
 	public VoteSiteManager(VotingPluginMain plugin) {
 		this.plugin = plugin;
+		registry = new VoteSiteRegistry();
+		validator = new VoteSiteValidator(plugin);
+		resolver = new VoteSiteResolver(plugin, registry, validator);
+		factory = new VoteSiteFactory(plugin, resolver, validator);
 	}
 
 	/**
@@ -36,281 +47,90 @@ public class VoteSiteManager {
 		newSites.addAll(plugin.getConfigVoteSites().getVoteSitesLoad());
 
 		for (VoteSite site : newSites) {
-			validateVoteSiteName(site.getKey());
+			validator.validateVoteSiteName(site.getKey());
 		}
 
-		voteSites = newSites;
+		registry.setVoteSites(newSites);
 
-		if (voteSites.isEmpty()) {
+		if (registry.getVoteSites().isEmpty()) {
 			plugin.getLogger().warning("Detected no voting sites, this may mean something isn't properly setup");
 		}
 
 		plugin.debug("Loaded VoteSites");
-		return voteSites;
+		return registry.getVoteSites();
+	}
+
+	public List<VoteSite> getVoteSites() {
+		return registry.getVoteSites();
 	}
 
 	/**
-	 * Validates a vote site name for common problems.
+	 * Kept for API compatibility. New code should prefer the registry directly.
 	 *
-	 * @param siteName the site name
+	 * @param voteSites the loaded vote sites
 	 */
+	public void setVoteSites(List<VoteSite> voteSites) {
+		registry.setVoteSites(voteSites);
+	}
+
 	public void validateVoteSiteName(String siteName) {
-		if (siteName == null) {
-			return;
-		}
-
-		if (siteName.equalsIgnoreCase("null")) {
-			plugin.getLogger().warning("Vote site name 'null' is not valid");
-			return;
-		}
-
-		if (siteName.contains(" ")) {
-			plugin.getLogger().warning("Vote site " + siteName + " contains spaces, this may cause issues");
-		}
+		validator.validateVoteSiteName(siteName);
 	}
 
-	/**
-	 * Normalizes a vote site key for generated or matched site names.
-	 *
-	 * @param name the input name
-	 * @return the normalized vote site key
-	 */
 	public String normalizeVoteSiteKey(String name) {
-		if (name == null) {
-			return null;
-		}
-		return name.replaceAll("[\\.\\s]+", "_");
+		return validator.normalizeVoteSiteKey(name);
 	}
 
-	/**
-	 * Resolves identifiers against every configured vote-site section, including
-	 * disabled sites.
-	 *
-	 * @param identifiers vote-site keys, service sites, or display names
-	 * @return the configured vote-site key, or null when no configuration matches
-	 */
-	private String getConfiguredVoteSiteName(String... identifiers) {
-		if (identifiers == null) {
-			return null;
-		}
-
-		ArrayList<String> configuredSites = plugin.getConfigVoteSites().getRawVoteSiteNames();
-		if (configuredSites == null || configuredSites.isEmpty()) {
-			return null;
-		}
-
-		for (String identifier : identifiers) {
-			if (identifier == null || identifier.isEmpty()) {
-				continue;
-			}
-
-			String normalizedIdentifier = normalizeVoteSiteKey(identifier);
-			for (String siteName : configuredSites) {
-				if (siteName == null) {
-					continue;
-				}
-
-				String serviceSite = plugin.getConfigVoteSites().getServiceSite(siteName);
-				String displayName = plugin.getConfigVoteSites().getDisplayName(siteName);
-				if (siteName.equalsIgnoreCase(identifier) || siteName.equalsIgnoreCase(normalizedIdentifier)
-						|| (serviceSite != null && !serviceSite.isEmpty()
-								&& serviceSite.equalsIgnoreCase(identifier))
-						|| (displayName != null && !displayName.isEmpty()
-								&& displayName.equalsIgnoreCase(identifier))) {
-					return siteName;
-				}
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Checks whether an identifier belongs to any configured vote site, including
-	 * a disabled site.
-	 *
-	 * @param identifiers vote-site identifiers
-	 * @return true when a configured vote-site section matches
-	 */
 	public boolean hasConfiguredVoteSite(String... identifiers) {
-		return getConfiguredVoteSiteName(identifiers) != null;
+		return resolver.hasConfiguredVoteSite(identifiers);
 	}
 
-	/**
-	 * Attempts to map a URL, display name, or key to the configured vote site key.
-	 *
-	 * @param checkEnabled whether to only consider enabled vote sites
-	 * @param urls one or more identifiers to resolve
-	 * @return the resolved vote site key, or the first provided value if no match is
-	 *         found
-	 */
 	public String getVoteSiteName(boolean checkEnabled, String... urls) {
-		if (urls == null) {
-			return null;
-		}
-
-		for (String url : urls) {
-			if (url == null) {
-				return null;
-			}
-
-			if (!url.isEmpty()) {
-				for (VoteSite site : voteSites) {
-					if (checkEnabled && !site.isEnabled()) {
-						continue;
-					}
-
-					String serviceSite = site.getServiceSite();
-					if (serviceSite != null && serviceSite.equalsIgnoreCase(url)) {
-						return site.getKey();
-					}
-
-					if (site.getKey().equalsIgnoreCase(url)) {
-						return site.getKey();
-					}
-
-					String displayName = site.getDisplayName();
-					if (displayName != null && displayName.equalsIgnoreCase(url)) {
-						return site.getKey();
-					}
-				}
-			}
-		}
-
-		if (!checkEnabled) {
-			String configuredSiteName = getConfiguredVoteSiteName(urls);
-			if (configuredSiteName != null) {
-				return configuredSiteName;
-			}
-		}
-
-		for (String url : urls) {
-			return url;
-		}
-
-		return "";
+		return resolver.getVoteSiteName(checkEnabled, urls);
 	}
 
 	/**
-	 * Resolves a VoteSite from an identifier.
+	 * Resolves an already-loaded vote site without creating configuration.
 	 *
 	 * @param site the site identifier
 	 * @param checkEnabled whether to only match enabled sites
-	 * @return the vote site, or null if not found
+	 * @return the loaded vote site, or null when none matches
 	 */
-	public VoteSite getVoteSite(String site, boolean checkEnabled) {
-		String siteName = getVoteSiteName(checkEnabled, site);
-
-		for (VoteSite voteSite : getVoteSites()) {
-			if (voteSite.getKey().equalsIgnoreCase(siteName)) {
-				return voteSite;
-			}
-
-			String displayName = voteSite.getDisplayName();
-			if (displayName != null && displayName.equalsIgnoreCase(siteName)) {
-				return voteSite;
-			}
-		}
-
-		if (plugin.getConfigFile().isAutoCreateVoteSites() && !hasVoteSite(siteName)
-				&& !hasConfiguredVoteSite(siteName)) {
-			if (!ServiceSiteValidator.isValid(siteName)) {
-				plugin.getLogger().warning("Unable to auto-create vote site with unsupported name '"
-						+ ServiceSiteValidator.sanitizeForLog(siteName) + "'");
-				return null;
-			}
-			if (!plugin.getConfigVoteSites().tryGenerateVoteSite(siteName)) {
-				return null;
-			}
-			return new VoteSite(plugin, normalizeVoteSiteKey(siteName));
-		}
-
-		return null;
+	public VoteSite resolveVoteSite(String site, boolean checkEnabled) {
+		return resolver.resolveVoteSite(site, checkEnabled);
 	}
 
 	/**
-	 * Gets all enabled vote sites.
-	 *
-	 * @return the enabled vote sites
-	 */
-	public ArrayList<VoteSite> getVoteSitesEnabled() {
-		ArrayList<VoteSite> sites = new ArrayList<VoteSite>();
-
-		for (VoteSite site : getVoteSites()) {
-			if (site.isEnabled()) {
-				sites.add(site);
-			}
-		}
-
-		return sites;
-	}
-
-	/**
-	 * Converts an input name or key into the configured service site if possible.
-	 *
-	 * @param name the input name
-	 * @return the service site, or the original input if no mapping exists
-	 */
-	public String getVoteSiteServiceSite(String name) {
-		if (name == null) {
-			return null;
-		}
-
-		for (VoteSite site : voteSites) {
-			if (!site.isEnabled()) {
-				continue;
-			}
-
-			String url = site.getServiceSite();
-			if (url != null) {
-				if (url.equalsIgnoreCase(name) || name.equalsIgnoreCase(site.getKey())) {
-					return url;
-				}
-			}
-		}
-
-		return name;
-	}
-
-	/**
-	 * Checks whether a vote site exists.
+	 * Resolves a vote site and preserves the legacy auto-create behavior when no
+	 * loaded site matches.
 	 *
 	 * @param site the site identifier
-	 * @return true if the vote site exists
+	 * @param checkEnabled whether to only match enabled sites
+	 * @return the vote site, or null if not found or created
 	 */
-	public boolean hasVoteSite(String site) {
-		String siteName = getVoteSiteName(false, site);
-		if (siteName == null) {
-			return false;
+	public VoteSite getVoteSite(String site, boolean checkEnabled) {
+		VoteSite voteSite = resolver.resolveVoteSite(site, checkEnabled);
+		if (voteSite != null) {
+			return voteSite;
 		}
 
-		for (VoteSite voteSite : getVoteSites()) {
-			if (voteSite.getKey().equalsIgnoreCase(siteName)) {
-				return true;
-			}
-
-			String displayName = voteSite.getDisplayName();
-			if (displayName != null && displayName.equalsIgnoreCase(siteName)) {
-				return true;
-			}
-		}
-
-		return false;
+		String siteName = resolver.getVoteSiteName(checkEnabled, site);
+		return factory.createIfAllowed(siteName);
 	}
 
-	/**
-	 * Checks whether a vote site key exists.
-	 *
-	 * @param voteSite the vote site key
-	 * @return true if it exists
-	 */
-	public boolean isVoteSite(String voteSite) {
-		for (VoteSite site : getVoteSites()) {
-			if (site.getKey().equalsIgnoreCase(voteSite)) {
-				return true;
-			}
-		}
+	public ArrayList<VoteSite> getVoteSitesEnabled() {
+		return registry.getEnabledVoteSites();
+	}
 
-		return false;
+	public String getVoteSiteServiceSite(String name) {
+		return resolver.getVoteSiteServiceSite(name);
+	}
+
+	public boolean hasVoteSite(String site) {
+		return resolver.hasVoteSite(site);
+	}
+
+	public boolean isVoteSite(String voteSite) {
+		return resolver.isVoteSite(voteSite);
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteRegistry.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteRegistry.java
@@ -1,0 +1,35 @@
+package com.bencodez.votingplugin.votesites;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Owns the currently loaded vote sites.
+ */
+public class VoteSiteRegistry {
+
+	private List<VoteSite> voteSites = Collections.synchronizedList(new ArrayList<VoteSite>());
+
+	public List<VoteSite> getVoteSites() {
+		return voteSites;
+	}
+
+	public void setVoteSites(List<VoteSite> voteSites) {
+		if (voteSites == null) {
+			this.voteSites = Collections.synchronizedList(new ArrayList<VoteSite>());
+			return;
+		}
+		this.voteSites = voteSites;
+	}
+
+	public ArrayList<VoteSite> getEnabledVoteSites() {
+		ArrayList<VoteSite> sites = new ArrayList<VoteSite>();
+		for (VoteSite site : voteSites) {
+			if (site.isEnabled()) {
+				sites.add(site);
+			}
+		}
+		return sites;
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteResolver.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteResolver.java
@@ -1,0 +1,158 @@
+package com.bencodez.votingplugin.votesites;
+
+import java.util.ArrayList;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+
+/**
+ * Resolves vote-site identifiers without mutating configuration.
+ */
+public class VoteSiteResolver {
+
+	private final VotingPluginMain plugin;
+	private final VoteSiteRegistry registry;
+	private final VoteSiteValidator validator;
+
+	public VoteSiteResolver(VotingPluginMain plugin, VoteSiteRegistry registry, VoteSiteValidator validator) {
+		this.plugin = plugin;
+		this.registry = registry;
+		this.validator = validator;
+	}
+
+	public String getConfiguredVoteSiteName(String... identifiers) {
+		if (identifiers == null) {
+			return null;
+		}
+
+		ArrayList<String> configuredSites = plugin.getConfigVoteSites().getRawVoteSiteNames();
+		if (configuredSites == null || configuredSites.isEmpty()) {
+			return null;
+		}
+
+		for (String identifier : identifiers) {
+			if (identifier == null || identifier.isEmpty()) {
+				continue;
+			}
+
+			String normalizedIdentifier = validator.normalizeVoteSiteKey(identifier);
+			for (String siteName : configuredSites) {
+				if (siteName == null) {
+					continue;
+				}
+
+				String serviceSite = plugin.getConfigVoteSites().getServiceSite(siteName);
+				String displayName = plugin.getConfigVoteSites().getDisplayName(siteName);
+				if (siteName.equalsIgnoreCase(identifier) || siteName.equalsIgnoreCase(normalizedIdentifier)
+						|| (serviceSite != null && !serviceSite.isEmpty() && serviceSite.equalsIgnoreCase(identifier))
+						|| (displayName != null && !displayName.isEmpty() && displayName.equalsIgnoreCase(identifier))) {
+					return siteName;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	public boolean hasConfiguredVoteSite(String... identifiers) {
+		return getConfiguredVoteSiteName(identifiers) != null;
+	}
+
+	public String getVoteSiteName(boolean checkEnabled, String... identifiers) {
+		if (identifiers == null) {
+			return null;
+		}
+
+		for (String identifier : identifiers) {
+			if (identifier == null) {
+				return null;
+			}
+
+			if (!identifier.isEmpty()) {
+				for (VoteSite site : registry.getVoteSites()) {
+					if (checkEnabled && !site.isEnabled()) {
+						continue;
+					}
+
+					String serviceSite = site.getServiceSite();
+					if (serviceSite != null && serviceSite.equalsIgnoreCase(identifier)) {
+						return site.getKey();
+					}
+					if (site.getKey().equalsIgnoreCase(identifier)) {
+						return site.getKey();
+					}
+					String displayName = site.getDisplayName();
+					if (displayName != null && displayName.equalsIgnoreCase(identifier)) {
+						return site.getKey();
+					}
+				}
+			}
+		}
+
+		if (!checkEnabled) {
+			String configuredSiteName = getConfiguredVoteSiteName(identifiers);
+			if (configuredSiteName != null) {
+				return configuredSiteName;
+			}
+		}
+
+		for (String identifier : identifiers) {
+			return identifier;
+		}
+
+		return "";
+	}
+
+	public VoteSite resolveVoteSite(String identifier, boolean checkEnabled) {
+		String siteName = getVoteSiteName(checkEnabled, identifier);
+		if (siteName == null) {
+			return null;
+		}
+
+		for (VoteSite voteSite : registry.getVoteSites()) {
+			if (voteSite.getKey().equalsIgnoreCase(siteName)) {
+				return voteSite;
+			}
+
+			String displayName = voteSite.getDisplayName();
+			if (displayName != null && displayName.equalsIgnoreCase(siteName)) {
+				return voteSite;
+			}
+		}
+		return null;
+	}
+
+	public String getVoteSiteServiceSite(String name) {
+		if (name == null) {
+			return null;
+		}
+
+		for (VoteSite site : registry.getVoteSites()) {
+			if (!site.isEnabled()) {
+				continue;
+			}
+
+			String serviceSite = site.getServiceSite();
+			if (serviceSite != null
+					&& (serviceSite.equalsIgnoreCase(name) || name.equalsIgnoreCase(site.getKey()))) {
+				return serviceSite;
+			}
+		}
+		return name;
+	}
+
+	public boolean hasVoteSite(String site) {
+		return resolveVoteSite(site, false) != null;
+	}
+
+	public boolean isVoteSite(String voteSite) {
+		if (voteSite == null) {
+			return false;
+		}
+		for (VoteSite site : registry.getVoteSites()) {
+			if (site.getKey().equalsIgnoreCase(voteSite)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteResolver.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteResolver.java
@@ -109,6 +109,10 @@ public class VoteSiteResolver {
 		}
 
 		for (VoteSite voteSite : registry.getVoteSites()) {
+			if (checkEnabled && !voteSite.isEnabled()) {
+				continue;
+			}
+
 			if (voteSite.getKey().equalsIgnoreCase(siteName)) {
 				return voteSite;
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteValidator.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votesites/VoteSiteValidator.java
@@ -1,0 +1,37 @@
+package com.bencodez.votingplugin.votesites;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+
+/**
+ * Handles vote-site key validation and normalization.
+ */
+public class VoteSiteValidator {
+
+	private final VotingPluginMain plugin;
+
+	public VoteSiteValidator(VotingPluginMain plugin) {
+		this.plugin = plugin;
+	}
+
+	public void validateVoteSiteName(String siteName) {
+		if (siteName == null) {
+			return;
+		}
+
+		if (siteName.equalsIgnoreCase("null")) {
+			plugin.getLogger().warning("Vote site name 'null' is not valid");
+			return;
+		}
+
+		if (siteName.contains(" ")) {
+			plugin.getLogger().warning("Vote site " + siteName + " contains spaces, this may cause issues");
+		}
+	}
+
+	public String normalizeVoteSiteKey(String name) {
+		if (name == null) {
+			return null;
+		}
+		return name.replaceAll("[\\.\\s]+", "_");
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteResolverTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteResolverTest.java
@@ -52,6 +52,19 @@ public class VoteSiteResolverTest {
 	}
 
 	@Test
+	public void testResolveDisabledLoadedSiteHonorsCheckEnabled() {
+		VoteSite site = mock(VoteSite.class);
+		when(site.getKey()).thenReturn("DisabledSite");
+		when(site.getDisplayName()).thenReturn("Disabled Site");
+		when(site.isEnabled()).thenReturn(false);
+		registry.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>(Arrays.asList(site))));
+
+		assertNull(resolver.resolveVoteSite("DisabledSite", true));
+		assertNull(resolver.resolveVoteSite("Disabled Site", true));
+		assertSame(site, resolver.resolveVoteSite("DisabledSite", false));
+	}
+
+	@Test
 	public void testConfiguredDisabledSiteCanResolveNameWithoutCreating() {
 		when(config.getRawVoteSiteNames()).thenReturn(new ArrayList<String>(Arrays.asList("DisabledSite")));
 		when(config.getServiceSite("DisabledSite")).thenReturn("disabled.example.com");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteResolverTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votesite/VoteSiteResolverTest.java
@@ -1,0 +1,69 @@
+package com.bencodez.votingplugin.tests.votesite;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.config.ConfigVoteSites;
+import com.bencodez.votingplugin.votesites.VoteSite;
+import com.bencodez.votingplugin.votesites.VoteSiteRegistry;
+import com.bencodez.votingplugin.votesites.VoteSiteResolver;
+import com.bencodez.votingplugin.votesites.VoteSiteValidator;
+
+public class VoteSiteResolverTest {
+
+	private ConfigVoteSites config;
+	private VoteSiteRegistry registry;
+	private VoteSiteResolver resolver;
+
+	@BeforeEach
+	public void setUp() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class);
+		config = mock(ConfigVoteSites.class);
+		when(plugin.getConfigVoteSites()).thenReturn(config);
+
+		registry = new VoteSiteRegistry();
+		resolver = new VoteSiteResolver(plugin, registry, new VoteSiteValidator(plugin));
+	}
+
+	@Test
+	public void testResolveLoadedSiteByServiceSite() {
+		VoteSite site = mock(VoteSite.class);
+		when(site.getKey()).thenReturn("TopSite");
+		when(site.getDisplayName()).thenReturn("Top Site");
+		when(site.getServiceSite()).thenReturn("minecraftservers.org");
+		when(site.isEnabled()).thenReturn(true);
+		registry.setVoteSites(Collections.synchronizedList(new ArrayList<VoteSite>(Arrays.asList(site))));
+
+		assertSame(site, resolver.resolveVoteSite("minecraftservers.org", true));
+	}
+
+	@Test
+	public void testConfiguredDisabledSiteCanResolveNameWithoutCreating() {
+		when(config.getRawVoteSiteNames()).thenReturn(new ArrayList<String>(Arrays.asList("DisabledSite")));
+		when(config.getServiceSite("DisabledSite")).thenReturn("disabled.example.com");
+		when(config.getDisplayName("DisabledSite")).thenReturn("Disabled Site");
+
+		assertEquals("DisabledSite", resolver.getVoteSiteName(false, "disabled.example.com"));
+		verify(config, never()).tryGenerateVoteSite(anyString());
+	}
+
+	@Test
+	public void testResolveMissingSiteNeverGeneratesConfig() {
+		assertNull(resolver.resolveVoteSite("new.site", false));
+		verify(config, never()).tryGenerateVoteSite(anyString());
+	}
+}


### PR DESCRIPTION
Refactors `VoteSiteManager` into focused vote-site components while preserving the existing manager API and auto-create behavior.

Changes:
- add `VoteSiteRegistry` for loaded site ownership/filtering
- add `VoteSiteResolver` for side-effect-free key/display/service-site resolution
- add `VoteSiteFactory` for auto-generation/creation only
- add `VoteSiteValidator` for name validation and normalization
- keep `VoteSiteManager` as the compatibility-facing coordinator
- preserve `setPlugin(...)` behavior by rebuilding plugin-bound components without losing the registry
- add resolver tests proving missing/configured lookups do not generate config

`VoteSiteManager#getVoteSite(...)` intentionally keeps legacy auto-create semantics for compatibility; `resolveVoteSite(...)` is the new side-effect-free lookup path.