### PR TITLE
Extract top voter state from main plugin

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -101,6 +101,7 @@ import com.bencodez.votingplugin.timequeue.TimeQueueHandler;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.topvoter.TopVoterHandler;
 import com.bencodez.votingplugin.topvoter.TopVoterPlayer;
+import com.bencodez.votingplugin.topvoter.TopVoterState;
 import com.bencodez.votingplugin.updater.CheckUpdate;
 import com.bencodez.votingplugin.user.UserManager;
 import com.bencodez.votingplugin.user.VotingPluginUser;
@@ -172,13 +173,6 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private ShopFile shopFile;
 
 	@Getter
-	private LinkedHashMap<TopVoterPlayer, Integer> lastMonthTopVoter;
-
-	@Getter
-	@Setter
-	private LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters;
-
-	@Getter
 	private MVdWPlaceholders mvdwPlaceholders;
 
 	@Getter
@@ -210,11 +204,10 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private String time = "";
 
 	@Getter
-	@Setter
-	private LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoter;
+	private TopVoterHandler topVoterHandler;
 
 	@Getter
-	private TopVoterHandler topVoterHandler;
+	private TopVoterState topVoterState;
 
 	@Getter
 	@Setter
@@ -243,10 +236,6 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	@Getter
 	private VoteSiteManager voteSiteManager;
-
-	@Getter
-	@Setter
-	private LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> voteToday;
 
 	private boolean votifierLoaded = true;
 
@@ -295,9 +284,9 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 			if (getGui().isChestVoteTopUseSkull()) {
 				int maxToLoad = 200;
-				for (TopVoter top : topVoter.keySet()) {
+				for (TopVoter top : getTopVoter().keySet()) {
 					int num = 1;
-					Set<TopVoterPlayer> players = topVoter.get(top).keySet();
+					Set<TopVoterPlayer> players = getTopVoter().get(top).keySet();
 					for (TopVoterPlayer p : players) {
 						if (num <= maxToLoad) {
 							getSkullCacheHandler().addToCache(p.getUuid(), p.getPlayerName());
@@ -359,12 +348,37 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		return configFile.getData();
 	}
 
+	public LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> getTopVoter() {
+		return topVoterState.getTopVoters();
+	}
+
+	public void setTopVoter(LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoter) {
+		topVoterState.setTopVoters(topVoter);
+	}
+
 	public LinkedHashMap<TopVoterPlayer, Integer> getTopVoter(TopVoter top) {
-		LinkedHashMap<TopVoterPlayer, Integer> top1 = topVoter.get(top);
-		if (top1 == null) {
-			top1 = new LinkedHashMap<>();
-		}
-		return top1;
+		return topVoterState.getTopVoters(top);
+	}
+
+	public LinkedHashMap<TopVoterPlayer, Integer> getLastMonthTopVoter() {
+		return topVoterState.getLastMonthTopVoters();
+	}
+
+	public LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> getPreviousMonthsTopVoters() {
+		return topVoterState.getPreviousMonthsTopVoters();
+	}
+
+	public void setPreviousMonthsTopVoters(
+			LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters) {
+		topVoterState.setPreviousMonthsTopVoters(previousMonthsTopVoters);
+	}
+
+	public LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> getVoteToday() {
+		return topVoterState.getVoteToday();
+	}
+
+	public void setVoteToday(LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> voteToday) {
+		topVoterState.setVoteToday(voteToday);
 	}
 
 	/**
@@ -1319,15 +1333,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			}
 		});
 
+		topVoterState = new TopVoterState();
 		topVoterHandler = new TopVoterHandler(this);
-		lastMonthTopVoter = new LinkedHashMap<>();
-		previousMonthsTopVoters = new LinkedHashMap<>();
-
-		topVoter = new LinkedHashMap<>();
-		for (TopVoter top : TopVoter.values()) {
-			topVoter.put(top, new LinkedHashMap<>());
-		}
-		voteToday = new LinkedHashMap<>();
 
 		new AdminGUI(this).loadHook();
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterState.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterState.java
@@ -1,16 +1,35 @@
 package com.bencodez.votingplugin.topvoter;
 
+import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+
+import com.bencodez.votingplugin.votesites.VoteSite;
 
 /**
  * Owns the mutable ranking state used by the top-voter subsystem.
  */
 public class TopVoterState {
 
-	private LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoters = new LinkedHashMap<>();
-	private LinkedHashMap<TopVoterPlayer, Integer> lastMonthTopVoters = new LinkedHashMap<>();
-	private LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters = new LinkedHashMap<>();
+	private LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoters;
+	private LinkedHashMap<TopVoterPlayer, Integer> lastMonthTopVoters;
+	private LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters;
+	private LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> voteToday;
+
+	public TopVoterState() {
+		reset();
+	}
+
+	public void reset() {
+		topVoters = new LinkedHashMap<>();
+		for (TopVoter topVoter : TopVoter.values()) {
+			topVoters.put(topVoter, new LinkedHashMap<>());
+		}
+		lastMonthTopVoters = new LinkedHashMap<>();
+		previousMonthsTopVoters = new LinkedHashMap<>();
+		voteToday = new LinkedHashMap<>();
+	}
 
 	public LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> getTopVoters() {
 		return topVoters;
@@ -40,5 +59,13 @@ public class TopVoterState {
 	public void setPreviousMonthsTopVoters(
 			LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters) {
 		this.previousMonthsTopVoters = previousMonthsTopVoters != null ? previousMonthsTopVoters : new LinkedHashMap<>();
+	}
+
+	public LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> getVoteToday() {
+		return voteToday;
+	}
+
+	public void setVoteToday(LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> voteToday) {
+		this.voteToday = voteToday != null ? voteToday : new LinkedHashMap<>();
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterState.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/topvoter/TopVoterState.java
@@ -1,0 +1,44 @@
+package com.bencodez.votingplugin.topvoter;
+
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
+
+/**
+ * Owns the mutable ranking state used by the top-voter subsystem.
+ */
+public class TopVoterState {
+
+	private LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoters = new LinkedHashMap<>();
+	private LinkedHashMap<TopVoterPlayer, Integer> lastMonthTopVoters = new LinkedHashMap<>();
+	private LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters = new LinkedHashMap<>();
+
+	public LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> getTopVoters() {
+		return topVoters;
+	}
+
+	public void setTopVoters(LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> topVoters) {
+		this.topVoters = topVoters != null ? topVoters : new LinkedHashMap<>();
+	}
+
+	public LinkedHashMap<TopVoterPlayer, Integer> getTopVoters(TopVoter topVoter) {
+		LinkedHashMap<TopVoterPlayer, Integer> result = topVoters.get(topVoter);
+		return result != null ? result : new LinkedHashMap<>();
+	}
+
+	public LinkedHashMap<TopVoterPlayer, Integer> getLastMonthTopVoters() {
+		return lastMonthTopVoters;
+	}
+
+	public void setLastMonthTopVoters(LinkedHashMap<TopVoterPlayer, Integer> lastMonthTopVoters) {
+		this.lastMonthTopVoters = lastMonthTopVoters != null ? lastMonthTopVoters : new LinkedHashMap<>();
+	}
+
+	public LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> getPreviousMonthsTopVoters() {
+		return previousMonthsTopVoters;
+	}
+
+	public void setPreviousMonthsTopVoters(
+			LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previousMonthsTopVoters) {
+		this.previousMonthsTopVoters = previousMonthsTopVoters != null ? previousMonthsTopVoters : new LinkedHashMap<>();
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/topvoter/TopVoterStateTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/topvoter/TopVoterStateTest.java
@@ -1,0 +1,56 @@
+package com.bencodez.votingplugin.tests.topvoter;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.YearMonth;
+import java.util.LinkedHashMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.topvoter.TopVoter;
+import com.bencodez.votingplugin.topvoter.TopVoterPlayer;
+import com.bencodez.votingplugin.topvoter.TopVoterState;
+
+public class TopVoterStateTest {
+
+	@Test
+	public void testDefaultsAreUsable() {
+		TopVoterState state = new TopVoterState();
+
+		assertNotNull(state.getTopVoters());
+		assertNotNull(state.getLastMonthTopVoters());
+		assertNotNull(state.getPreviousMonthsTopVoters());
+		assertTrue(state.getTopVoters(TopVoter.Monthly).isEmpty());
+	}
+
+	@Test
+	public void testStoresRankingMapsWithoutCopying() {
+		TopVoterState state = new TopVoterState();
+		LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> rankings = new LinkedHashMap<>();
+		LinkedHashMap<TopVoterPlayer, Integer> lastMonth = new LinkedHashMap<>();
+		LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previous = new LinkedHashMap<>();
+
+		state.setTopVoters(rankings);
+		state.setLastMonthTopVoters(lastMonth);
+		state.setPreviousMonthsTopVoters(previous);
+
+		assertSame(rankings, state.getTopVoters());
+		assertSame(lastMonth, state.getLastMonthTopVoters());
+		assertSame(previous, state.getPreviousMonthsTopVoters());
+	}
+
+	@Test
+	public void testNullAssignmentsResetToEmptyMaps() {
+		TopVoterState state = new TopVoterState();
+
+		state.setTopVoters(null);
+		state.setLastMonthTopVoters(null);
+		state.setPreviousMonthsTopVoters(null);
+
+		assertTrue(state.getTopVoters().isEmpty());
+		assertTrue(state.getLastMonthTopVoters().isEmpty());
+		assertTrue(state.getPreviousMonthsTopVoters().isEmpty());
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/topvoter/TopVoterStateTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/topvoter/TopVoterStateTest.java
@@ -1,10 +1,13 @@
 package com.bencodez.votingplugin.tests.topvoter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.topvoter.TopVoterPlayer;
 import com.bencodez.votingplugin.topvoter.TopVoterState;
+import com.bencodez.votingplugin.votesites.VoteSite;
 
 public class TopVoterStateTest {
 
@@ -22,23 +26,28 @@ public class TopVoterStateTest {
 		assertNotNull(state.getTopVoters());
 		assertNotNull(state.getLastMonthTopVoters());
 		assertNotNull(state.getPreviousMonthsTopVoters());
+		assertNotNull(state.getVoteToday());
+		assertEquals(TopVoter.values().length, state.getTopVoters().size());
 		assertTrue(state.getTopVoters(TopVoter.Monthly).isEmpty());
 	}
 
 	@Test
-	public void testStoresRankingMapsWithoutCopying() {
+	public void testStoresStateMapsWithoutCopying() {
 		TopVoterState state = new TopVoterState();
 		LinkedHashMap<TopVoter, LinkedHashMap<TopVoterPlayer, Integer>> rankings = new LinkedHashMap<>();
 		LinkedHashMap<TopVoterPlayer, Integer> lastMonth = new LinkedHashMap<>();
 		LinkedHashMap<YearMonth, LinkedHashMap<TopVoterPlayer, Integer>> previous = new LinkedHashMap<>();
+		LinkedHashMap<TopVoterPlayer, HashMap<VoteSite, LocalDateTime>> voteToday = new LinkedHashMap<>();
 
 		state.setTopVoters(rankings);
 		state.setLastMonthTopVoters(lastMonth);
 		state.setPreviousMonthsTopVoters(previous);
+		state.setVoteToday(voteToday);
 
 		assertSame(rankings, state.getTopVoters());
 		assertSame(lastMonth, state.getLastMonthTopVoters());
 		assertSame(previous, state.getPreviousMonthsTopVoters());
+		assertSame(voteToday, state.getVoteToday());
 	}
 
 	@Test
@@ -48,9 +57,11 @@ public class TopVoterStateTest {
 		state.setTopVoters(null);
 		state.setLastMonthTopVoters(null);
 		state.setPreviousMonthsTopVoters(null);
+		state.setVoteToday(null);
 
 		assertTrue(state.getTopVoters().isEmpty());
 		assertTrue(state.getLastMonthTopVoters().isEmpty());
 		assertTrue(state.getPreviousMonthsTopVoters().isEmpty());
+		assertTrue(state.getVoteToday().isEmpty());
 	}
 }


### PR DESCRIPTION
Moves mutable top-voter state out of individual fields on `VotingPluginMain` into a dedicated `TopVoterState` component.

Implemented:
- `TopVoterState` owns current rankings, last-month rankings, previous-month rankings, and today's vote timestamps
- `VotingPluginMain` no longer stores those four maps directly
- existing `VotingPluginMain` getter/setter APIs delegate to `TopVoterState` for compatibility with current internal/API callers
- startup creates `TopVoterState` before `TopVoterHandler`
- first-load skull preloading now reads the delegated top-voter state rather than a direct field
- background vote-today updates continue through the existing `setVoteToday(...)` API and now land in `TopVoterState`
- tests cover default category initialization, map identity, vote-today ownership, and null-safe assignments

Java CI with Maven passes.

Note: `VotingPluginMain.java` had CRLF line endings before this change; the GitHub connector normalized that edited file to LF, so GitHub displays more line churn than the logical code change.