### PR TITLE
Restore /vote togglereminders

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -3337,7 +3337,7 @@ public class CommandLoader {
 				});
 
 		plugin.getVoteCommand().add(new CommandHandler(plugin, new String[] { "ToggleReminders" },
-				"VotingPlugin.Commands.Vote.ToggleReminders", "Enable/disable vote reminders", false) {
+				"VotingPlugin.Commands.Vote.ToggleReminders|" + playerPerm, "Enable/disable vote reminders", false) {
 
 			@Override
 			public void execute(CommandSender sender, String[] args) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -3336,6 +3336,24 @@ public class CommandLoader {
 					}
 				});
 
+		plugin.getVoteCommand().add(new CommandHandler(plugin, new String[] { "ToggleReminders" },
+				"VotingPlugin.Commands.Vote.ToggleReminders", "Enable/disable vote reminders", false) {
+
+			@Override
+			public void execute(CommandSender sender, String[] args) {
+				VotingPluginUser user = plugin.getVotingPluginUserManager()
+						.getVotingPluginUser((Player) sender);
+				boolean enabled = plugin.getVoteRemindersManager().toggleReminders(user.getJavaUUID());
+				plugin.getPlaceholders().onUpdate(user, true);
+
+				if (enabled) {
+					sendMessage(sender, plugin.getConfigFile().getFormatCommandsVoteToggleRemindersEnabled());
+				} else {
+					sendMessage(sender, plugin.getConfigFile().getFormatCommandsVoteToggleRemindersDisabled());
+				}
+			}
+		});
+
 		plugin.getVoteCommand().add(new CommandHandler(plugin, new String[] { "Next", "(player)" },
 				"VotingPlugin.Commands.Vote.Next.Other|" + modPerm, "See other players next votes") {
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
@@ -346,19 +346,13 @@ public class PlaceHolders {
 			}
 		}.withDescription("Returns true/false if user has broadcast disabled").updateDataKey("DisableBroadcast"));
 
-		/*
-		 * placeholders.add(new PlaceHolder<VotingPluginUser>("DisableReminders") {
-		 * 
-		 * @Override public String placeholderRequest(VotingPluginUser user, String
-		 * identifier) { if
-		 * (plugin.getVoteReminding().getRemindersEnabled().containsKey(user.getJavaUUID
-		 * ())) { if
-		 * (!plugin.getVoteReminding().getRemindersEnabled().get(user.getJavaUUID()).
-		 * booleanValue()) {
-		 * 
-		 * return "True"; } } return "False"; }
-		 * }.withDescription("Returns true/false if user has reminders disabled"));
-		 */
+		placeholders.add(new PlaceHolder<VotingPluginUser>("DisableReminders") {
+
+			@Override
+			public String placeholderRequest(VotingPluginUser user, String identifier) {
+				return plugin.getVoteRemindersManager().isRemindersEnabled(user.getJavaUUID()) ? "False" : "True";
+			}
+		}.withDescription("Returns true/false if user has reminders disabled"));
 
 		for (final String identifier : plugin.getShopFile().getShopIdentifiers()) {
 			if (plugin.getShopFile().getShopIdentifierLimit(identifier) > 0) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votereminding/VoteRemindersManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votereminding/VoteRemindersManager.java
@@ -856,6 +856,11 @@ public final class VoteRemindersManager {
 
 	private boolean attemptFireNow(VotingPluginUser user, Player player, VoteReminderDefinition def,
 			Map<String, String> placeholders) {
+		if (!isUserReminderEnabled(user)) {
+			plugin.extraDebug("[VoteReminders] gate disabled-reminders-map for " + user.getPlayerName()
+					+ " def=" + def.getName());
+			return false;
+		}
 
 		if (!user.shouldBeReminded()) {
 			plugin.extraDebug(

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/votereminding/VoteRemindersManager.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/votereminding/VoteRemindersManager.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -272,6 +273,7 @@ public final class VoteRemindersManager {
 
 	private final VotingPluginMain plugin;
 	private final VoteReminderCooldownStore store;
+	private final Set<UUID> disabledReminders = ConcurrentHashMap.newKeySet();
 
 	private VoteReminderOptions options;
 	private VoteReminderCooldowns cooldowns;
@@ -331,6 +333,7 @@ public final class VoteRemindersManager {
 	public VoteRemindersManager(VotingPluginMain plugin, VoteReminderCooldownStore store) {
 		this.plugin = plugin;
 		this.store = store;
+		loadDisabledReminders();
 
 		this.scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
 			private final AtomicInteger n = new AtomicInteger();
@@ -351,6 +354,7 @@ public final class VoteRemindersManager {
 	public void reload() {
 		stopTasks();
 
+		loadDisabledReminders();
 		loadConfig();
 		this.cooldowns = new VoteReminderCooldowns(store, options.getGlobalCooldown());
 
@@ -965,7 +969,56 @@ public final class VoteRemindersManager {
 	}
 
 	private boolean isUserReminderEnabled(VotingPluginUser user) {
-		return true;
+		return isRemindersEnabled(user.getJavaUUID());
+	}
+
+	/**
+	 * Checks whether vote reminders are enabled for a player.
+	 *
+	 * @param uuid the player's UUID
+	 * @return true when reminders are enabled
+	 */
+	public boolean isRemindersEnabled(UUID uuid) {
+		return uuid == null || !disabledReminders.contains(uuid);
+	}
+
+	/**
+	 * Toggles and immediately persists a player's vote reminder preference.
+	 *
+	 * @param uuid the player's UUID
+	 * @return the new enabled state
+	 */
+	public synchronized boolean toggleReminders(UUID uuid) {
+		if (uuid == null) {
+			return true;
+		}
+
+		boolean enabled;
+		if (disabledReminders.remove(uuid)) {
+			enabled = true;
+		} else {
+			disabledReminders.add(uuid);
+			enabled = false;
+		}
+		saveDisabledReminders();
+		return enabled;
+	}
+
+	private synchronized void loadDisabledReminders() {
+		disabledReminders.clear();
+		for (String uuid : plugin.getServerData().getDisabledReminders()) {
+			try {
+				disabledReminders.add(UUID.fromString(uuid));
+			} catch (IllegalArgumentException e) {
+				plugin.getLogger().warning("Ignoring invalid UUID in VotingPlugin.DisabledReminders: " + uuid);
+			}
+		}
+	}
+
+	private void saveDisabledReminders() {
+		ArrayList<UUID> uuids = new ArrayList<>(disabledReminders);
+		uuids.sort(Comparator.comparing(UUID::toString));
+		plugin.getServerData().saveDisabledReminders(uuids);
 	}
 
 	/*

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/reminders/VoteRemindersManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/reminders/VoteRemindersManagerTest.java
@@ -2,11 +2,15 @@ package com.bencodez.votingplugin.tests.reminders;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
@@ -15,6 +19,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.bencodez.simpleapi.time.ParsedDuration;
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.data.ServerData;
 import com.bencodez.votingplugin.votereminding.VoteRemindersManager;
 import com.bencodez.votingplugin.votereminding.store.VoteReminderCooldownStore;
 
@@ -65,5 +71,31 @@ public class VoteRemindersManagerTest {
 
 		cd.markFired(uuid, "Basic", 123L);
 		verify(store).setPerReminderLast(uuid, "Basic", 123L);
+	}
+
+	@Test
+	public void reminderPreference_loadsLegacyDisabledPlayersAndPersistsToggles() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class);
+		ServerData serverData = mock(ServerData.class);
+		VoteReminderCooldownStore store = mock(VoteReminderCooldownStore.class);
+		UUID disabled = UUID.randomUUID();
+		UUID enabled = UUID.randomUUID();
+
+		when(plugin.getServerData()).thenReturn(serverData);
+		when(serverData.getDisabledReminders()).thenReturn(Arrays.asList(disabled.toString()));
+
+		VoteRemindersManager manager = new VoteRemindersManager(plugin, store);
+		try {
+			assertFalse(manager.isRemindersEnabled(disabled));
+			assertTrue(manager.isRemindersEnabled(enabled));
+
+			assertTrue(manager.toggleReminders(disabled));
+			assertFalse(manager.toggleReminders(enabled));
+
+			verify(serverData, times(2)).saveDisabledReminders(any());
+			verify(serverData).saveDisabledReminders(argThat(uuids -> uuids.size() == 1 && uuids.contains(enabled)));
+		} finally {
+			manager.shutdown();
+		}
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/reminders/VoteRemindersManagerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/reminders/VoteRemindersManagerTest.java
@@ -6,14 +6,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
+import org.bukkit.entity.Player;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,7 +25,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.bencodez.simpleapi.time.ParsedDuration;
 import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.data.ServerData;
+import com.bencodez.votingplugin.user.VotingPluginUser;
 import com.bencodez.votingplugin.votereminding.VoteRemindersManager;
+import com.bencodez.votingplugin.votereminding.VoteRemindersManager.VoteReminderConditions;
+import com.bencodez.votingplugin.votereminding.VoteRemindersManager.VoteReminderDefinition;
+import com.bencodez.votingplugin.votereminding.VoteRemindersManager.VoteReminderType;
 import com.bencodez.votingplugin.votereminding.store.VoteReminderCooldownStore;
 
 @ExtendWith(MockitoExtension.class)
@@ -94,6 +102,37 @@ public class VoteRemindersManagerTest {
 
 			verify(serverData, times(2)).saveDisabledReminders(any());
 			verify(serverData).saveDisabledReminders(argThat(uuids -> uuids.size() == 1 && uuids.contains(enabled)));
+		} finally {
+			manager.shutdown();
+		}
+	}
+
+	@Test
+	public void fireAttempt_rechecksReminderPreferenceAfterDelay() throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class);
+		ServerData serverData = mock(ServerData.class);
+		VoteReminderCooldownStore store = mock(VoteReminderCooldownStore.class);
+		VotingPluginUser user = mock(VotingPluginUser.class);
+		UUID uuid = UUID.randomUUID();
+
+		when(plugin.getServerData()).thenReturn(serverData);
+		when(serverData.getDisabledReminders()).thenReturn(Collections.emptyList());
+		when(user.getJavaUUID()).thenReturn(uuid);
+		when(user.getPlayerName()).thenReturn("TestPlayer");
+
+		VoteRemindersManager manager = new VoteRemindersManager(plugin, store);
+		try {
+			assertFalse(manager.toggleReminders(uuid));
+
+			VoteReminderDefinition definition = new VoteReminderDefinition("Delayed", VoteReminderType.LOGIN, 0,
+					ParsedDuration.parse(""), ParsedDuration.parse(""), "", new VoteReminderConditions(),
+					ParsedDuration.parse(""));
+			Method attemptFireNow = VoteRemindersManager.class.getDeclaredMethod("attemptFireNow",
+					VotingPluginUser.class, Player.class, VoteReminderDefinition.class, Map.class);
+			attemptFireNow.setAccessible(true);
+
+			assertFalse((boolean) attemptFireNow.invoke(manager, user, null, definition, null));
+			verify(user, never()).shouldBeReminded();
 		} finally {
 			manager.shutdown();
 		}


### PR DESCRIPTION
## Summary
- restore `/vote togglereminders` with the original `VotingPlugin.Commands.Vote.ToggleReminders` permission and default `VotingPlugin.Player` access
- reconnect the new reminder engine's per-player enabled gate to persisted `ServerData.yml` `DisabledReminders` preferences
- recheck the preference immediately before firing so reminders queued during a delay respect later opt-outs
- restore the `DisableReminders` placeholder
- add regression coverage for legacy preference loading, toggle persistence, and delayed firing

## Testing
- `mvn -f VotingPlugin/pom.xml test` (394 tests passed)