### PR TITLE
Fix VoteShop hide-limit migration key

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ShopFile.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/ShopFile.java
@@ -82,7 +82,7 @@ public class ShopFile extends YMLFile {
 	public void convertFromGUIFile() {
 		setValue("VoteShop.Enabled", plugin.getGui().getData().getBoolean("CHEST.VoteShopEnabled"));
 		setValue("VoteShop.BackButton", plugin.getGui().getData().getBoolean("CHEST.VoteShopBackButton"));
-		setValue("VoteShop.HideLimitReached", plugin.getGui().getData().getBoolean("CHEST.VoteShopHideLimitedReached"));
+		setValue("VoteShop.HideLimitedReached", plugin.getGui().getData().getBoolean("CHEST.VoteShopHideLimitedReached"));
 		setValue("VoteShop.RequireConfirmation",
 				plugin.getGui().getData().getBoolean("CHEST.VoteShopRequireConfirmation"));
 		setValue("VoteShop.ReopenGUIOnPurchase",


### PR DESCRIPTION
Fixes the legacy GUI.yml -> Shop.yml VoteShop migration to write `VoteShop.HideLimitedReached`, matching the current Shop.yml key and `ShopFile` annotation. The migration has historically written `VoteShop.HideLimitReached`, so upgrades with the old GUI option disabled could silently fall back to the new Shop.yml default.

This is intentionally a one-line compatibility fix with no broader VoteShop refactor.