### PR TITLE
Create Control credential placeholder under control directory

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -130,7 +130,7 @@ public final class BackendControlConnector implements AutoCloseable {
 				|| (endpoint.getPath() != null && !endpoint.getPath().isEmpty() && !"/".equals(endpoint.getPath()))) {
 			throw new IllegalArgumentException("Control.Backend.Endpoint must be an HTTP(S) origin");
 		}
-		String credentialFile = control.getString("CredentialFile", "control-credential.txt");
+		String credentialFile = control.getString("CredentialFile", "control/control-credential.txt");
 		String credential = ControlCredentialFile.read(root, credentialFile);
 		Settings settings = new Settings(nodeId, endpoint, credentialFile,
 				bounded(control.getInt("HeartbeatSeconds", 30), 10, 300, "HeartbeatSeconds"),

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/bungee/BungeeConfig.java
@@ -61,7 +61,7 @@ public class BungeeConfig implements VotingPluginProxyConfig {
 
 	@Override
 	public String getControlCredentialFile() {
-		return getData().getString("Control.CredentialFile", "control-credential.txt");
+		return getData().getString("Control.CredentialFile", "control/control-credential.txt");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
@@ -179,7 +179,7 @@ public class VelocityConfig extends VelocityYMLFile implements VotingPluginProxy
 
 	@Override
 	public String getControlCredentialFile() {
-		return getString(getNode("Control", "CredentialFile"), "control-credential.txt");
+		return getString(getNode("Control", "CredentialFile"), "control/control-credential.txt");
 	}
 
 	@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ControlCredentialFile.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ControlCredentialFile.java
@@ -9,10 +9,15 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 /** Symlink-safe, bounded credential loading shared by proxy and Bukkit Control connectors. */
 public final class ControlCredentialFile {
 	private static final int MAX_BYTES = 512;
+	private static final Set<PosixFilePermission> OWNER_ONLY = Set.of(
+			PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
 
 	private ControlCredentialFile() { }
 
@@ -37,7 +42,6 @@ public final class ControlCredentialFile {
 				|| credential.indexOf('\n') >= 0) throw invalid();
 		return credential;
 	}
-
 
 	private static Path resolveAndCreate(Path rootDirectory, String configuredPath) throws IOException {
 		if (configuredPath == null || configuredPath.isBlank()) throw invalid();
@@ -71,7 +75,19 @@ public final class ControlCredentialFile {
 			}
 		}
 		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target)) throw invalid();
+		restrictPermissions(target);
 		return target;
+	}
+
+	private static void restrictPermissions(Path target) throws IOException {
+		PosixFileAttributeView view = Files.getFileAttributeView(target, PosixFileAttributeView.class,
+				LinkOption.NOFOLLOW_LINKS);
+		if (view == null) return;
+		try {
+			view.setPermissions(OWNER_ONLY);
+		} catch (UnsupportedOperationException ignored) {
+			// Non-POSIX providers retain their platform-default access controls.
+		}
 	}
 
 	private static IOException invalid() {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ControlCredentialFile.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/ControlCredentialFile.java
@@ -17,15 +17,7 @@ public final class ControlCredentialFile {
 	private ControlCredentialFile() { }
 
 	public static String read(Path rootDirectory, String configuredPath) throws IOException {
-		if (configuredPath == null || configuredPath.isBlank()) throw invalid();
-		Path lexicalRoot = rootDirectory.toAbsolutePath().normalize();
-		Path requested = lexicalRoot.resolve(configuredPath).normalize();
-		if (!requested.startsWith(lexicalRoot) || requested.getParent() == null) throw invalid();
-		Path realRoot = lexicalRoot.toRealPath();
-		Path realParent = requested.getParent().toRealPath();
-		if (!realParent.startsWith(realRoot)) throw invalid();
-		Path target = realParent.resolve(requested.getFileName());
-		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target)) throw invalid();
+		Path target = resolveAndCreate(rootDirectory, configuredPath);
 
 		ByteBuffer bytes = ByteBuffer.allocate(MAX_BYTES + 1);
 		try (SeekableByteChannel channel = Files.newByteChannel(target, StandardOpenOption.READ,
@@ -44,6 +36,42 @@ public final class ControlCredentialFile {
 		if (credential.isEmpty() || credential.length() > MAX_BYTES || credential.indexOf('\r') >= 0
 				|| credential.indexOf('\n') >= 0) throw invalid();
 		return credential;
+	}
+
+
+	private static Path resolveAndCreate(Path rootDirectory, String configuredPath) throws IOException {
+		if (configuredPath == null || configuredPath.isBlank()) throw invalid();
+		Path lexicalRoot = rootDirectory.toAbsolutePath().normalize();
+		Path requested = lexicalRoot.resolve(configuredPath).normalize();
+		if (!requested.startsWith(lexicalRoot) || requested.getParent() == null) throw invalid();
+
+		Path realRoot = lexicalRoot.toRealPath();
+		Path current = realRoot;
+		for (Path component : lexicalRoot.relativize(requested.getParent())) {
+			Path child = current.resolve(component.toString());
+			if (!Files.exists(child, LinkOption.NOFOLLOW_LINKS)) {
+				try {
+					Files.createDirectory(child);
+				} catch (java.nio.file.FileAlreadyExistsException ignored) {
+					// Revalidate below in case another process created it.
+				}
+			}
+			if (Files.isSymbolicLink(child) || !Files.isDirectory(child, LinkOption.NOFOLLOW_LINKS)) throw invalid();
+			current = child.toRealPath();
+			if (!current.startsWith(realRoot)) throw invalid();
+		}
+
+		Path target = current.resolve(requested.getFileName());
+		if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) {
+			try (SeekableByteChannel ignored = Files.newByteChannel(target,
+					StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS)) {
+				// Publish an empty placeholder for enrollment through the file manager or WebUI.
+			} catch (java.nio.file.FileAlreadyExistsException ignored) {
+				// Revalidate below in case another process created it.
+			}
+		}
+		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target)) throw invalid();
+		return target;
 	}
 
 	private static IOException invalid() {

--- a/VotingPlugin/src/main/resources/Config.yml
+++ b/VotingPlugin/src/main/resources/Config.yml
@@ -1188,7 +1188,8 @@ Control:
     # Must be unique for every Bukkit/Paper backend in the network.
     NodeId: ''
     Endpoint: 'http://127.0.0.1:8080'
-    CredentialFile: 'control-credential.txt'
+    # VotingPlugin creates this blank file automatically; paste only the enrollment credential into it.
+    CredentialFile: 'control/control-credential.txt'
     HeartbeatSeconds: 30
     ConnectTimeoutMillis: 3000
     RequestTimeoutMillis: 10000

--- a/VotingPlugin/src/main/resources/bungeeconfig.yml
+++ b/VotingPlugin/src/main/resources/bungeeconfig.yml
@@ -486,8 +486,9 @@ Control:
   Endpoint: 'http://127.0.0.1:8080'
   # Blank reuses ProxyServerName. This must match the identity enrolled in Control.
   NodeId: ''
-  # Relative to the VotingPlugin proxy data folder. Put only the enrollment credential in this file.
-  CredentialFile: 'control-credential.txt'
+  # Relative to the VotingPlugin proxy data folder. VotingPlugin creates it blank automatically.
+  # Paste only the enrollment credential into this file.
+  CredentialFile: 'control/control-credential.txt'
   HeartbeatSeconds: 30
   ConnectTimeoutMillis: 3000
   RequestTimeoutMillis: 5000

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/ControlCredentialFileTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/ControlCredentialFileTest.java
@@ -2,6 +2,7 @@ package com.bencodez.votingplugin.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +12,18 @@ import org.junit.jupiter.api.io.TempDir;
 
 class ControlCredentialFileTest {
 	@TempDir Path directory;
+
+
+	@Test void createsBlankContainedCredentialFileBeforeEnrollment() throws Exception {
+		Path root = Files.createDirectory(directory.resolve("plugin"));
+		Path credential = root.resolve("control/control-credential.txt");
+
+		assertThrows(java.io.IOException.class,
+				() -> ControlCredentialFile.read(root, "control/control-credential.txt"));
+
+		assertTrue(Files.isRegularFile(credential));
+		assertEquals("", Files.readString(credential));
+	}
 
 	@Test void readsContainedFileAndRejectsFileDirectoryAndTraversalEscapes() throws Exception {
 		Path root = Files.createDirectory(directory.resolve("plugin"));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/ControlCredentialFileTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/ControlCredentialFileTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -23,6 +26,11 @@ class ControlCredentialFileTest {
 
 		assertTrue(Files.isRegularFile(credential));
 		assertEquals("", Files.readString(credential));
+		PosixFileAttributeView posix = Files.getFileAttributeView(credential, PosixFileAttributeView.class);
+		if (posix != null) {
+			assertEquals(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+					posix.readAttributes().permissions());
+		}
 	}
 
 	@Test void readsContainedFileAndRejectsFileDirectoryAndTraversalEscapes() throws Exception {

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -40,7 +40,7 @@ Control:
   Enabled: true
   Endpoint: 'http://127.0.0.1:8080'
   NodeId: 'proxy-a'
-  CredentialFile: 'control-credential.txt'
+  CredentialFile: 'control/control-credential.txt'
   Hosted:
     Enabled: true
     AutoDownload: true
@@ -76,7 +76,7 @@ Control:
     Enabled: true
     NodeId: 'backend-lobby'
     Endpoint: 'http://127.0.0.1:8080'
-    CredentialFile: 'control-credential.txt'
+    CredentialFile: 'control/control-credential.txt'
     HeartbeatSeconds: 30
     ConnectTimeoutMillis: 3000
     RequestTimeoutMillis: 10000
@@ -106,14 +106,11 @@ Manual installation remains supported: put a Control JAR at `JarFile`, configure
 
 ## Enrollment and configuration
 
-1. Build/run Control and use its owner command to enroll the exact stable node ID:
+1. Start Control, complete its one-time WebUI setup, and use the Node enrollment page to enroll the exact stable node ID.
 
-   ```shell
-   java -jar votingplugin-control-0.1.0-SNAPSHOT-all.jar enroll proxy-a data
-   ```
-
-2. On that proxy or backend, create `plugins/VotingPlugin/control-credential.txt` (or the platform-equivalent VotingPlugin
-   data directory) containing only the printed credential. Restrict filesystem access to the Minecraft service account.
+2. On the first connector start, VotingPlugin automatically creates the blank
+   `plugins/VotingPlugin/control/control-credential.txt` placeholder (or its platform-equivalent data path). Paste only
+   the generated enrollment credential into that file and restrict filesystem access to the Minecraft service account.
 
 3. Configure `bungeeconfig.yml`:
 
@@ -122,7 +119,7 @@ Manual installation remains supported: put a Control JAR at `JarFile`, configure
      Enabled: true
      Endpoint: 'http://127.0.0.1:8080'
      NodeId: 'proxy-a'
-     CredentialFile: 'control-credential.txt'
+     CredentialFile: 'control/control-credential.txt'
      HeartbeatSeconds: 30
      ConnectTimeoutMillis: 3000
      RequestTimeoutMillis: 5000
@@ -130,7 +127,8 @@ Manual installation remains supported: put a Control JAR at `JarFile`, configure
 
 `NodeId` may be blank to reuse the existing `ProxyServerName`, but every simultaneously connected proxy must have a unique,
 stable enrolled identity. Explicitly setting it is recommended. `CredentialFile` must resolve inside VotingPlugin's data
-directory; credentials in URLs and parent-directory traversal are rejected. The credential is never logged or placed in
+directory. Its missing parent directories and blank placeholder are created automatically; credentials in URLs and
+parent-directory traversal are rejected. The credential is never logged or placed in
 plugin messages.
 
 The endpoint must be an `http` or `https` origin without embedded credentials, query, fragment, or path. Plain HTTP is
@@ -157,7 +155,7 @@ Control:
     Enabled: true
     NodeId: 'backend-lobby'
     Endpoint: 'http://127.0.0.1:8080'
-    CredentialFile: 'control-credential.txt'
+    CredentialFile: 'control/control-credential.txt'
     HeartbeatSeconds: 30
     ConnectTimeoutMillis: 3000
     RequestTimeoutMillis: 10000


### PR DESCRIPTION
## Summary

- change the default proxy and backend credential path to `control/control-credential.txt`
- create missing contained parent directories and a blank credential placeholder automatically on connector startup
- tighten new and existing credential files to owner read/write only on POSIX systems
- keep containment and symlink checks before reading credentials
- update both generated configurations and the Control connector documentation
- document WebUI enrollment without requiring a server console command

## Validation

- Java CI with Maven: passed (run 593)
- added coverage for automatic nested blank-file creation and POSIX owner-only permissions
- Codex review: completed with no open findings on `f3c8fd7`
- existing credential validation, size limits, UTF-8 checks, and symlink/traversal rejection remain in place

After the user enrolls the exact node ID in the hosted Control WebUI, they only need to paste the generated credential into the pre-created file and restart/reload VotingPlugin.

AI disclosure: This pull request was created with assistance from OpenAI Codex and reviewed by BenCodez.