### PR TITLE
Add SSL/TLS support for Redis connections

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/transport/RedisBackendProxyTransport.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/transport/RedisBackendProxyTransport.java
@@ -23,7 +23,8 @@ public class RedisBackendProxyTransport implements BackendProxyTransport {
 	public void start(GlobalMessageHandler messageHandler) {
 		redisHandler = new RedisHandler(plugin.getBungeeSettings().getRedisHost(),
 				plugin.getBungeeSettings().getRedisPort(), plugin.getBungeeSettings().getRedisUsername(),
-				plugin.getBungeeSettings().getRedisPassword(), plugin.getBungeeSettings().getRedisdbindex()) {
+				plugin.getBungeeSettings().getRedisPassword(), plugin.getBungeeSettings().getRedisdbindex(),
+				plugin.getBungeeSettings().isRedisSsl()) {
 			@Override
 			public void debug(String message) {
 				if (plugin.getBungeeSettings().isBungeeDebug()) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/BungeeSettings.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/config/BungeeSettings.java
@@ -58,6 +58,10 @@ public class BungeeSettings extends YMLFile {
 	@Getter
 	private int redisPort = 6379;
 
+	@ConfigDataBoolean(path = "Redis.SSL")
+	@Getter
+	private boolean redisSsl = false;
+
 	@ConfigDataString(path = "MQTT.ClientID")
 	@Getter
 	private String mqttClientID = "";

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxy.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import javax.net.ssl.SSLParameters;
+
 import org.eclipse.paho.client.mqttv3.MqttException;
 
 import com.bencodez.advancedcore.api.time.TimeType;
@@ -1331,7 +1333,8 @@ public abstract class VotingPluginProxy {
 			}
 		} else if (method.equals(BungeeMethod.REDIS)) {
 			redisHandler = new RedisHandler(getConfig().getRedisHost(), getConfig().getRedisPort(),
-					getConfig().getRedisUsername(), getConfig().getRedisPassword(), getConfig().getRedisDbIndex()) {
+					getConfig().getRedisUsername(), getConfig().getRedisPassword(), getConfig().getRedisDbIndex(),
+					getConfig().getRedisSsl()) {
 
 				@Override
 				public void debug(String message) {
@@ -1339,7 +1342,7 @@ public abstract class VotingPluginProxy {
 				}
 			};
 			redisPublisherPool = new JedisPool(new HostAndPort(getConfig().getRedisHost(), getConfig().getRedisPort()),
-					buildRedisClientConfig());
+					buildRedisClientConfig(getConfig()));
 
 			runAsync(() -> {
 				RedisListener listener = redisHandler.createEnvelopeListener(
@@ -1782,6 +1785,11 @@ public abstract class VotingPluginProxy {
 			@Override
 			public int getMultiProxyRedisPort() {
 				return getConfig().getMultiProxyRedisPort();
+			}
+
+			@Override
+			public boolean getMultiProxyRedisSsl() {
+				return getConfig().getMultiProxyRedisSsl();
 			}
 
 			@Override
@@ -2498,14 +2506,20 @@ public abstract class VotingPluginProxy {
 		}
 	}
 
-	private DefaultJedisClientConfig buildRedisClientConfig() {
+	static DefaultJedisClientConfig buildRedisClientConfig(VotingPluginProxyConfig configSource) {
 		DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
-				.database(getConfig().getRedisDbIndex()).connectionTimeoutMillis(2000).socketTimeoutMillis(2000);
-		if (getConfig().getRedisUsername() != null && !getConfig().getRedisUsername().isEmpty()) {
-			config.user(getConfig().getRedisUsername());
+				.database(configSource.getRedisDbIndex()).ssl(configSource.getRedisSsl()).connectionTimeoutMillis(2000)
+				.socketTimeoutMillis(2000);
+		if (configSource.getRedisSsl()) {
+			SSLParameters sslParameters = new SSLParameters();
+			sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+			config.sslParameters(sslParameters);
 		}
-		if (getConfig().getRedisPassword() != null && !getConfig().getRedisPassword().isEmpty()) {
-			config.password(getConfig().getRedisPassword());
+		if (configSource.getRedisUsername() != null && !configSource.getRedisUsername().isEmpty()) {
+			config.user(configSource.getRedisUsername());
+		}
+		if (configSource.getRedisPassword() != null && !configSource.getRedisPassword().isEmpty()) {
+			config.password(configSource.getRedisPassword());
 		}
 		return config.build();
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxyConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/VotingPluginProxyConfig.java
@@ -266,6 +266,15 @@ public interface VotingPluginProxyConfig {
 	public int getMultiProxyRedisPort();
 
 	/**
+	 * Gets whether the multi-proxy Redis connection uses SSL/TLS.
+	 *
+	 * @return true if SSL/TLS is enabled
+	 */
+	default boolean getMultiProxyRedisSsl() {
+		return false;
+	}
+
+	/**
 	 * Gets whether multi-proxy Redis uses existing connection.
 	 *
 	 * @return true if using existing connection
@@ -370,6 +379,15 @@ public interface VotingPluginProxyConfig {
 	 * @return the Redis port
 	 */
 	public int getRedisPort();
+
+	/**
+	 * Gets whether the Redis connection uses SSL/TLS.
+	 *
+	 * @return true if SSL/TLS is enabled
+	 */
+	default boolean getRedisSsl() {
+		return false;
+	}
 
 	/**
 	 * Gets the Redis database index.

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
@@ -167,6 +167,11 @@ public class BungeeConfig implements VotingPluginProxyConfig {
 	}
 
 	@Override
+	public boolean getMultiProxyRedisSsl() {
+		return getData().getBoolean("MultiProxyRedis.SSL", false);
+	}
+
+	@Override
 	public int getMultiProxyRedisDbIndex() {
 		return getData().getInt("MultiProxyRedis.Db-Index", 0);
 	}
@@ -244,6 +249,11 @@ public class BungeeConfig implements VotingPluginProxyConfig {
 	@Override
 	public int getRedisPort() {
 		return getData().getInt("Redis.Port", 6379);
+	}
+
+	@Override
+	public boolean getRedisSsl() {
+		return getData().getBoolean("Redis.SSL", false);
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/multiproxy/MultiProxyHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/multiproxy/MultiProxyHandler.java
@@ -106,6 +106,13 @@ public abstract class MultiProxyHandler {
 	public abstract int getMultiProxyRedisPort();
 
 	/**
+	 * Gets whether the multi-proxy Redis connection uses SSL/TLS.
+	 *
+	 * @return true if SSL/TLS is enabled
+	 */
+	public abstract boolean getMultiProxyRedisSsl();
+
+	/**
 	 * Gets the multi-proxy Redis database index.
 	 *
 	 * @return the database index
@@ -286,7 +293,8 @@ public abstract class MultiProxyHandler {
 				multiProxyRedis = getRedisHandler();
 			} else {
 				multiProxyRedis = new RedisHandler(getMultiProxyRedisHost(), getMultiProxyRedisPort(),
-						getMultiProxyUsername(), getMultiProxyPassword(), getMultiProxyRedisDbIndex()) {
+						getMultiProxyUsername(), getMultiProxyPassword(), getMultiProxyRedisDbIndex(),
+						getMultiProxyRedisSsl()) {
 					@Override
 					public void debug(String message) {
 						if (getDebug()) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
@@ -147,6 +147,11 @@ public class VelocityConfig extends VelocityYMLFile implements VotingPluginProxy
 	}
 
 	@Override
+	public boolean getMultiProxyRedisSsl() {
+		return getBoolean(getNode("MultiProxyRedis", "SSL"), false);
+	}
+
+	@Override
 	public int getMultiProxyRedisDbIndex() {
 		return getInt(getNode("MultiProxyRedis", "Db-Index"), 0);
 	}
@@ -247,6 +252,11 @@ public class VelocityConfig extends VelocityYMLFile implements VotingPluginProxy
 	@Override
 	public int getRedisPort() {
 		return getInt(getNode("Redis", "Port"), 6379);
+	}
+
+	@Override
+	public boolean getRedisSsl() {
+		return getBoolean(getNode("Redis", "SSL"), false);
 	}
 
 	@Override

--- a/VotingPlugin/src/main/resources/BungeeSettings.yml
+++ b/VotingPlugin/src/main/resources/BungeeSettings.yml
@@ -72,6 +72,8 @@ BungeeMethod: PLUGINMESSAGING
 Redis:
   Host: localhost
   Port: 6379
+  # Enable SSL/TLS. The Redis certificate must be trusted by the Java runtime.
+  SSL: false
   # To get the user name, run redis-cli
   # If you set a password, run "auth <your password>"
   # If the output is "OK" run "ACL USERS"

--- a/VotingPlugin/src/main/resources/bungeeconfig.yml
+++ b/VotingPlugin/src/main/resources/bungeeconfig.yml
@@ -284,6 +284,8 @@ PluginMessageEncryption: false
 Redis:
   Host: localhost
   Port: 6379
+  # Enable SSL/TLS. The Redis certificate must be trusted by the Java runtime.
+  SSL: false
   Username: ''
   Password: ''
   # Set a prefix from an entire proxy network if using multi-proxy setup below
@@ -448,6 +450,8 @@ MultiProxyRedis:
   UseExistingConnection: false
   Host: localhost
   Port: 6379
+  # Ignored when UseExistingConnection is true; the Redis.SSL setting is used instead.
+  SSL: false
   Username: ''
   Password: ''
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/RedisClientConfigTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/RedisClientConfigTest.java
@@ -1,0 +1,34 @@
+package com.bencodez.votingplugin.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.DefaultJedisClientConfig;
+
+class RedisClientConfigTest {
+
+	@Test
+	void tlsCanBeEnabledForProxyPublisherConnections() {
+		VotingPluginProxyConfig config = mock(VotingPluginProxyConfig.class);
+		when(config.getRedisDbIndex()).thenReturn(2);
+		when(config.getRedisSsl()).thenReturn(true);
+
+		DefaultJedisClientConfig clientConfig = VotingPluginProxy.buildRedisClientConfig(config);
+
+		assertTrue(clientConfig.isSsl());
+		assertEquals(2, clientConfig.getDatabase());
+		assertEquals("HTTPS", clientConfig.getSslParameters().getEndpointIdentificationAlgorithm());
+	}
+
+	@Test
+	void tlsRemainsDisabledByDefault() {
+		VotingPluginProxyConfig config = mock(VotingPluginProxyConfig.class);
+
+		assertFalse(VotingPluginProxy.buildRedisClientConfig(config).isSsl());
+	}
+}


### PR DESCRIPTION
## Summary

- add opt-in `Redis.SSL` support for backend (Paper/Spigot), BungeeCord, and Velocity Redis connections
- apply TLS consistently to both Redis subscribers and the proxy's dedicated publisher pool
- add `MultiProxyRedis.SSL` for separate multi-proxy Redis connections
- preserve existing plaintext behavior by default
- validate Redis certificates with the JVM truststore and verify hostnames
- document the new settings in the bundled YAML configurations
- add unit coverage for TLS-enabled and default plaintext client configuration

## Configuration

```yaml
Redis:
  SSL: true
```

For a separate multi-proxy connection:

```yaml
MultiProxyRedis:
  SSL: true
```

When `MultiProxyRedis.UseExistingConnection` is `true`, the primary `Redis.SSL` value applies.

## Verification

- `mvn test` on Java 21: **297 tests passed**, 0 failures, 0 errors
- both YAML resource files parse successfully
- whitespace validation passed
- dynamic CodeQL analysis completed successfully

## Dependency

Depends on BenCodez/SimpleAPI#72. Merge and publish/rebuild that snapshot before building this PR.