### PR TITLE
Allow Bukkit backends to host VotingPlugin Control

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -168,6 +168,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private volatile HostedControlManager.HostConfiguration backendHostedControlConfiguration;
 	private volatile HostedControlManager backendHostedControlActiveManager;
 	private volatile HostedControlManager.HostConfiguration backendHostedControlActiveConfiguration;
+	private final Set<HostedControlManager> backendHostedControlManagers = java.util.concurrent.ConcurrentHashMap.newKeySet();
 	private final ExecutorService backendHostedControlLifecycle = Executors.newSingleThreadExecutor(runnable -> {
 		Thread thread = new Thread(runnable, "votingplugin-control-backend-host-lifecycle");
 		thread.setDaemon(true);
@@ -779,6 +780,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			backendHostedControlManager = HostedControlManager.create(getDataFolder().toPath(), configuration,
 					message -> getLogger().info("[Control Host] " + message));
 			backendHostedControlActiveManager = backendHostedControlManager;
+			if (backendHostedControlActiveManager != null) backendHostedControlManagers.add(backendHostedControlActiveManager);
 			if (backendHostedControlActiveManager != null) backendHostedControlActiveManager.start();
 		} catch (IllegalArgumentException e) {
 			backendHostedControlManager = null;
@@ -825,6 +827,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 					+ e.getMessage());
 			return;
 		}
+		if (replacement != null) backendHostedControlManagers.add(replacement);
 		backendHostedControlConfiguration = replacementConfiguration;
 		backendHostedControlManager = replacement;
 		try {
@@ -833,7 +836,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		} catch (RejectedExecutionException e) {
 			backendHostedControlConfiguration = backendHostedControlActiveConfiguration;
 			backendHostedControlManager = backendHostedControlActiveManager;
-			if (replacement != null) replacement.close();
+			closeBackendHostedControlManager(replacement, false);
 			getLogger().warning("[Control Host] Bukkit hosting settings require a server restart after lifecycle shutdown");
 		}
 	}
@@ -853,25 +856,27 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 								+ e.getMessage());
 					}
 				}
-				replacement.close();
+				closeBackendHostedControlManager(replacement, false);
 				return;
 			}
 		}
 		HostedControlManager previous;
+		HostedControlManager.HostConfiguration previousConfiguration;
 		synchronized (this) {
 			if (backendHostedControlStopping || backendHostedControlLifecycleFailed
 					|| backendHostedControlManager != replacement
 					|| !replacementConfiguration.equals(backendHostedControlConfiguration)) {
-				if (replacement != null) replacement.close();
+				closeBackendHostedControlManager(replacement, false);
 				return;
 			}
 			previous = backendHostedControlActiveManager;
+			previousConfiguration = backendHostedControlActiveConfiguration;
 		}
 		try {
-			if (previous != null) previous.closeAndWait();
+			closeBackendHostedControlManager(previous, true);
 		} catch (RuntimeException e) {
 			backendHostedControlLifecycleFailed = true;
-			if (replacement != null) replacement.close();
+			closeBackendHostedControlManager(replacement, false);
 			synchronized (this) {
 				if (backendHostedControlManager == replacement) {
 					backendHostedControlManager = previous;
@@ -884,38 +889,119 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			}
 			return;
 		}
+		if (backendHostedControlStopping) {
+			closeBackendHostedControlManager(replacement, false);
+			return;
+		}
+		boolean started;
+		try {
+			started = replacement == null || replacement.startAndWaitForInitialResult();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			closeBackendHostedControlManager(replacement, false);
+			return;
+		}
+		if (!started) {
+			try {
+				closeBackendHostedControlManager(replacement, true);
+			} catch (RuntimeException e) {
+				backendHostedControlLifecycleFailed = true;
+				getLogger().warning("[Control Host] Failed replacement could not be stopped; restoration is blocked");
+				debug(e);
+				return;
+			}
+			if (!backendHostedControlStopping) {
+				restoreBackendHostedControl(previousConfiguration, replacement, replacementConfiguration);
+			}
+			return;
+		}
 		synchronized (this) {
-			if (backendHostedControlActiveManager == previous) backendHostedControlActiveManager = null;
 			if (backendHostedControlStopping || backendHostedControlLifecycleFailed) {
-				if (replacement != null) replacement.close();
+				closeBackendHostedControlManager(replacement, false);
 				return;
 			}
 			backendHostedControlActiveManager = replacement;
 			backendHostedControlActiveConfiguration = replacementConfiguration;
-			if (replacement != null) replacement.start();
 		}
+	}
+
+	private void restoreBackendHostedControl(HostedControlManager.HostConfiguration previousConfiguration,
+			HostedControlManager failedReplacement,
+			HostedControlManager.HostConfiguration failedConfiguration) {
+		if (previousConfiguration == null) {
+			backendHostedControlLifecycleFailed = true;
+			getLogger().warning("[Control Host] Replacement failed and no previous hosted settings were available");
+			return;
+		}
+		HostedControlManager restored = null;
+		try {
+			restored = HostedControlManager.create(getDataFolder().toPath(), previousConfiguration,
+					message -> getLogger().info("[Control Host] " + message));
+			if (restored != null) backendHostedControlManagers.add(restored);
+			if (restored != null && !restored.startAndWaitForInitialResult()) {
+				closeBackendHostedControlManager(restored, true);
+				throw new IllegalStateException("the previous hosted settings did not become healthy");
+			}
+		} catch (Exception e) {
+			if (e instanceof InterruptedException) Thread.currentThread().interrupt();
+			if (restored != null) {
+				try {
+					closeBackendHostedControlManager(restored, false);
+				} catch (RuntimeException closeFailure) {
+					e.addSuppressed(closeFailure);
+				}
+			}
+			if (backendHostedControlStopping) return;
+			backendHostedControlLifecycleFailed = true;
+			getLogger().warning("[Control Host] Replacement failed and the previous host could not be restored: "
+					+ e.getMessage());
+			return;
+		}
+		synchronized (this) {
+			if (backendHostedControlStopping) {
+				closeBackendHostedControlManager(restored, false);
+				return;
+			}
+			backendHostedControlActiveManager = restored;
+			backendHostedControlActiveConfiguration = previousConfiguration;
+			if (backendHostedControlManager == failedReplacement
+					&& failedConfiguration.equals(backendHostedControlConfiguration)) {
+				backendHostedControlManager = restored;
+				backendHostedControlConfiguration = previousConfiguration;
+			}
+		}
+		getLogger().warning("[Control Host] Replacement did not become healthy; the previous host was restored");
+	}
+
+	private void closeBackendHostedControlManager(HostedControlManager manager, boolean waitForProcess) {
+		if (manager == null) return;
+		if (waitForProcess) manager.closeAndWait();
+		else manager.close();
+		backendHostedControlManagers.remove(manager);
 	}
 
 	private void stopBackendHostedControlLifecycle() {
 		backendHostedControlStopping = true;
+		backendHostedControlLifecycle.shutdownNow();
+		Set<HostedControlManager> managers = new java.util.HashSet<>(backendHostedControlManagers);
+		if (backendHostedControlActiveManager != null) managers.add(backendHostedControlActiveManager);
+		if (backendHostedControlManager != null) managers.add(backendHostedControlManager);
+		for (HostedControlManager manager : managers) {
+			try {
+				closeBackendHostedControlManager(manager, true);
+			} catch (RuntimeException e) {
+				getLogger().warning("[Control Host] A hosted process did not stop cleanly during unload");
+				debug(e);
+			}
+		}
+		backendHostedControlManager = null;
+		backendHostedControlActiveManager = null;
 		try {
-			backendHostedControlLifecycle.execute(() -> {
-				HostedControlManager active = backendHostedControlActiveManager;
-				HostedControlManager requested = backendHostedControlManager;
-				if (active != null) active.close();
-				if (requested != null && requested != active) requested.close();
-				backendHostedControlManager = null;
-				backendHostedControlActiveManager = null;
-			});
-		} catch (RejectedExecutionException e) {
-			HostedControlManager active = backendHostedControlActiveManager;
-			HostedControlManager requested = backendHostedControlManager;
-			if (active != null) active.close();
-			if (requested != null && requested != active) requested.close();
-			backendHostedControlManager = null;
-			backendHostedControlActiveManager = null;
-		} finally {
-			backendHostedControlLifecycle.shutdown();
+			if (!backendHostedControlLifecycle.awaitTermination(10, TimeUnit.SECONDS)) {
+				getLogger().warning("[Control Host] The hosted lifecycle worker did not stop during unload");
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -92,6 +92,7 @@ import com.bencodez.votingplugin.placeholders.MVdWPlaceholders;
 import com.bencodez.votingplugin.placeholders.PlaceHolders;
 import com.bencodez.votingplugin.placeholders.VotingPluginExpansion;
 import com.bencodez.votingplugin.presets.VoteSitePresetSetupHandler;
+import com.bencodez.votingplugin.proxy.control.HostedControlManager;
 import com.bencodez.votingplugin.rewards.VotingPluginRewardRegistrar;
 import com.bencodez.votingplugin.servicesites.ServiceSiteHandler;
 import com.bencodez.votingplugin.signs.Signs;
@@ -160,6 +161,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private final AtomicReference<GlobalMessageHandler> backendPluginMessageTarget = new AtomicReference<>();
 	private PluginMessageHandler backendPluginMessageRelay;
 	private BackendControlConnector backendControlConnector;
+	private HostedControlManager backendHostedControlManager;
+	private HostedControlManager.HostConfiguration backendHostedControlConfiguration;
 
 	@Getter
 	private BungeeSettings bungeeSettings;
@@ -740,8 +743,58 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			}, 10);
 		}
 
+		startBackendHostedControl();
 		startBackendControlConnector();
 
+	}
+
+	private void startBackendHostedControl() {
+		HostedControlManager.HostConfiguration configuration = readBackendHostedControlConfiguration();
+		backendHostedControlConfiguration = configuration;
+		if (!configuration.enabled()) return;
+		try {
+			backendHostedControlManager = HostedControlManager.create(getDataFolder().toPath(), configuration,
+					message -> getLogger().info("[Control Host] " + message));
+			if (backendHostedControlManager != null) backendHostedControlManager.start();
+		} catch (IllegalArgumentException e) {
+			backendHostedControlManager = null;
+			getLogger().warning("[Control Host] Bukkit hosting configuration is invalid; VotingPlugin remains active: "
+					+ e.getMessage());
+		}
+	}
+
+	private HostedControlManager.HostConfiguration readBackendHostedControlConfiguration() {
+		ConfigurationSection hosted = getConfigFile().getData().getConfigurationSection("Control.Hosted");
+		if (hosted == null) {
+			return new HostedControlManager.HostConfiguration(false, true, false, "", "",
+					"control/votingplugin-control.jar", "control/data", "127.0.0.1", 8080, 30, 60);
+		}
+		return new HostedControlManager.HostConfiguration(hosted.getBoolean("Enabled", false),
+				hosted.getBoolean("AutoDownload", true), hosted.getBoolean("AutoUpdate", false),
+				hosted.getString("DownloadUrl", ""), hosted.getString("Sha256", ""),
+				hosted.getString("JarFile", "control/votingplugin-control.jar"),
+				hosted.getString("DataDirectory", "control/data"), hosted.getString("Host", "127.0.0.1"),
+				hosted.getInt("Port", 8080), hosted.getInt("StartupTimeoutSeconds", 30),
+				hosted.getInt("DownloadTimeoutSeconds", 60));
+	}
+
+	private void restartBackendHostedControlIfChanged() {
+		HostedControlManager.HostConfiguration replacementConfiguration = readBackendHostedControlConfiguration();
+		if (replacementConfiguration.equals(backendHostedControlConfiguration)) return;
+		HostedControlManager replacement;
+		try {
+			replacement = HostedControlManager.create(getDataFolder().toPath(), replacementConfiguration,
+					message -> getLogger().info("[Control Host] " + message));
+		} catch (IllegalArgumentException e) {
+			getLogger().warning("[Control Host] Applied Bukkit hosting settings are invalid; the current host is unchanged: "
+					+ e.getMessage());
+			return;
+		}
+		HostedControlManager previous = backendHostedControlManager;
+		backendHostedControlConfiguration = replacementConfiguration;
+		backendHostedControlManager = replacement;
+		if (previous != null) previous.close();
+		if (replacement != null) replacement.start();
 	}
 
 	private void startBackendControlConnector() {
@@ -754,7 +807,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		}
 	}
 
-	/** Refreshes the optional Control connector after its Config.yml settings were applied. */
+	/** Refreshes the optional Control services after their Config.yml settings were applied. */
 	public synchronized void restartBackendControlConnector() {
 		BackendControlConnector connector = backendControlConnector;
 		if (connector != null && connector.hasPendingResults()) {
@@ -771,6 +824,13 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		if (connector != null) connector.close();
 		if (backendControlConnector == connector) backendControlConnector = replacement;
 		if (replacement != null) replacement.start();
+		restartBackendHostedControlIfChanged();
+	}
+
+	/** Redacted lifecycle status for the optional Control process hosted by Bukkit. */
+	public String getBackendHostedControlStatus() {
+		HostedControlManager manager = backendHostedControlManager;
+		return manager == null ? "DISABLED" : manager.status().name();
 	}
 
 	/** Recreates proxy transports after Control applies BungeeSettings.yml. */
@@ -915,6 +975,17 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				debug(e);
 			} finally {
 				if (backendControlConnector == connector) backendControlConnector = null;
+			}
+		}
+		HostedControlManager hosted = backendHostedControlManager;
+		if (hosted != null) {
+			try {
+				hosted.close();
+			} catch (RuntimeException e) {
+				getLogger().warning("[Control Host] Bukkit host did not stop cleanly; normal plugin cleanup will continue");
+				debug(e);
+			} finally {
+				if (backendHostedControlManager == hosted) backendHostedControlManager = null;
 			}
 		}
 		if (getBackendProxyHandler() != null) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -164,7 +164,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private final AtomicReference<GlobalMessageHandler> backendPluginMessageTarget = new AtomicReference<>();
 	private PluginMessageHandler backendPluginMessageRelay;
 	private volatile BackendControlConnector backendControlConnector;
-	private final ExecutorService backendControlConnectorLifecycle = Executors.newSingleThreadExecutor(runnable -> {
+	private final ScheduledExecutorService backendControlConnectorLifecycle = Executors.newSingleThreadScheduledExecutor(runnable -> {
 		Thread thread = new Thread(runnable, "votingplugin-control-backend-connector-lifecycle");
 		thread.setDaemon(true);
 		return thread;
@@ -1045,7 +1045,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 					return;
 				}
 				previous = backendControlConnector;
-				if (previous != null && previous.hasPendingResults()) {
+				if (previous != null && !previous.isClosed() && previous.hasPendingResults()) {
 					backendControlConnectorReconcileQueued = false;
 					getLogger().warning("[Control] Deferring connector and hosted settings until pending results drain");
 					return;
@@ -1057,10 +1057,18 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			} catch (RuntimeException e) {
 				synchronized (this) {
 					backendControlConnectorReconcileRequested = true;
-					backendControlConnectorReconcileQueued = false;
 				}
-				getLogger().warning("[Control] Previous Bukkit connector did not stop; reconciliation is deferred");
+				getLogger().warning("[Control] Previous Bukkit connector is still draining; reconciliation will retry");
 				debug(e);
+				if (backendControlConnectorStopping) {
+					synchronized (this) { backendControlConnectorReconcileQueued = false; }
+					return;
+				}
+				try {
+					backendControlConnectorLifecycle.schedule(this::reconcileBackendControlConnector, 5, TimeUnit.SECONDS);
+				} catch (RejectedExecutionException rejected) {
+					synchronized (this) { backendControlConnectorReconcileQueued = false; }
+				}
 				return;
 			}
 			BackendControlConnector replacement;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -825,7 +825,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		backendHostedControlConfiguration = replacementConfiguration;
 		backendHostedControlManager = replacement;
 		try {
-			backendHostedControlLifecycle.execute(() -> replaceBackendHostedControl(previous, replacement));
+			backendHostedControlLifecycle.execute(
+					() -> replaceBackendHostedControl(previous, previousConfiguration, replacement));
 		} catch (RejectedExecutionException e) {
 			backendHostedControlConfiguration = previousConfiguration;
 			backendHostedControlManager = previous;
@@ -834,7 +835,24 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		}
 	}
 
-	private void replaceBackendHostedControl(HostedControlManager previous, HostedControlManager replacement) {
+	private void replaceBackendHostedControl(HostedControlManager previous,
+			HostedControlManager.HostConfiguration previousConfiguration, HostedControlManager replacement) {
+		if (replacement != null) {
+			try {
+				replacement.prepareForReplacement();
+			} catch (Exception e) {
+				synchronized (this) {
+					if (backendHostedControlManager == replacement) {
+						backendHostedControlManager = previous;
+						backendHostedControlConfiguration = previousConfiguration;
+						replacement.close();
+						getLogger().warning("[Control Host] Replacement provisioning failed; the current host is unchanged: "
+								+ e.getMessage());
+						return;
+					}
+				}
+			}
+		}
 		try {
 			if (previous != null) previous.closeAndWait();
 		} catch (RuntimeException e) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -163,7 +163,15 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private final ProcessedVoteCache backendProcessedVoteCache = new ProcessedVoteCache();
 	private final AtomicReference<GlobalMessageHandler> backendPluginMessageTarget = new AtomicReference<>();
 	private PluginMessageHandler backendPluginMessageRelay;
-	private BackendControlConnector backendControlConnector;
+	private volatile BackendControlConnector backendControlConnector;
+	private final ExecutorService backendControlConnectorLifecycle = Executors.newSingleThreadExecutor(runnable -> {
+		Thread thread = new Thread(runnable, "votingplugin-control-backend-connector-lifecycle");
+		thread.setDaemon(true);
+		return thread;
+	});
+	private boolean backendControlConnectorReconcileRequested;
+	private boolean backendControlConnectorReconcileQueued;
+	private volatile boolean backendControlConnectorStopping;
 	private volatile HostedControlManager backendHostedControlManager;
 	private volatile HostedControlManager.HostConfiguration backendHostedControlConfiguration;
 	private volatile HostedControlManager backendHostedControlActiveManager;
@@ -1017,22 +1025,100 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	/** Refreshes the optional Control services after their Config.yml settings were applied. */
 	public synchronized void restartBackendControlConnector() {
-		BackendControlConnector connector = backendControlConnector;
-		if (connector != null && connector.hasPendingResults()) {
-			getLogger().warning("[Control] Keeping the previous connector until its applied result is acknowledged");
-			return;
-		}
-		BackendControlConnector replacement;
+		backendControlConnectorReconcileRequested = true;
+		if (backendControlConnectorStopping || backendControlConnectorReconcileQueued) return;
+		backendControlConnectorReconcileQueued = true;
 		try {
-			replacement = BackendControlConnector.create(this);
-		} catch (Exception e) {
-			replacement = null;
-			getLogger().warning("[Control] Bukkit configuration connector was not restarted: " + e.getMessage());
+			backendControlConnectorLifecycle.execute(this::reconcileBackendControlConnector);
+		} catch (RejectedExecutionException e) {
+			backendControlConnectorReconcileQueued = false;
+			getLogger().warning("[Control] Bukkit connector settings require a server restart after lifecycle shutdown");
 		}
-		if (connector != null) connector.close();
-		if (backendControlConnector == connector) backendControlConnector = replacement;
-		if (replacement != null) replacement.start();
-		restartBackendHostedControlIfChanged();
+	}
+
+	private void reconcileBackendControlConnector() {
+		while (true) {
+			BackendControlConnector previous;
+			synchronized (this) {
+				if (backendControlConnectorStopping) {
+					backendControlConnectorReconcileQueued = false;
+					return;
+				}
+				previous = backendControlConnector;
+				if (previous != null && previous.hasPendingResults()) {
+					backendControlConnectorReconcileQueued = false;
+					getLogger().warning("[Control] Deferring connector and hosted settings until pending results drain");
+					return;
+				}
+				backendControlConnectorReconcileRequested = false;
+			}
+			try {
+				if (previous != null) previous.close();
+			} catch (RuntimeException e) {
+				synchronized (this) {
+					backendControlConnectorReconcileRequested = true;
+					backendControlConnectorReconcileQueued = false;
+				}
+				getLogger().warning("[Control] Previous Bukkit connector did not stop; reconciliation is deferred");
+				debug(e);
+				return;
+			}
+			BackendControlConnector replacement;
+			try {
+				replacement = BackendControlConnector.create(this);
+			} catch (Exception e) {
+				replacement = null;
+				getLogger().warning("[Control] Bukkit configuration connector was not restarted: " + e.getMessage());
+			}
+			synchronized (this) {
+				if (backendControlConnectorStopping) {
+					if (replacement != null) replacement.close();
+					backendControlConnectorReconcileQueued = false;
+					return;
+				}
+				if (backendControlConnector == previous) backendControlConnector = replacement;
+				if (replacement != null) replacement.start();
+			}
+			boolean pending = replacement != null && replacement.hasPendingResults();
+			if (pending) {
+				synchronized (this) { backendControlConnectorReconcileRequested = true; }
+			} else {
+				restartBackendHostedControlIfChanged();
+			}
+			synchronized (this) {
+				if (!backendControlConnectorReconcileRequested) {
+					backendControlConnectorReconcileQueued = false;
+					return;
+				}
+			}
+		}
+	}
+
+	/** True while a reload is waiting for the durable result queue to drain. */
+	public synchronized boolean hasDeferredBackendControlReconciliation() {
+		return backendControlConnectorReconcileRequested;
+	}
+
+	private void stopBackendControlConnectorLifecycle() {
+		backendControlConnectorStopping = true;
+		backendControlConnectorLifecycle.shutdownNow();
+		BackendControlConnector connector = backendControlConnector;
+		backendControlConnector = null;
+		if (connector != null) {
+			try {
+				connector.close();
+			} catch (RuntimeException e) {
+				getLogger().warning("[Control] Bukkit connector did not stop cleanly; normal plugin cleanup will continue");
+				debug(e);
+			}
+		}
+		try {
+			if (!backendControlConnectorLifecycle.awaitTermination(10, TimeUnit.SECONDS)) {
+				getLogger().warning("[Control] Bukkit connector lifecycle worker did not stop during unload");
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
 	}
 
 	/** Redacted lifecycle status for the optional Control process hosted by Bukkit. */
@@ -1176,17 +1262,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	@Override
 	public void onUnLoad() {
 		stopBackendHostedControlLifecycle();
-		BackendControlConnector connector = backendControlConnector;
-		if (connector != null) {
-			try {
-				connector.close();
-			} catch (RuntimeException e) {
-				getLogger().warning("[Control] Bukkit connector did not stop cleanly; normal plugin cleanup will continue");
-				debug(e);
-			} finally {
-				if (backendControlConnector == connector) backendControlConnector = null;
-			}
-		}
+		stopBackendControlConnectorLifecycle();
 		if (getBackendProxyHandler() != null) {
 			try {
 				getBackendProxyHandler().close();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -1157,14 +1157,19 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	 */
 	@Override
 	public void reload() {
-		reloadPlugin(false);
+		reloadPlugin(false, true);
 	}
 
 	public void reloadAll() {
-		reloadPlugin(true);
+		reloadPlugin(true, true);
 	}
 
-	private void reloadPlugin(boolean userStorage) {
+	/** Reloads configuration applied by Control before its result is acknowledged. */
+	public void reloadFromControl() {
+		reloadPlugin(false, false);
+	}
+
+	private void reloadPlugin(boolean userStorage, boolean reconcileHostedControl) {
 		configFile.reloadData();
 		configFile.loadValues();
 
@@ -1221,6 +1226,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		voteShopManager.reload();
 
 		loadDirectlyDefined();
+
+		if (reconcileHostedControl) restartBackendHostedControlIfChanged();
 
 		setUpdate(true);
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -1,6 +1,7 @@
 package com.bencodez.votingplugin;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
@@ -759,6 +760,16 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	private void startBackendHostedControl() {
 		HostedControlManager.HostConfiguration configuration = readBackendHostedControlConfiguration();
+		try {
+			HostedControlManager.HostConfiguration recovered = BackendControlConnector
+					.recoveredHostedConfiguration(getDataFolder().toPath());
+			if (recovered != null) {
+				configuration = recovered;
+				getLogger().info("[Control Host] Keeping the previous hosted settings until pending results are acknowledged");
+			}
+		} catch (IOException e) {
+			getLogger().warning("[Control Host] Pending hosted settings could not be recovered: " + e.getMessage());
+		}
 		backendHostedControlConfiguration = configuration;
 		if (!configuration.enabled()) return;
 		try {
@@ -785,6 +796,12 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				hosted.getString("DataDirectory", "control/data"), hosted.getString("Host", "127.0.0.1"),
 				hosted.getInt("Port", 8080), hosted.getInt("StartupTimeoutSeconds", 30),
 				hosted.getInt("DownloadTimeoutSeconds", 60));
+	}
+
+	/** Immutable active hosted settings captured in the durable Control result journal. */
+	public HostedControlManager.HostConfiguration getActiveBackendHostedControlConfigurationSnapshot() {
+		HostedControlManager.HostConfiguration active = backendHostedControlConfiguration;
+		return active == null ? readBackendHostedControlConfiguration() : active;
 	}
 
 	private synchronized void restartBackendHostedControlIfChanged() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -923,13 +923,31 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			}
 			return;
 		}
-		synchronized (this) {
-			if (backendHostedControlStopping || backendHostedControlLifecycleFailed) {
-				closeBackendHostedControlManager(replacement, false);
-				return;
+		try {
+			synchronized (this) {
+				if (backendHostedControlStopping || backendHostedControlLifecycleFailed) {
+					closeBackendHostedControlManager(replacement, false);
+					return;
+				}
+				Runnable publication = () -> {
+					backendHostedControlActiveManager = replacement;
+					backendHostedControlActiveConfiguration = replacementConfiguration;
+				};
+				BackendControlConnector connector = backendControlConnector;
+				if (connector == null) publication.run();
+				else connector.publishHostedConfiguration(replacementConfiguration, publication);
 			}
-			backendHostedControlActiveManager = replacement;
-			backendHostedControlActiveConfiguration = replacementConfiguration;
+		} catch (IOException e) {
+			try {
+				closeBackendHostedControlManager(replacement, true);
+			} catch (RuntimeException closeFailure) {
+				e.addSuppressed(closeFailure);
+			}
+			if (!backendHostedControlStopping) {
+				getLogger().warning("[Control Host] Replacement publication failed; restoring the previous host");
+				debug(e);
+				restoreBackendHostedControl(previousConfiguration, replacement, replacementConfiguration);
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -1090,10 +1090,12 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				return;
 			}
 			BackendControlConnector replacement;
+			boolean creationFailed = false;
 			try {
 				replacement = BackendControlConnector.create(this);
 			} catch (Exception e) {
 				replacement = null;
+				creationFailed = true;
 				getLogger().warning("[Control] Bukkit configuration connector was not restarted: " + e.getMessage());
 			}
 			synchronized (this) {
@@ -1104,6 +1106,11 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				}
 				if (backendControlConnector == previous) backendControlConnector = replacement;
 				if (replacement != null) replacement.start();
+				if (creationFailed) {
+					backendControlConnectorReconcileQueued = false;
+					getLogger().warning("[Control] Hosted settings remain unchanged until the connector can restart");
+					return;
+				}
 			}
 			boolean pending = replacement != null && replacement.hasPendingResults();
 			if (pending) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -166,6 +166,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private BackendControlConnector backendControlConnector;
 	private volatile HostedControlManager backendHostedControlManager;
 	private volatile HostedControlManager.HostConfiguration backendHostedControlConfiguration;
+	private volatile HostedControlManager backendHostedControlActiveManager;
+	private volatile HostedControlManager.HostConfiguration backendHostedControlActiveConfiguration;
 	private final ExecutorService backendHostedControlLifecycle = Executors.newSingleThreadExecutor(runnable -> {
 		Thread thread = new Thread(runnable, "votingplugin-control-backend-host-lifecycle");
 		thread.setDaemon(true);
@@ -771,13 +773,16 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			getLogger().warning("[Control Host] Pending hosted settings could not be recovered: " + e.getMessage());
 		}
 		backendHostedControlConfiguration = configuration;
+		backendHostedControlActiveConfiguration = configuration;
 		if (!configuration.enabled()) return;
 		try {
 			backendHostedControlManager = HostedControlManager.create(getDataFolder().toPath(), configuration,
 					message -> getLogger().info("[Control Host] " + message));
-			if (backendHostedControlManager != null) backendHostedControlManager.start();
+			backendHostedControlActiveManager = backendHostedControlManager;
+			if (backendHostedControlActiveManager != null) backendHostedControlActiveManager.start();
 		} catch (IllegalArgumentException e) {
 			backendHostedControlManager = null;
+			backendHostedControlActiveManager = null;
 			getLogger().warning("[Control Host] Bukkit hosting configuration is invalid; VotingPlugin remains active: "
 					+ e.getMessage());
 		}
@@ -800,7 +805,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	/** Immutable active hosted settings captured in the durable Control result journal. */
 	public HostedControlManager.HostConfiguration getActiveBackendHostedControlConfigurationSnapshot() {
-		HostedControlManager.HostConfiguration active = backendHostedControlConfiguration;
+		HostedControlManager.HostConfiguration active = backendHostedControlActiveConfiguration;
 		return active == null ? readBackendHostedControlConfiguration() : active;
 	}
 
@@ -820,44 +825,59 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 					+ e.getMessage());
 			return;
 		}
-		HostedControlManager previous = backendHostedControlManager;
-		HostedControlManager.HostConfiguration previousConfiguration = backendHostedControlConfiguration;
 		backendHostedControlConfiguration = replacementConfiguration;
 		backendHostedControlManager = replacement;
 		try {
 			backendHostedControlLifecycle.execute(
-					() -> replaceBackendHostedControl(previous, previousConfiguration, replacement));
+					() -> replaceBackendHostedControl(replacement, replacementConfiguration));
 		} catch (RejectedExecutionException e) {
-			backendHostedControlConfiguration = previousConfiguration;
-			backendHostedControlManager = previous;
+			backendHostedControlConfiguration = backendHostedControlActiveConfiguration;
+			backendHostedControlManager = backendHostedControlActiveManager;
 			if (replacement != null) replacement.close();
 			getLogger().warning("[Control Host] Bukkit hosting settings require a server restart after lifecycle shutdown");
 		}
 	}
 
-	private void replaceBackendHostedControl(HostedControlManager previous,
-			HostedControlManager.HostConfiguration previousConfiguration, HostedControlManager replacement) {
+	private void replaceBackendHostedControl(HostedControlManager replacement,
+			HostedControlManager.HostConfiguration replacementConfiguration) {
 		if (replacement != null) {
 			try {
 				replacement.prepareForReplacement();
 			} catch (Exception e) {
 				synchronized (this) {
-					if (backendHostedControlManager == replacement) {
-						backendHostedControlManager = previous;
-						backendHostedControlConfiguration = previousConfiguration;
-						replacement.close();
+					if (backendHostedControlManager == replacement
+							&& replacementConfiguration.equals(backendHostedControlConfiguration)) {
+						backendHostedControlManager = backendHostedControlActiveManager;
+						backendHostedControlConfiguration = backendHostedControlActiveConfiguration;
 						getLogger().warning("[Control Host] Replacement provisioning failed; the current host is unchanged: "
 								+ e.getMessage());
-						return;
 					}
 				}
+				replacement.close();
+				return;
 			}
+		}
+		HostedControlManager previous;
+		synchronized (this) {
+			if (backendHostedControlStopping || backendHostedControlLifecycleFailed
+					|| backendHostedControlManager != replacement
+					|| !replacementConfiguration.equals(backendHostedControlConfiguration)) {
+				if (replacement != null) replacement.close();
+				return;
+			}
+			previous = backendHostedControlActiveManager;
 		}
 		try {
 			if (previous != null) previous.closeAndWait();
 		} catch (RuntimeException e) {
 			backendHostedControlLifecycleFailed = true;
 			if (replacement != null) replacement.close();
+			synchronized (this) {
+				if (backendHostedControlManager == replacement) {
+					backendHostedControlManager = previous;
+					backendHostedControlConfiguration = backendHostedControlActiveConfiguration;
+				}
+			}
 			if (!backendHostedControlStopping) {
 				getLogger().warning("[Control Host] The previous Bukkit-hosted process did not stop; replacement is blocked");
 				debug(e);
@@ -865,11 +885,13 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			return;
 		}
 		synchronized (this) {
-			if (backendHostedControlStopping || backendHostedControlLifecycleFailed
-					|| backendHostedControlManager != replacement) {
+			if (backendHostedControlActiveManager == previous) backendHostedControlActiveManager = null;
+			if (backendHostedControlStopping || backendHostedControlLifecycleFailed) {
 				if (replacement != null) replacement.close();
 				return;
 			}
+			backendHostedControlActiveManager = replacement;
+			backendHostedControlActiveConfiguration = replacementConfiguration;
 			if (replacement != null) replacement.start();
 		}
 	}
@@ -878,14 +900,20 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		backendHostedControlStopping = true;
 		try {
 			backendHostedControlLifecycle.execute(() -> {
-				HostedControlManager hosted = backendHostedControlManager;
-				if (hosted != null) hosted.close();
+				HostedControlManager active = backendHostedControlActiveManager;
+				HostedControlManager requested = backendHostedControlManager;
+				if (active != null) active.close();
+				if (requested != null && requested != active) requested.close();
 				backendHostedControlManager = null;
+				backendHostedControlActiveManager = null;
 			});
 		} catch (RejectedExecutionException e) {
-			HostedControlManager hosted = backendHostedControlManager;
-			if (hosted != null) hosted.close();
+			HostedControlManager active = backendHostedControlActiveManager;
+			HostedControlManager requested = backendHostedControlManager;
+			if (active != null) active.close();
+			if (requested != null && requested != active) requested.close();
 			backendHostedControlManager = null;
+			backendHostedControlActiveManager = null;
 		} finally {
 			backendHostedControlLifecycle.shutdown();
 		}
@@ -924,7 +952,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	/** Redacted lifecycle status for the optional Control process hosted by Bukkit. */
 	public String getBackendHostedControlStatus() {
 		if (backendHostedControlLifecycleFailed) return "FAILED";
-		HostedControlManager manager = backendHostedControlManager;
+		HostedControlManager manager = backendHostedControlActiveManager;
 		return manager == null ? "DISABLED" : manager.status().name();
 	}
 
@@ -1262,7 +1290,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 		loadDirectlyDefined();
 
-		if (reconcileHostedControl) restartBackendHostedControlIfChanged();
+		if (reconcileHostedControl) restartBackendControlConnector();
 
 		setUpdate(true);
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -11,7 +11,9 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -161,8 +163,15 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private final AtomicReference<GlobalMessageHandler> backendPluginMessageTarget = new AtomicReference<>();
 	private PluginMessageHandler backendPluginMessageRelay;
 	private BackendControlConnector backendControlConnector;
-	private HostedControlManager backendHostedControlManager;
-	private HostedControlManager.HostConfiguration backendHostedControlConfiguration;
+	private volatile HostedControlManager backendHostedControlManager;
+	private volatile HostedControlManager.HostConfiguration backendHostedControlConfiguration;
+	private final ExecutorService backendHostedControlLifecycle = Executors.newSingleThreadExecutor(runnable -> {
+		Thread thread = new Thread(runnable, "votingplugin-control-backend-host-lifecycle");
+		thread.setDaemon(true);
+		return thread;
+	});
+	private volatile boolean backendHostedControlLifecycleFailed;
+	private volatile boolean backendHostedControlStopping;
 
 	@Getter
 	private BungeeSettings bungeeSettings;
@@ -778,9 +787,13 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				hosted.getInt("DownloadTimeoutSeconds", 60));
 	}
 
-	private void restartBackendHostedControlIfChanged() {
+	private synchronized void restartBackendHostedControlIfChanged() {
 		HostedControlManager.HostConfiguration replacementConfiguration = readBackendHostedControlConfiguration();
 		if (replacementConfiguration.equals(backendHostedControlConfiguration)) return;
+		if (backendHostedControlStopping || backendHostedControlLifecycleFailed) {
+			getLogger().warning("[Control Host] Bukkit hosting settings require a server restart after lifecycle shutdown");
+			return;
+		}
 		HostedControlManager replacement;
 		try {
 			replacement = HostedControlManager.create(getDataFolder().toPath(), replacementConfiguration,
@@ -791,10 +804,56 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			return;
 		}
 		HostedControlManager previous = backendHostedControlManager;
+		HostedControlManager.HostConfiguration previousConfiguration = backendHostedControlConfiguration;
 		backendHostedControlConfiguration = replacementConfiguration;
 		backendHostedControlManager = replacement;
-		if (previous != null) previous.close();
-		if (replacement != null) replacement.start();
+		try {
+			backendHostedControlLifecycle.execute(() -> replaceBackendHostedControl(previous, replacement));
+		} catch (RejectedExecutionException e) {
+			backendHostedControlConfiguration = previousConfiguration;
+			backendHostedControlManager = previous;
+			if (replacement != null) replacement.close();
+			getLogger().warning("[Control Host] Bukkit hosting settings require a server restart after lifecycle shutdown");
+		}
+	}
+
+	private void replaceBackendHostedControl(HostedControlManager previous, HostedControlManager replacement) {
+		try {
+			if (previous != null) previous.closeAndWait();
+		} catch (RuntimeException e) {
+			backendHostedControlLifecycleFailed = true;
+			if (replacement != null) replacement.close();
+			if (!backendHostedControlStopping) {
+				getLogger().warning("[Control Host] The previous Bukkit-hosted process did not stop; replacement is blocked");
+				debug(e);
+			}
+			return;
+		}
+		synchronized (this) {
+			if (backendHostedControlStopping || backendHostedControlLifecycleFailed
+					|| backendHostedControlManager != replacement) {
+				if (replacement != null) replacement.close();
+				return;
+			}
+			if (replacement != null) replacement.start();
+		}
+	}
+
+	private void stopBackendHostedControlLifecycle() {
+		backendHostedControlStopping = true;
+		try {
+			backendHostedControlLifecycle.execute(() -> {
+				HostedControlManager hosted = backendHostedControlManager;
+				if (hosted != null) hosted.close();
+				backendHostedControlManager = null;
+			});
+		} catch (RejectedExecutionException e) {
+			HostedControlManager hosted = backendHostedControlManager;
+			if (hosted != null) hosted.close();
+			backendHostedControlManager = null;
+		} finally {
+			backendHostedControlLifecycle.shutdown();
+		}
 	}
 
 	private void startBackendControlConnector() {
@@ -829,6 +888,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	/** Redacted lifecycle status for the optional Control process hosted by Bukkit. */
 	public String getBackendHostedControlStatus() {
+		if (backendHostedControlLifecycleFailed) return "FAILED";
 		HostedControlManager manager = backendHostedControlManager;
 		return manager == null ? "DISABLED" : manager.status().name();
 	}
@@ -966,6 +1026,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 	@Override
 	public void onUnLoad() {
+		stopBackendHostedControlLifecycle();
 		BackendControlConnector connector = backendControlConnector;
 		if (connector != null) {
 			try {
@@ -975,17 +1036,6 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 				debug(e);
 			} finally {
 				if (backendControlConnector == connector) backendControlConnector = null;
-			}
-		}
-		HostedControlManager hosted = backendHostedControlManager;
-		if (hosted != null) {
-			try {
-				hosted.close();
-			} catch (RuntimeException e) {
-				getLogger().warning("[Control Host] Bukkit host did not stop cleanly; normal plugin cleanup will continue");
-				debug(e);
-			} finally {
-				if (backendHostedControlManager == hosted) backendHostedControlManager = null;
 			}
 		}
 		if (getBackendProxyHandler() != null) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -89,7 +89,7 @@ public final class BackendControlConnector implements AutoCloseable {
 		synchronized (operationLifecycle) {
 			if (closed) throw new IllegalStateException("Bukkit Control connector is stopping");
 			reload = plugin.getServer().getScheduler().callSyncMethod(plugin, () -> {
-				plugin.reload();
+				plugin.reloadFromControl();
 				if ("BungeeSettings.yml".equals(fileName)) plugin.restartBackendProxyHandler();
 				return null;
 			});

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -30,6 +30,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.control.BackendControlResultStore.Route;
 import com.bencodez.votingplugin.control.BackendControlResultStore.StoredResult;
+import com.bencodez.votingplugin.proxy.control.HostedControlManager.HostConfiguration;
 import com.bencodez.votingplugin.util.BoundedHttpBodyHandler;
 import com.bencodez.votingplugin.util.ControlCredentialFile;
 import com.google.gson.JsonArray;
@@ -49,6 +50,7 @@ public final class BackendControlConnector implements AutoCloseable {
 	private final Path dataDirectory;
 	private final Settings settings;
 	private final String credential;
+	private volatile HostConfiguration hostedConfiguration;
 	private final ScheduledExecutorService executor;
 	private final HttpClient http;
 	private final BackendConfigurationService configurations;
@@ -67,11 +69,12 @@ public final class BackendControlConnector implements AutoCloseable {
 	private volatile CompletableFuture<Void> activeOperation;
 
 	private BackendControlConnector(VotingPluginMain plugin, Path dataDirectory, Settings settings, String credential,
-			boolean recovering) {
+			HostConfiguration hostedConfiguration, boolean recovering) {
 		this.plugin = plugin;
 		this.dataDirectory = dataDirectory;
 		this.settings = settings;
 		this.credential = credential;
+		this.hostedConfiguration = hostedConfiguration;
 		this.recovering = recovering;
 		ThreadFactory factory = runnable -> {
 			Thread thread = new Thread(runnable, "votingplugin-control-backend");
@@ -110,7 +113,8 @@ public final class BackendControlConnector implements AutoCloseable {
 		if (recovered != null) {
 			Settings settings = Settings.from(recovered.route());
 			String credential = ControlCredentialFile.read(root, settings.credentialFile());
-			BackendControlConnector connector = new BackendControlConnector(plugin, root, settings, credential, true);
+			BackendControlConnector connector = new BackendControlConnector(plugin, root, settings, credential,
+					recovered.hostedConfiguration(), true);
 			connector.completed.putAll(recovered.results());
 			return connector;
 		}
@@ -131,7 +135,14 @@ public final class BackendControlConnector implements AutoCloseable {
 				bounded(control.getInt("HeartbeatSeconds", 30), 10, 300, "HeartbeatSeconds"),
 				bounded(control.getInt("ConnectTimeoutMillis", 3000), 500, 30000, "ConnectTimeoutMillis"),
 				bounded(control.getInt("RequestTimeoutMillis", 10000), 500, 30000, "RequestTimeoutMillis"));
-		return new BackendControlConnector(plugin, root, settings, credential, false);
+		return new BackendControlConnector(plugin, root, settings, credential,
+				plugin.getActiveBackendHostedControlConfigurationSnapshot(), false);
+	}
+
+	/** Hosted settings that must remain active while a durable result is recovered. */
+	public static HostConfiguration recoveredHostedConfiguration(Path dataDirectory) throws IOException {
+		BackendControlResultStore.State recovered = BackendControlResultStore.load(dataDirectory);
+		return recovered == null ? null : recovered.hostedConfiguration();
 	}
 
 	public boolean hasPendingResults() {
@@ -329,12 +340,13 @@ public final class BackendControlConnector implements AutoCloseable {
 	private void persistCompleted() throws IOException {
 		Map<UUID, StoredResult> snapshot;
 		synchronized (completed) { snapshot = new LinkedHashMap<>(completed); }
-		BackendControlResultStore.save(dataDirectory, settings.route(), snapshot);
+		BackendControlResultStore.save(dataDirectory, settings.route(), hostedConfiguration, snapshot);
 	}
 
 	private void persistIntent(UUID operationId, TaskResult anticipated, String attemptId) throws IOException {
 		JsonObject result = anticipated.json();
 		result.addProperty("attemptId", attemptId);
+		hostedConfiguration = plugin.getActiveBackendHostedControlConfigurationSnapshot();
 		synchronized (completed) {
 			completed.put(operationId, new StoredResult(result, anticipated.restartConnector(), false, false));
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -314,7 +314,8 @@ public final class BackendControlConnector implements AutoCloseable {
 		}
 		boolean drained;
 		synchronized (completed) { drained = completed.isEmpty(); }
-		if (drained && (submitted.restartConnector() || recovering)) {
+		if (drained && (submitted.restartConnector() || recovering
+				|| plugin.hasDeferredBackendControlReconciliation())) {
 			plugin.getServer().getScheduler().runTask(plugin, plugin::restartBackendControlConnector);
 		}
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -345,6 +345,7 @@ public final class BackendControlConnector implements AutoCloseable {
 	private void persistCompleted() throws IOException {
 		Map<UUID, StoredResult> snapshot;
 		synchronized (completed) { snapshot = new LinkedHashMap<>(completed); }
+		if (!snapshot.isEmpty()) hostedConfiguration = plugin.getActiveBackendHostedControlConfigurationSnapshot();
 		BackendControlResultStore.save(dataDirectory, settings.route(), hostedConfiguration, snapshot);
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -149,6 +149,10 @@ public final class BackendControlConnector implements AutoCloseable {
 		synchronized (completed) { return !completed.isEmpty(); }
 	}
 
+	public boolean isClosed() {
+		return closed;
+	}
+
 	public void start() { schedule(0); }
 
 	private void schedule(long delayMillis) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -59,6 +59,7 @@ public final class BackendControlConnector implements AutoCloseable {
 	private final boolean recovering;
 	private final AtomicBoolean running = new AtomicBoolean();
 	private final Object operationLifecycle = new Object();
+	private final Object journalLifecycle = new Object();
 	private volatile boolean closed;
 	private volatile boolean registered;
 	private volatile boolean operationsAccepted;
@@ -343,16 +344,30 @@ public final class BackendControlConnector implements AutoCloseable {
 	}
 
 	private void persistCompleted() throws IOException {
-		Map<UUID, StoredResult> snapshot;
-		synchronized (completed) { snapshot = new LinkedHashMap<>(completed); }
-		if (!snapshot.isEmpty()) hostedConfiguration = plugin.getActiveBackendHostedControlConfigurationSnapshot();
-		BackendControlResultStore.save(dataDirectory, settings.route(), hostedConfiguration, snapshot);
+		synchronized (journalLifecycle) {
+			Map<UUID, StoredResult> snapshot;
+			synchronized (completed) { snapshot = new LinkedHashMap<>(completed); }
+			if (!snapshot.isEmpty()) hostedConfiguration = plugin.getActiveBackendHostedControlConfigurationSnapshot();
+			BackendControlResultStore.save(dataDirectory, settings.route(), hostedConfiguration, snapshot);
+		}
+	}
+
+	/** Durably aligns pending results before the hosted lifecycle publishes a new active process. */
+	public void publishHostedConfiguration(HostConfiguration configuration, Runnable publication) throws IOException {
+		synchronized (journalLifecycle) {
+			Map<UUID, StoredResult> snapshot;
+			synchronized (completed) { snapshot = new LinkedHashMap<>(completed); }
+			if (!snapshot.isEmpty()) {
+				BackendControlResultStore.save(dataDirectory, settings.route(), configuration, snapshot);
+			}
+			hostedConfiguration = configuration;
+			publication.run();
+		}
 	}
 
 	private void persistIntent(UUID operationId, TaskResult anticipated, String attemptId) throws IOException {
 		JsonObject result = anticipated.json();
 		result.addProperty("attemptId", attemptId);
-		hostedConfiguration = plugin.getActiveBackendHostedControlConfigurationSnapshot();
 		synchronized (completed) {
 			completed.put(operationId, new StoredResult(result, anticipated.restartConnector(), false, false));
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlResultStore.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonParser;
 /** Durable result journal used to make locally applied Control operations restart-safe. */
 final class BackendControlResultStore {
 	private static final int VERSION = 3;
+	private static final int LEGACY_VERSION = 2;
 	// A valid 512 KiB YAML result may expand up to sixfold when characters require JSON unicode escaping.
 	private static final int MAX_BYTES = 4 * 1024 * 1024;
 	private static final int MAX_RESULTS = 128;
@@ -54,18 +55,14 @@ final class BackendControlResultStore {
 			JsonElement parsed = JsonParser.parseString(new String(bytes, StandardCharsets.UTF_8));
 			if (!parsed.isJsonObject()) throw invalid();
 			JsonObject root = parsed.getAsJsonObject();
-			if (integer(root, "version") != VERSION) throw invalid();
+			int version = integer(root, "version");
+			if (version != VERSION && version != LEGACY_VERSION) throw invalid();
 			JsonObject routeJson = object(root, "route");
 			Route route = new Route(string(routeJson, "nodeId"), URI.create(string(routeJson, "endpoint")),
 					string(routeJson, "credentialFile"), integer(routeJson, "heartbeatSeconds"),
 					integer(routeJson, "connectTimeoutMillis"), integer(routeJson, "requestTimeoutMillis"));
-			JsonObject hostedJson = object(root, "hosted");
-			HostConfiguration hosted = new HostConfiguration(bool(hostedJson, "enabled"),
-					bool(hostedJson, "autoDownload"), bool(hostedJson, "autoUpdate"),
-					optionalString(hostedJson, "downloadUrl"), optionalString(hostedJson, "sha256"),
-					string(hostedJson, "jarFile"), string(hostedJson, "dataDirectory"),
-					string(hostedJson, "host"), integer(hostedJson, "port"),
-					integer(hostedJson, "startupTimeoutSeconds"), integer(hostedJson, "downloadTimeoutSeconds"));
+			HostConfiguration hosted = version == LEGACY_VERSION ? legacyHostedConfiguration()
+					: hostedConfiguration(object(root, "hosted"));
 			JsonArray listed = array(root, "results");
 			if (listed.size() == 0 || listed.size() > MAX_RESULTS) throw invalid();
 			Map<UUID, StoredResult> results = new LinkedHashMap<>();
@@ -184,6 +181,21 @@ final class BackendControlResultStore {
 	private static boolean bool(JsonObject object, String name) {
 		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
 		return object.get(name).getAsBoolean();
+	}
+
+	private static HostConfiguration hostedConfiguration(JsonObject hosted) {
+		return new HostConfiguration(bool(hosted, "enabled"), bool(hosted, "autoDownload"),
+				bool(hosted, "autoUpdate"), optionalString(hosted, "downloadUrl"),
+				optionalString(hosted, "sha256"), string(hosted, "jarFile"),
+				string(hosted, "dataDirectory"), string(hosted, "host"), integer(hosted, "port"),
+				integer(hosted, "startupTimeoutSeconds"), integer(hosted, "downloadTimeoutSeconds"));
+	}
+
+	private static HostConfiguration legacyHostedConfiguration() {
+		// Version 2 predates Bukkit-hosted Control, so recovery must keep hosting disabled
+		// until the old connector route has submitted its pending result.
+		return new HostConfiguration(false, false, false, "", "", "control/votingplugin-control.jar",
+				"control/data", "127.0.0.1", 8080, 30, 60);
 	}
 
 	private static int integer(JsonObject object, String name) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlResultStore.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import com.bencodez.votingplugin.util.DurableFiles;
+import com.bencodez.votingplugin.proxy.control.HostedControlManager.HostConfiguration;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -24,7 +25,7 @@ import com.google.gson.JsonParser;
 
 /** Durable result journal used to make locally applied Control operations restart-safe. */
 final class BackendControlResultStore {
-	private static final int VERSION = 2;
+	private static final int VERSION = 3;
 	// A valid 512 KiB YAML result may expand up to sixfold when characters require JSON unicode escaping.
 	private static final int MAX_BYTES = 4 * 1024 * 1024;
 	private static final int MAX_RESULTS = 128;
@@ -58,6 +59,13 @@ final class BackendControlResultStore {
 			Route route = new Route(string(routeJson, "nodeId"), URI.create(string(routeJson, "endpoint")),
 					string(routeJson, "credentialFile"), integer(routeJson, "heartbeatSeconds"),
 					integer(routeJson, "connectTimeoutMillis"), integer(routeJson, "requestTimeoutMillis"));
+			JsonObject hostedJson = object(root, "hosted");
+			HostConfiguration hosted = new HostConfiguration(bool(hostedJson, "enabled"),
+					bool(hostedJson, "autoDownload"), bool(hostedJson, "autoUpdate"),
+					optionalString(hostedJson, "downloadUrl"), optionalString(hostedJson, "sha256"),
+					string(hostedJson, "jarFile"), string(hostedJson, "dataDirectory"),
+					string(hostedJson, "host"), integer(hostedJson, "port"),
+					integer(hostedJson, "startupTimeoutSeconds"), integer(hostedJson, "downloadTimeoutSeconds"));
 			JsonArray listed = array(root, "results");
 			if (listed.size() == 0 || listed.size() > MAX_RESULTS) throw invalid();
 			Map<UUID, StoredResult> results = new LinkedHashMap<>();
@@ -74,13 +82,14 @@ final class BackendControlResultStore {
 								item.get("committed").getAsBoolean(), item.get("claimRequired").getAsBoolean()));
 				if (previous != null) throw invalid();
 			}
-			return new State(route, Map.copyOf(results));
+			return new State(route, hosted, Map.copyOf(results));
 		} catch (RuntimeException e) {
 			throw new IOException("Control pending-result journal is malformed", e);
 		}
 	}
 
-	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results) throws IOException {
+	static void save(Path dataDirectory, Route route, HostConfiguration hosted,
+			Map<UUID, StoredResult> results) throws IOException {
 		Path target = target(dataDirectory);
 		if (results.isEmpty()) {
 			if (Files.isSymbolicLink(target)) throw new IOException("Control pending-result journal is unsafe");
@@ -102,6 +111,19 @@ final class BackendControlResultStore {
 		routeJson.addProperty("connectTimeoutMillis", route.connectTimeoutMillis());
 		routeJson.addProperty("requestTimeoutMillis", route.requestTimeoutMillis());
 		root.add("route", routeJson);
+		JsonObject hostedJson = new JsonObject();
+		hostedJson.addProperty("enabled", hosted.enabled());
+		hostedJson.addProperty("autoDownload", hosted.autoDownload());
+		hostedJson.addProperty("autoUpdate", hosted.autoUpdate());
+		hostedJson.addProperty("downloadUrl", hosted.downloadUrl());
+		hostedJson.addProperty("sha256", hosted.sha256());
+		hostedJson.addProperty("jarFile", hosted.jarFile());
+		hostedJson.addProperty("dataDirectory", hosted.dataDirectory());
+		hostedJson.addProperty("host", hosted.host());
+		hostedJson.addProperty("port", hosted.port());
+		hostedJson.addProperty("startupTimeoutSeconds", hosted.startupTimeoutSeconds());
+		hostedJson.addProperty("downloadTimeoutSeconds", hosted.downloadTimeoutSeconds());
+		root.add("hosted", hostedJson);
 		JsonArray listed = new JsonArray();
 		results.forEach((operationId, result) -> {
 			JsonObject item = new JsonObject();
@@ -152,6 +174,18 @@ final class BackendControlResultStore {
 		return value;
 	}
 
+	private static String optionalString(JsonObject object, String name) {
+		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
+		String value = object.get(name).getAsString();
+		if (value == null || value.length() > 2048) throw invalid();
+		return value;
+	}
+
+	private static boolean bool(JsonObject object, String name) {
+		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
+		return object.get(name).getAsBoolean();
+	}
+
 	private static int integer(JsonObject object, String name) {
 		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
 		return object.get(name).getAsInt();
@@ -168,5 +202,5 @@ final class BackendControlResultStore {
 			if (committed && claimRequired) throw new IllegalArgumentException("committed result cannot require a claim");
 		}
 	}
-	record State(Route route, Map<UUID, StoredResult> results) { }
+	record State(Route route, HostConfiguration hostedConfiguration, Map<UUID, StoredResult> results) { }
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
@@ -728,6 +728,7 @@ public final class HostedControlManager implements AutoCloseable {
 					|| downloadTimeoutSeconds < 5 || downloadTimeoutSeconds > 300) {
 				throw new IllegalArgumentException("Control hosted bounds are invalid");
 			}
+			parseEndpoint(host, port);
 		}
 
 		Path previousFile() {
@@ -751,8 +752,16 @@ public final class HostedControlManager implements AutoCloseable {
 		}
 
 		URI endpoint() {
+			return parseEndpoint(host, port);
+		}
+
+		private static URI parseEndpoint(String host, int port) {
 			try {
-				return new URI("http", null, host, port, "/", null, null);
+				URI endpoint = new URI("http", null, host, port, "/", null, null);
+				if (endpoint.getHost() == null) {
+					throw new IllegalArgumentException("Control hosted endpoint is invalid");
+				}
+				return endpoint;
 			} catch (Exception e) {
 				throw new IllegalArgumentException("Control hosted endpoint is invalid");
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
@@ -123,10 +123,25 @@ public final class HostedControlManager implements AutoCloseable {
 	}
 
 	public void start() {
-		if (closed || activeTask != null) {
-			return;
+		submitInitialTask();
+	}
+
+	/** Starts on the manager worker and waits for the initial health result. */
+	public boolean startAndWaitForInitialResult() throws InterruptedException {
+		Future<?> task = submitInitialTask();
+		if (task == null) return false;
+		try {
+			task.get();
+		} catch (java.util.concurrent.CancellationException | java.util.concurrent.ExecutionException e) {
+			return false;
 		}
-		activeTask = executor.submit(this::runOnce);
+		return status == Status.RUNNING || status == Status.ROLLED_BACK;
+	}
+
+	private synchronized Future<?> submitInitialTask() {
+		if (closed) return null;
+		if (activeTask == null) activeTask = executor.submit(this::runOnce);
+		return activeTask;
 	}
 
 	/** Downloads and verifies a replacement without disturbing the active process. */

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
@@ -60,11 +60,13 @@ public final class HostedControlManager implements AutoCloseable {
 	private final Consumer<String> logger;
 	private final AtomicBoolean workInProgress = new AtomicBoolean();
 	private final Object processLifecycle = new Object();
+	private final Object preparationLifecycle = new Object();
 	private volatile boolean closed;
 	private volatile Status status = Status.STARTING;
 	private volatile ManagedProcess managedProcess;
 	private volatile ManagedProcess exitAwaitedProcess;
 	private volatile Future<?> activeTask;
+	private volatile PreparedArtifact preparedArtifact;
 	private volatile int failures;
 	private volatile String quarantinedSha256;
 	private volatile String trustedRollbackSha256;
@@ -127,6 +129,21 @@ public final class HostedControlManager implements AutoCloseable {
 		activeTask = executor.submit(this::runOnce);
 	}
 
+	/** Downloads and verifies a replacement without disturbing the active process. */
+	public void prepareForReplacement() throws IOException, InterruptedException {
+		synchronized (preparationLifecycle) {
+			if (closed) throw new IOException("Hosted Control manager is closed");
+			if (activeTask != null || workInProgress.get()) {
+				throw new IOException("Hosted Control manager has already started");
+			}
+			if (preparedArtifact != null) return;
+			secureDirectory(settings.rootDirectory(), settings.jarFile().getParent());
+			secureDirectory(settings.rootDirectory(), settings.dataDirectory());
+			loadPersistedQuarantineStateForPreparation();
+			preparedArtifact = stageArtifact();
+		}
+	}
+
 	void runOnce() {
 		if (closed || !workInProgress.compareAndSet(false, true)) {
 			return;
@@ -148,7 +165,16 @@ public final class HostedControlManager implements AutoCloseable {
 				restoreIncompleteActivation();
 			}
 			recoverPersistedQuarantineState();
-			boolean updated = prepareArtifact();
+			PreparedArtifact prepared = takePreparedArtifact();
+			if (prepared == null) prepared = stageArtifact();
+			boolean updated;
+			synchronized (processLifecycle) {
+				if (closed) {
+					deletePreparedArtifact(prepared);
+					return;
+				}
+				updated = activatePreparedArtifact(prepared);
+			}
 			if (updated) {
 				rollbackCandidateSha256 = settings.sha256();
 				rollbackPending = true;
@@ -222,15 +248,17 @@ public final class HostedControlManager implements AutoCloseable {
 		return false;
 	}
 
-	private boolean prepareArtifact() throws IOException, InterruptedException {
+	private PreparedArtifact stageArtifact() throws IOException, InterruptedException {
 		String installedSha256 = null;
 		if (Files.isRegularFile(settings.jarFile(), LinkOption.NOFOLLOW_LINKS)) {
 			installedSha256 = sha256(settings.jarFile());
 			if (settings.sha256().equals(installedSha256)) {
-				return false;
+				return new PreparedArtifact(null, true, installedSha256);
 			}
 			if (settings.sha256().equals(quarantinedSha256)) {
-				if (installedSha256.equals(trustedRollbackSha256)) return false;
+				if (installedSha256.equals(trustedRollbackSha256)) {
+					return new PreparedArtifact(null, true, installedSha256);
+				}
 				throw new IOException("Rolled-back Control artifact no longer matches its trusted digest");
 			}
 			trustedRollbackSha256 = installedSha256;
@@ -254,10 +282,47 @@ public final class HostedControlManager implements AutoCloseable {
 			if (!settings.sha256().equals(sha256(staged))) {
 				throw new IOException("Downloaded Control artifact failed SHA-256 verification");
 			}
-			activate(staged, installed, installedSha256);
+			return new PreparedArtifact(staged, installed, installedSha256);
+		} catch (IOException | InterruptedException | RuntimeException e) {
+			Files.deleteIfExists(staged);
+			throw e;
+		}
+	}
+
+	private boolean activatePreparedArtifact(PreparedArtifact prepared) throws IOException {
+		if (prepared.staged() == null) return false;
+		try {
+			boolean installed = Files.isRegularFile(settings.jarFile(), LinkOption.NOFOLLOW_LINKS);
+			String installedSha256 = installed ? sha256(settings.jarFile()) : null;
+			if (installed != prepared.installed()
+					|| !Objects.equals(installedSha256, prepared.installedSha256())) {
+				throw new IOException("Control artifact changed while its replacement was staged");
+			}
+			activate(prepared.staged(), installed, installedSha256);
 			return installed;
 		} finally {
-			Files.deleteIfExists(staged);
+			Files.deleteIfExists(prepared.staged());
+		}
+	}
+
+	private PreparedArtifact takePreparedArtifact() {
+		synchronized (preparationLifecycle) {
+			PreparedArtifact prepared = preparedArtifact;
+			preparedArtifact = null;
+			return prepared;
+		}
+	}
+
+	private void discardPreparedArtifact() {
+		deletePreparedArtifact(takePreparedArtifact());
+	}
+
+	private void deletePreparedArtifact(PreparedArtifact prepared) {
+		if (prepared == null || prepared.staged() == null) return;
+		try {
+			Files.deleteIfExists(prepared.staged());
+		} catch (IOException ignored) {
+			// The contained staging file is best-effort cleanup during shutdown.
 		}
 	}
 
@@ -389,6 +454,18 @@ public final class HostedControlManager implements AutoCloseable {
 		}
 		trustedRollbackSha256 = previousSha256;
 		quarantinedSha256 = candidateSha256;
+	}
+
+	/** Reads a matching quarantine without clearing state still owned by the active manager. */
+	private void loadPersistedQuarantineStateForPreparation() throws IOException {
+		String[] lines = readDigestState(settings.quarantineFile(), "quarantine");
+		if (lines == null || !settings.sha256().equals(lines[1])) return;
+		if (!Files.isRegularFile(settings.jarFile(), LinkOption.NOFOLLOW_LINKS)
+				|| !lines[0].equals(sha256(settings.jarFile()))) {
+			throw new IOException("Active Control artifact does not match quarantined rollback state");
+		}
+		trustedRollbackSha256 = lines[0];
+		quarantinedSha256 = lines[1];
 	}
 
 	private String[] readDigestState(Path marker, String name) throws IOException {
@@ -562,6 +639,7 @@ public final class HostedControlManager implements AutoCloseable {
 		} catch (RuntimeException failure) {
 			shutdownFailure = failure;
 		} finally {
+			discardPreparedArtifact();
 			executor.shutdownNow();
 		}
 		if (waitForProcess) {
@@ -700,6 +778,8 @@ public final class HostedControlManager implements AutoCloseable {
 	public record HostConfiguration(boolean enabled, boolean autoDownload, boolean autoUpdate, String downloadUrl,
 			String sha256, String jarFile, String dataDirectory, String host, int port, int startupTimeoutSeconds,
 			int downloadTimeoutSeconds) { }
+
+	private record PreparedArtifact(Path staged, boolean installed, String installedSha256) { }
 
 	record Settings(Path rootDirectory, Path jarFile, Path dataDirectory, boolean autoDownload, boolean autoUpdate,
 			URI downloadUri, String sha256, String host, int port, int startupTimeoutSeconds,

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/HostedControlManager.java
@@ -92,18 +92,32 @@ public final class HostedControlManager implements AutoCloseable {
 
 	public static HostedControlManager create(VotingPluginProxy proxy) {
 		VotingPluginProxyConfig config = proxy.getConfig();
-		if (!config.getControlHostedEnabled()) {
-			return null;
-		}
-		Path root = proxy.getDataFolderPlugin().toPath().toAbsolutePath().normalize();
-		Settings settings = new Settings(root,
-				resolveInside(root, config.getControlHostedJarFile(), "Control hosted JAR"),
-				resolveInside(root, config.getControlHostedDataDirectory(), "Control hosted data directory"),
+		HostConfiguration hosted = new HostConfiguration(config.getControlHostedEnabled(),
 				config.getControlHostedAutoDownload(), config.getControlHostedAutoUpdate(),
-				parseDownloadUri(config.getControlHostedDownloadUrl()), config.getControlHostedSha256(),
+				config.getControlHostedDownloadUrl(), config.getControlHostedSha256(),
+				config.getControlHostedJarFile(), config.getControlHostedDataDirectory(),
 				config.getControlHostedHost(), config.getControlHostedPort(),
 				config.getControlHostedStartupTimeoutSeconds(), config.getControlHostedDownloadTimeoutSeconds());
-		return new HostedControlManager(settings, message -> proxy.log("[Control Host] " + message));
+		return create(proxy.getDataFolderPlugin().toPath(), hosted,
+				message -> proxy.log("[Control Host] " + message));
+	}
+
+	/**
+	 * Creates the platform-neutral hosted Control supervisor. Bukkit uses this
+	 * entry point so the shared manager never links against the Bukkit API when it
+	 * is loaded on BungeeCord or Velocity.
+	 */
+	public static HostedControlManager create(Path rootDirectory, HostConfiguration config,
+			Consumer<String> logger) {
+		Objects.requireNonNull(config, "config");
+		if (!config.enabled()) return null;
+		Path root = Objects.requireNonNull(rootDirectory, "rootDirectory").toAbsolutePath().normalize();
+		Settings settings = new Settings(root,
+				resolveInside(root, config.jarFile(), "Control hosted JAR"),
+				resolveInside(root, config.dataDirectory(), "Control hosted data directory"),
+				config.autoDownload(), config.autoUpdate(), parseDownloadUri(config.downloadUrl()), config.sha256(),
+				config.host(), config.port(), config.startupTimeoutSeconds(), config.downloadTimeoutSeconds());
+		return new HostedControlManager(settings, Objects.requireNonNull(logger, "logger"));
 	}
 
 	public void start() {
@@ -681,6 +695,11 @@ public final class HostedControlManager implements AutoCloseable {
 	public enum Status {
 		STARTING, DOWNLOADING, STARTING_PROCESS, RUNNING, ROLLED_BACK, FAILED, STOPPED
 	}
+
+	/** Platform configuration for the separate hosted Control process. */
+	public record HostConfiguration(boolean enabled, boolean autoDownload, boolean autoUpdate, String downloadUrl,
+			String sha256, String jarFile, String dataDirectory, String host, int port, int startupTimeoutSeconds,
+			int downloadTimeoutSeconds) { }
 
 	record Settings(Path rootDirectory, Path jarFile, Path dataDirectory, boolean autoDownload, boolean autoUpdate,
 			URI downloadUri, String sha256, String host, int port, int startupTimeoutSeconds,

--- a/VotingPlugin/src/main/resources/Config.yml
+++ b/VotingPlugin/src/main/resources/Config.yml
@@ -1165,6 +1165,24 @@ Webhooks:
 ###########################################
 
 Control:
+  # Optionally let this Bukkit/Paper backend provision and supervise VotingPlugin Control as a separate JVM.
+  # Enable this on only one proxy or backend in the network.
+  Hosted:
+    Enabled: false
+    # Download a missing artifact. An exact SHA-256 pin is always required.
+    AutoDownload: true
+    # Disabled by default. When enabled, a new configured SHA-256 may replace the installed artifact.
+    AutoUpdate: false
+    # Use a versioned release asset URL; /latest/ URLs are rejected.
+    DownloadUrl: ''
+    Sha256: ''
+    # Both paths must remain relative to this backend's VotingPlugin data folder.
+    JarFile: 'control/votingplugin-control.jar'
+    DataDirectory: 'control/data'
+    Host: '127.0.0.1'
+    Port: 8080
+    StartupTimeoutSeconds: 30
+    DownloadTimeoutSeconds: 60
   Backend:
     Enabled: false
     # Must be unique for every Bukkit/Paper backend in the network.

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlResultStoreTest.java
@@ -17,10 +17,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.bencodez.votingplugin.control.BackendControlResultStore.Route;
 import com.bencodez.votingplugin.control.BackendControlResultStore.StoredResult;
+import com.bencodez.votingplugin.proxy.control.HostedControlManager.HostConfiguration;
 import com.google.gson.JsonObject;
 
 class BackendControlResultStoreTest {
 	@TempDir Path directory;
+	private final HostConfiguration hosted = new HostConfiguration(true, false, false, "", "0".repeat(64),
+			"control/control.jar", "control/data", "127.0.0.1", 8080, 30, 60);
 
 	@Test void pendingResultAndOriginalRouteSurviveRestartUntilAcknowledged() throws Exception {
 		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000099");
@@ -32,13 +35,14 @@ class BackendControlResultStoreTest {
 		Map<UUID, StoredResult> pending = new LinkedHashMap<>();
 		pending.put(operationId, new StoredResult(result, true, true, false));
 
-		BackendControlResultStore.save(directory, route, pending);
+		BackendControlResultStore.save(directory, route, hosted, pending);
 		BackendControlResultStore.State recovered = BackendControlResultStore.load(directory);
 
 		assertEquals(route, recovered.route());
+		assertEquals(hosted, recovered.hostedConfiguration());
 		assertEquals("applied-revision", recovered.results().get(operationId).result().get("revision").getAsString());
 		assertTrue(recovered.results().get(operationId).committed());
-		BackendControlResultStore.save(directory, route, Map.of());
+		BackendControlResultStore.save(directory, route, hosted, Map.of());
 		assertFalse(Files.exists(directory.resolve(".control-pending-results.json")));
 	}
 
@@ -49,7 +53,7 @@ class BackendControlResultStoreTest {
 		JsonObject result = new JsonObject();
 		result.addProperty("revision", "anticipated-revision");
 
-		BackendControlResultStore.save(directory, route,
+		BackendControlResultStore.save(directory, route, hosted,
 				Map.of(operationId, new StoredResult(result, false, false, false)));
 
 		StoredResult recovered = BackendControlResultStore.load(directory).results().get(operationId);
@@ -76,7 +80,7 @@ class BackendControlResultStoreTest {
 		result.addProperty("success", true);
 		result.add("configuration", configuration);
 
-		BackendControlResultStore.save(directory, route,
+		BackendControlResultStore.save(directory, route, hosted,
 				Map.of(UUID.fromString("00000000-0000-0000-0000-000000000099"),
 						new StoredResult(result, false, true, false)));
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlResultStoreTest.java
@@ -61,6 +61,37 @@ class BackendControlResultStoreTest {
 		assertFalse(recovered.claimRequired());
 	}
 
+	@Test void versionTwoJournalRecoversWithBackendHostingDisabled() throws Exception {
+		JsonObject root = new JsonObject();
+		root.addProperty("version", 2);
+		JsonObject route = new JsonObject();
+		route.addProperty("nodeId", "backend-old");
+		route.addProperty("endpoint", "https://control.example:8443");
+		route.addProperty("credentialFile", "old-credential.txt");
+		route.addProperty("heartbeatSeconds", 30);
+		route.addProperty("connectTimeoutMillis", 3000);
+		route.addProperty("requestTimeoutMillis", 10000);
+		root.add("route", route);
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+		JsonObject pending = new JsonObject();
+		pending.addProperty("operationId", "00000000-0000-0000-0000-000000000099");
+		pending.add("result", result);
+		pending.addProperty("restartConnector", true);
+		pending.addProperty("committed", true);
+		pending.addProperty("claimRequired", false);
+		com.google.gson.JsonArray results = new com.google.gson.JsonArray();
+		results.add(pending);
+		root.add("results", results);
+		Files.writeString(directory.resolve(".control-pending-results.json"), root.toString());
+
+		BackendControlResultStore.State recovered = BackendControlResultStore.load(directory);
+
+		assertEquals(URI.create("https://control.example:8443"), recovered.route().endpoint());
+		assertFalse(recovered.hostedConfiguration().enabled());
+		assertTrue(recovered.results().values().iterator().next().committed());
+	}
+
 	@Test void symbolicPendingResultJournalIsRejected() throws Exception {
 		Path external = directory.resolve("external.json");
 		Files.writeString(external, "{}");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
@@ -2,6 +2,7 @@ package com.bencodez.votingplugin.proxy.control;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +44,17 @@ class HostedControlManagerTest {
 						"https://github.com/BenCodez/VotingPlugin-Control/releases/latest/download/control.jar"));
 		assertThrows(IllegalArgumentException.class, () -> settings(root.resolve("control.jar"), root.resolve("data"),
 				true, false, "not-a-digest", 30));
+	}
+
+	@Test
+	void platformNeutralFactoryKeepsHostingOptIn() {
+		HostedControlManager.HostConfiguration disabled = new HostedControlManager.HostConfiguration(false, true,
+				false, "", "", "control/control.jar", "control/data", "127.0.0.1", 8080, 30, 60);
+		assertNull(HostedControlManager.create(directory, disabled, message -> { }));
+		HostedControlManager.HostConfiguration escaping = new HostedControlManager.HostConfiguration(true, false,
+				false, "", "0".repeat(64), "../control.jar", "control/data", "127.0.0.1", 8080, 30, 60);
+		assertThrows(IllegalArgumentException.class,
+				() -> HostedControlManager.create(directory, escaping, message -> { }));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
@@ -55,6 +55,10 @@ class HostedControlManagerTest {
 				false, "", "0".repeat(64), "../control.jar", "control/data", "127.0.0.1", 8080, 30, 60);
 		assertThrows(IllegalArgumentException.class,
 				() -> HostedControlManager.create(directory, escaping, message -> { }));
+		HostedControlManager.HostConfiguration invalidHost = new HostedControlManager.HostConfiguration(true, false,
+				false, "", "0".repeat(64), "control/control.jar", "control/data", "[", 8080, 30, 60);
+		assertThrows(IllegalArgumentException.class,
+				() -> HostedControlManager.create(directory, invalidHost, message -> { }));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
@@ -233,7 +233,7 @@ class HostedControlManagerTest {
 
 		assertEquals("previous-release", Files.readString(jar));
 		assertTrue(launcher.launchedContents.isEmpty());
-		manager.runOnce();
+		assertTrue(manager.startAndWaitForInitialResult());
 		assertEquals(List.of("new-release"), launcher.launchedContents);
 		manager.close();
 	}
@@ -258,6 +258,25 @@ class HostedControlManagerTest {
 
 		assertEquals("previous-release", Files.readString(jar));
 		assertTrue(launcher.launchedContents.isEmpty());
+		manager.close();
+	}
+
+	@Test
+	void initialHealthFailureIsReportedToLifecycleCaller() throws Exception {
+		byte[] release = "new-release".getBytes(StandardCharsets.UTF_8);
+		Path root = directory.toAbsolutePath().normalize();
+		Path jar = root.resolve("control/control.jar");
+		HostedControlManager.Settings settings = settings(jar, root.resolve("control/data"), true, false,
+				digest(release), 1);
+		AtomicLong clock = new AtomicLong();
+		HostedControlManager manager = new HostedControlManager(settings,
+				Executors.newSingleThreadScheduledExecutor(),
+				(source, target, maximum, timeout) -> Files.write(target, release), new FakeLauncher(),
+				(endpoint, timeout, launchId) -> false,
+				millis -> clock.addAndGet(TimeUnit.MILLISECONDS.toNanos(millis)), clock::get, message -> { });
+
+		assertFalse(manager.startAndWaitForInitialResult());
+		assertEquals(HostedControlManager.Status.FAILED, manager.status());
 		manager.close();
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/HostedControlManagerTest.java
@@ -214,6 +214,54 @@ class HostedControlManagerTest {
 	}
 
 	@Test
+	void replacementIsDownloadedAndVerifiedBeforeActiveArtifactChanges() throws Exception {
+		byte[] previous = "previous-release".getBytes(StandardCharsets.UTF_8);
+		byte[] update = "new-release".getBytes(StandardCharsets.UTF_8);
+		Path root = directory.toAbsolutePath().normalize();
+		Path jar = root.resolve("control/control.jar");
+		Files.createDirectories(jar.getParent());
+		Files.write(jar, previous);
+		HostedControlManager.Settings settings = settings(jar, root.resolve("control/data"), true, true,
+				digest(update), 30);
+		FakeLauncher launcher = new FakeLauncher();
+		HostedControlManager manager = new HostedControlManager(settings,
+				Executors.newSingleThreadScheduledExecutor(),
+				(source, target, maximum, timeout) -> Files.write(target, update), launcher,
+				(endpoint, timeout, launchId) -> true, millis -> { }, System::nanoTime, message -> { });
+
+		manager.prepareForReplacement();
+
+		assertEquals("previous-release", Files.readString(jar));
+		assertTrue(launcher.launchedContents.isEmpty());
+		manager.runOnce();
+		assertEquals(List.of("new-release"), launcher.launchedContents);
+		manager.close();
+	}
+
+	@Test
+	void unusableReplacementDoesNotChangeActiveArtifact() throws Exception {
+		byte[] previous = "previous-release".getBytes(StandardCharsets.UTF_8);
+		byte[] update = "new-release".getBytes(StandardCharsets.UTF_8);
+		Path root = directory.toAbsolutePath().normalize();
+		Path jar = root.resolve("control/control.jar");
+		Files.createDirectories(jar.getParent());
+		Files.write(jar, previous);
+		HostedControlManager.Settings settings = settings(jar, root.resolve("control/data"), true, false,
+				digest(update), 30);
+		FakeLauncher launcher = new FakeLauncher();
+		HostedControlManager manager = new HostedControlManager(settings,
+				Executors.newSingleThreadScheduledExecutor(),
+				(source, target, maximum, timeout) -> { throw new AssertionError("replacement downloaded"); },
+				launcher, (endpoint, timeout, launchId) -> true, millis -> { }, System::nanoTime, message -> { });
+
+		assertThrows(IOException.class, manager::prepareForReplacement);
+
+		assertEquals("previous-release", Files.readString(jar));
+		assertTrue(launcher.launchedContents.isEmpty());
+		manager.close();
+	}
+
+	@Test
 	void manualPinnedInstallNeedsNoDownloaderAndCloseIsNonBlocking() throws Exception {
 		byte[] release = "manual-release".getBytes(StandardCharsets.UTF_8);
 		Path root = directory.toAbsolutePath().normalize();

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -168,9 +168,10 @@ installed plugin names for WebUI command suggestions and negotiates
 `config.files.v1` and `config.quick-setup.v1`, then polls the same outbound operation queue as proxies. File apply schedules
 the VotingPlugin reload on the Bukkit thread and waits only on the connector worker. Control failure never blocks votes,
 joins, commands, or plugin shutdown. A successful `Config.yml` apply reports its result first, then recreates the connector
-so changes to `Control.Backend` take effect without a full server restart. If `Control.Hosted` changed, the existing child
-is asked to stop only after that result is acknowledged and a replacement supervisor starts with the new settings. Invalid
-host settings leave the currently running Control child unchanged.
+so changes to `Control.Backend` take effect without a full server restart. If `Control.Hosted` changed, a dedicated daemon
+lifecycle worker waits for the existing child to stop only after that result is acknowledged, then starts the replacement
+with the new settings. This prevents the old and new children from racing for the same listener. Invalid host settings leave
+the currently running Control child unchanged.
 
 ## Discovery semantics
 

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -4,7 +4,8 @@ This development milestone adds an optional connector from the BungeeCord and Ve
 to the separate [VotingPlugin Control](https://github.com/BenCodez/VotingPlugin-Control) application. It discovers each
 proxy and its eligible backend server names. Enrolled Bukkit nodes can also connect outbound for full configuration-file
 and quick-setup control. Control includes the local WebUI. VotingPlugin may now explicitly opt in to
-provisioning and supervising that application as a separate child JVM; it is never loaded into the proxy classloader. The
+provisioning and supervising that application from either a proxy or a Bukkit backend as a separate child JVM; it is
+never loaded into the proxy or server classloader. The
 connector does not expose backend addresses. Configuration secrets are masked on every read and never enter audit records.
 
 ## Failure isolation
@@ -20,14 +21,15 @@ Shutdown cancels the scheduled cycle and active future without waiting indefinit
 
 The hosted-Control manager is independently disabled by default. Downloads, hashing, activation, health checks, process
 startup, and restart backoff run on its own daemon worker. Hosting failure changes only its redacted status/log and never
-blocks the proxy event loop or vote processing. Stopping VotingPlugin asks only the child process it created to terminate
+blocks the proxy event loop, Bukkit server thread, or vote processing. Stopping VotingPlugin asks only the child process it created to terminate
 and applies a bounded asynchronous force-stop fallback.
 
 ## Optional hosted WebUI
 
-Use one hosted Control instance for the network. Other proxies should use the connector against that instance rather than
-each starting a competing service. Hosting and discovery are separate switches: `Control.Hosted.Enabled` runs Control,
-while `Control.Enabled` reports this proxy to it.
+Use one hosted Control instance for the network. It may run on one BungeeCord/Velocity proxy or on one Bukkit/Paper backend.
+Every other node should use its connector against that instance rather than starting a competing service. Hosting and
+discovery are separate switches: `Control.Hosted.Enabled` runs Control, while proxy `Control.Enabled` or backend
+`Control.Backend.Enabled` enrolls and reports that node to it.
 
 Control releases publish `votingplugin-control.jar` and `votingplugin-control.jar.sha256`. Configure an immutable versioned
 asset URL and copy its exact digest into `Sha256`; `/latest/` URLs, unpinned artifacts, plaintext download URLs, redirects
@@ -53,8 +55,35 @@ Control:
     DownloadTimeoutSeconds: 60
 ```
 
+The same hosted block may instead be placed in the backend's `Config.yml`, alongside `Control.Backend`. In this example the
+backend both hosts Control and enrolls itself for full configuration management:
+
+```yaml
+Control:
+  Hosted:
+    Enabled: true
+    AutoDownload: true
+    AutoUpdate: false
+    DownloadUrl: 'https://github.com/BenCodez/VotingPlugin-Control/releases/download/v0.1.0/votingplugin-control.jar'
+    Sha256: '<64-character SHA-256 from the pinned release>'
+    JarFile: 'control/votingplugin-control.jar'
+    DataDirectory: 'control/data'
+    Host: '127.0.0.1'
+    Port: 8080
+    StartupTimeoutSeconds: 30
+    DownloadTimeoutSeconds: 60
+  Backend:
+    Enabled: true
+    NodeId: 'backend-lobby'
+    Endpoint: 'http://127.0.0.1:8080'
+    CredentialFile: 'control-credential.txt'
+    HeartbeatSeconds: 30
+    ConnectTimeoutMillis: 3000
+    RequestTimeoutMillis: 10000
+```
+
 On first start, the artifact is downloaded to a unique staging file with a 64 MiB hard limit, verified, and atomically
-activated before launch with the same Java runtime as the proxy. An existing matching manual installation is launched
+activated before launch with the same Java runtime as the hosting proxy or backend. An existing matching manual installation is launched
 without downloading. `AutoUpdate` is false by default; when explicitly enabled and the configured digest changes, the
 current release is retained as `.previous`. A failed process/protocol health check atomically restores and starts that
 previous release, retaining the failed candidate as `.failed`. Unexpected exits use bounded restart backoff.
@@ -83,8 +112,8 @@ Manual installation remains supported: put a Control JAR at `JarFile`, configure
    java -jar votingplugin-control-0.1.0-SNAPSHOT-all.jar enroll proxy-a data
    ```
 
-2. On that proxy, create `plugins/VotingPlugin/control-credential.txt` (or the platform-equivalent VotingPlugin proxy data
-   directory) containing only the printed credential. Restrict filesystem access to the proxy service account.
+2. On that proxy or backend, create `plugins/VotingPlugin/control-credential.txt` (or the platform-equivalent VotingPlugin
+   data directory) containing only the printed credential. Restrict filesystem access to the Minecraft service account.
 
 3. Configure `bungeeconfig.yml`:
 
@@ -139,7 +168,9 @@ installed plugin names for WebUI command suggestions and negotiates
 `config.files.v1` and `config.quick-setup.v1`, then polls the same outbound operation queue as proxies. File apply schedules
 the VotingPlugin reload on the Bukkit thread and waits only on the connector worker. Control failure never blocks votes,
 joins, commands, or plugin shutdown. A successful `Config.yml` apply reports its result first, then recreates the connector
-so changes to `Control.Backend` take effect without a full server restart.
+so changes to `Control.Backend` take effect without a full server restart. If `Control.Hosted` changed, the existing child
+is asked to stop only after that result is acknowledged and a replacement supervisor starts with the new settings. Invalid
+host settings leave the currently running Control child unchanged.
 
 ## Discovery semantics
 

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -171,7 +171,8 @@ joins, commands, or plugin shutdown. A successful `Config.yml` apply reports its
 so changes to `Control.Backend` take effect without a full server restart. If `Control.Hosted` changed, a dedicated daemon
 lifecycle worker waits for the existing child to stop only after that result is acknowledged, then starts the replacement
 with the new settings. This prevents the old and new children from racing for the same listener. Invalid host settings leave
-the currently running Control child unchanged.
+the currently running Control child unchanged. If the backend restarts with a pending result, the durable journal also
+restores the previous hosted settings until that result is acknowledged, preserving the recovery connector's endpoint.
 
 ## Discovery semantics
 


### PR DESCRIPTION
## Summary

- allow a Bukkit/Paper backend to provision and supervise the separate VotingPlugin Control JVM using `Config.yml` → `Control.Hosted`
- reuse the existing pinned download, atomic activation, health checking, rollback, restart backoff, and child-process isolation used by proxy hosting
- start hosting before the backend connector, stop the child during plugin unload, and expose a redacted backend-host lifecycle status
- reconcile hosted settings and the backend connector together off the Bukkit thread, while applying Control-originated changes only after their result is acknowledged
- close and drain the old connector before loading durable state into its replacement, retain deferred reloads until pending results drain, and retry bounded shutdown timeouts
- preserve the previous hosted endpoint across restart while durable Control results are pending, including version-2 journal migration
- fully download and verify a replacement artifact before stopping a healthy hosted Control process
- keep requested and active hosted state separate so durable snapshots and queued reloads cannot disrupt the running host
- restore the previous healthy host if a replacement cannot launch or pass health checks
- interrupt provisioning and synchronously close every tracked hosted manager during plugin unload
- document backend hosting and include disabled-by-default configuration

Only one proxy or backend should enable hosted Control for a network. Hosting remains independent of backend enrollment through `Control.Backend`.

## Validation

- Java CI with Maven: passed (run 589)
- parsed the updated default `Config.yml` and existing `bungeeconfig.yml` as YAML
- `git diff --check`
- Codex code review: completed with no open findings on `afc5a59`

AI disclosure: This pull request was created with assistance from OpenAI Codex and reviewed by BenCodez.