### PR TITLE
Preserve comments in Control configuration edits

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -369,7 +369,7 @@ public final class BackendConfigurationService {
 		List<String> sanitized = new ArrayList<>(comments.size());
 		for (String original : comments) {
 			String comment = original;
-			for (String value : secretValues) {
+			for (String value : secretValues.stream().sorted(java.util.Comparator.comparingInt(String::length).reversed()).toList()) {
 				if (safeSecretValue(value)) comment = comment.replace(value, REDACTED);
 			}
 			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -320,6 +320,9 @@ public final class BackendConfigurationService {
 		if (content == null) throw new IllegalArgumentException("configuration content is required");
 		ensureBounded(content);
 		YamlConfiguration yaml = new YamlConfiguration();
+		// Comment retention is part of the hosted editor contract. Keep this
+		// explicit even though current Spigot versions default it to true.
+		yaml.options().parseComments(true);
 		try {
 			yaml.loadFromString(content);
 		} catch (InvalidConfigurationException e) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -40,6 +40,7 @@ public final class BackendConfigurationService {
 			"(?i)([\"']?\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
 					+ "\\b[\"']?\\s*[:=]\\s*)(.*)$");
 	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
+	private static final Pattern BLOCK_SCALAR_INDICATOR = Pattern.compile("[|>](?:[+-][1-9]?|[1-9][+-]?)?");
 
 	private final Path dataDirectory;
 	private final ApplyAction reload;
@@ -383,12 +384,17 @@ public final class BackendConfigurationService {
 			}
 			for (String value : secretValues) comment = comment.replace(value, REDACTED);
 			java.util.regex.Matcher labelledSecret = COMMENT_SECRET.matcher(original);
-			if (labelledSecret.find() && labelledSecret.group(2).isBlank()) redactContinuation = true;
+			if (labelledSecret.find() && commentContinuation(labelledSecret.group(2))) redactContinuation = true;
 			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);
 			if (secretPath) comment = SECRET_PATH_URL.matcher(comment).replaceAll("$1" + REDACTED);
 			sanitized.add(comment);
 		}
 		return sanitized;
+	}
+
+	private static boolean commentContinuation(String value) {
+		String trimmed = value.trim();
+		return trimmed.isEmpty() || BLOCK_SCALAR_INDICATOR.matcher(trimmed).matches();
 	}
 
 	private static boolean safeSecretValue(String value) {
@@ -397,10 +403,44 @@ public final class BackendConfigurationService {
 	}
 
 	private static YamlConfiguration resolveSecrets(YamlConfiguration proposal, YamlConfiguration current) {
+		YamlConfiguration redactedCurrent = parse(mask(parse(current.saveToString())));
 		for (String path : new ArrayList<>(proposal.getKeys(true))) {
 			if (secret(path) && REDACTED.equals(proposal.getString(path))) proposal.set(path, current.get(path));
 		}
+		restoreCommentSecrets(proposal, current, redactedCurrent);
 		return proposal;
+	}
+
+	private static void restoreCommentSecrets(YamlConfiguration proposal, YamlConfiguration current,
+			YamlConfiguration redactedCurrent) {
+		proposal.options().setHeader(restoreCommentSecrets(proposal.options().getHeader(),
+				current.options().getHeader(), redactedCurrent.options().getHeader()));
+		proposal.options().setFooter(restoreCommentSecrets(proposal.options().getFooter(),
+				current.options().getFooter(), redactedCurrent.options().getFooter()));
+		for (String path : new ArrayList<>(proposal.getKeys(true))) {
+			proposal.setComments(path, restoreCommentSecrets(proposal.getComments(path), current.getComments(path),
+					redactedCurrent.getComments(path)));
+			proposal.setInlineComments(path, restoreCommentSecrets(proposal.getInlineComments(path),
+					current.getInlineComments(path), redactedCurrent.getInlineComments(path)));
+		}
+	}
+
+	private static List<String> restoreCommentSecrets(List<String> proposed, List<String> current,
+			List<String> redactedCurrent) {
+		List<String> restored = new ArrayList<>(proposed.size());
+		for (int index = 0; index < proposed.size(); index++) {
+			String comment = proposed.get(index);
+			if (!comment.contains(REDACTED)) {
+				restored.add(comment);
+				continue;
+			}
+			if (index >= current.size() || index >= redactedCurrent.size()
+					|| !comment.equals(redactedCurrent.get(index))) {
+				throw new IllegalArgumentException("redacted comment placeholders must not be edited or moved");
+			}
+			restored.add(current.get(index));
+		}
+		return restored;
 	}
 
 	private static boolean secret(String path) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -37,7 +37,7 @@ public final class BackendConfigurationService {
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
-			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _-]?key|authorization|webhook[ _-]?url)"
+			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|webhook[ _.-]?url)"
 					+ "\\b\\s*[:=]\\s*)(.*)$");
 	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -362,21 +362,28 @@ public final class BackendConfigurationService {
 	}
 
 	private static void sanitizeCommentMetadata(YamlConfiguration yaml, Set<String> secretValues) {
-		yaml.options().setHeader(sanitizeComments(yaml.options().getHeader(), secretValues, false));
-		yaml.options().setFooter(sanitizeComments(yaml.options().getFooter(), secretValues, false));
+		List<String> replacements = secretValues.stream().filter(BackendConfigurationService::safeSecretValue)
+				.sorted(java.util.Comparator.comparingInt(String::length).reversed()).toList();
+		yaml.options().setHeader(sanitizeComments(yaml.options().getHeader(), replacements, false));
+		yaml.options().setFooter(sanitizeComments(yaml.options().getFooter(), replacements, false));
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
-			yaml.setComments(path, sanitizeComments(yaml.getComments(path), secretValues, secret(path)));
-			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), secretValues, secret(path)));
+			yaml.setComments(path, sanitizeComments(yaml.getComments(path), replacements, secret(path)));
+			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), replacements, secret(path)));
 		}
 	}
 
-	private static List<String> sanitizeComments(List<String> comments, Set<String> secretValues, boolean secretPath) {
+	private static List<String> sanitizeComments(List<String> comments, List<String> secretValues, boolean secretPath) {
 		List<String> sanitized = new ArrayList<>(comments.size());
+		boolean redactContinuation = false;
 		for (String original : comments) {
 			String comment = original;
-			for (String value : secretValues.stream().sorted(java.util.Comparator.comparingInt(String::length).reversed()).toList()) {
-				if (safeSecretValue(value)) comment = comment.replace(value, REDACTED);
+			if (redactContinuation && !original.isBlank()) {
+				comment = REDACTED;
+				redactContinuation = false;
 			}
+			for (String value : secretValues) comment = comment.replace(value, REDACTED);
+			java.util.regex.Matcher labelledSecret = COMMENT_SECRET.matcher(original);
+			if (labelledSecret.find() && labelledSecret.group(2).isBlank()) redactContinuation = true;
 			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);
 			if (secretPath) comment = SECRET_PATH_URL.matcher(comment).replaceAll("$1" + REDACTED);
 			sanitized.add(comment);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -35,6 +37,8 @@ public final class BackendConfigurationService {
 	public static final int MAX_CONTENT_BYTES = 512 * 1024;
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
+	private static final Pattern COMMENT_SECRET = Pattern.compile(
+			"(?i)(\\b(?:password|token|secret|credential|api[ _-]?key)\\b\\s*[:=]\\s*)([^\\s#]+)");
 
 	private final Path dataDirectory;
 	private final ApplyAction reload;
@@ -339,10 +343,45 @@ public final class BackendConfigurationService {
 	}
 
 	private static String mask(YamlConfiguration yaml) {
+		Set<String> secretValues = new HashSet<>();
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
-			if (!(yaml.get(path) instanceof ConfigurationSection) && secret(path)) yaml.set(path, REDACTED);
+			if (!(yaml.get(path) instanceof ConfigurationSection) && secret(path)) {
+				Object value = yaml.get(path);
+				if (value != null && !String.valueOf(value).isBlank()) secretValues.add(String.valueOf(value));
+				yaml.set(path, REDACTED);
+			}
 		}
-		return yaml.saveToString();
+		return sanitizeComments(yaml.saveToString(), secretValues);
+	}
+
+	private static String sanitizeComments(String content, Set<String> secretValues) {
+		StringBuilder sanitized = new StringBuilder(content.length());
+		for (String line : content.split("\\n", -1)) {
+			int commentStart = commentStart(line);
+			if (commentStart >= 0) {
+				String comment = line.substring(commentStart);
+				for (String value : secretValues) comment = comment.replace(value, REDACTED);
+				Matcher matcher = COMMENT_SECRET.matcher(comment);
+				comment = matcher.replaceAll("$1" + REDACTED);
+				line = line.substring(0, commentStart) + comment;
+			}
+			sanitized.append(line).append('\n');
+		}
+		return sanitized.substring(0, sanitized.length() - 1);
+	}
+
+	private static int commentStart(String line) {
+		boolean singleQuoted = false;
+		boolean doubleQuoted = false;
+		for (int index = 0; index < line.length(); index++) {
+			char current = line.charAt(index);
+			if (current == '\'' && !doubleQuoted) singleQuoted = !singleQuoted;
+			else if (current == '"' && !singleQuoted && (index == 0 || line.charAt(index - 1) != '\\')) {
+				doubleQuoted = !doubleQuoted;
+			} else if (current == '#' && !singleQuoted && !doubleQuoted
+					&& (index == 0 || Character.isWhitespace(line.charAt(index - 1)))) return index;
+		}
+		return -1;
 	}
 
 	private static YamlConfiguration resolveSecrets(YamlConfiguration proposal, YamlConfiguration current) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -357,6 +357,8 @@ public final class BackendConfigurationService {
 	}
 
 	private static void sanitizeCommentMetadata(YamlConfiguration yaml, Set<String> secretValues) {
+		yaml.options().setHeader(sanitizeComments(yaml.options().getHeader(), secretValues, false));
+		yaml.options().setFooter(sanitizeComments(yaml.options().getFooter(), secretValues, false));
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
 			yaml.setComments(path, sanitizeComments(yaml.getComments(path), secretValues, secret(path)));
 			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), secretValues, secret(path)));
@@ -368,13 +370,18 @@ public final class BackendConfigurationService {
 		for (String original : comments) {
 			String comment = original;
 			for (String value : secretValues) {
-				if (value.length() >= 8) comment = comment.replace(value, REDACTED);
+				if (safeSecretValue(value)) comment = comment.replace(value, REDACTED);
 			}
 			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);
 			if (secretPath) comment = SECRET_PATH_URL.matcher(comment).replaceAll("$1" + REDACTED);
 			sanitized.add(comment);
 		}
 		return sanitized;
+	}
+
+	private static boolean safeSecretValue(String value) {
+		if (value.length() < 6) return false;
+		return !Set.of("true", "false", "null", "yes", "no", "on", "off").contains(value.toLowerCase(Locale.ROOT));
 	}
 
 	private static YamlConfiguration resolveSecrets(YamlConfiguration proposal, YamlConfiguration current) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -39,7 +39,7 @@ public final class BackendConfigurationService {
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
 			"(?i)([\"']?\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
 					+ "\\b[\"']?\\s*[:=]\\s*)(.*)$");
-	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
+	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)([\"']?\\burl\\b[\"']?\\s*[:=]\\s*)(.*)$");
 	private static final Pattern BLOCK_SCALAR_INDICATOR = Pattern.compile("[|>](?:[+-][1-9]?|[1-9][+-]?)?");
 
 	private final Path dataDirectory;
@@ -378,9 +378,17 @@ public final class BackendConfigurationService {
 		boolean redactContinuation = false;
 		for (String original : comments) {
 			String comment = original;
-			if (redactContinuation && !original.isBlank()) {
-				comment = REDACTED;
-				redactContinuation = false;
+			if (redactContinuation) {
+				if (original.isBlank()) {
+					redactContinuation = false;
+				} else {
+					java.util.regex.Matcher continuedLabel = COMMENT_SECRET.matcher(original);
+					if (continuedLabel.find() && !commentContinuation(continuedLabel.group(2))) {
+						redactContinuation = false;
+					}
+					sanitized.add(REDACTED);
+					continue;
+				}
 			}
 			for (String value : secretValues) comment = comment.replace(value, REDACTED);
 			java.util.regex.Matcher labelledSecret = COMMENT_SECRET.matcher(original);
@@ -455,19 +463,34 @@ public final class BackendConfigurationService {
 		Set<String> paths = new LinkedHashSet<>(current.getKeys(true));
 		paths.addAll(proposal.getKeys(true));
 		List<String> changes = new ArrayList<>();
+		if (!current.options().getHeader().equals(proposal.options().getHeader())
+				&& !addChange(changes, "changed header comments")) return List.copyOf(changes);
+		if (!current.options().getFooter().equals(proposal.options().getFooter())
+				&& !addChange(changes, "changed footer comments")) return List.copyOf(changes);
 		for (String path : paths) {
 			Object before = current.get(path);
 			Object after = proposal.get(path);
-			if (before instanceof ConfigurationSection || after instanceof ConfigurationSection) continue;
-			if (!java.util.Objects.equals(before, after)) {
-				changes.add((secret(path) ? "changed secret " : "changed ") + path);
-				if (changes.size() == 19) {
-					changes.add("additional changes omitted");
-					break;
-				}
+			if (!(before instanceof ConfigurationSection) && !(after instanceof ConfigurationSection)
+					&& !java.util.Objects.equals(before, after)
+					&& !addChange(changes, (secret(path) ? "changed secret " : "changed ") + path)) {
+				break;
+			}
+			if ((!current.getComments(path).equals(proposal.getComments(path))
+					|| !current.getInlineComments(path).equals(proposal.getInlineComments(path)))
+					&& !addChange(changes, "changed comments " + path)) {
+				break;
 			}
 		}
 		return List.copyOf(changes);
+	}
+
+	private static boolean addChange(List<String> changes, String change) {
+		if (changes.size() == 19) {
+			changes.add("additional changes omitted");
+			return false;
+		}
+		changes.add(change);
+		return true;
 	}
 
 	private static String revision(String content) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -37,7 +37,7 @@ public final class BackendConfigurationService {
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
-			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|webhook[ _.-]?url)"
+			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
 					+ "\\b\\s*[:=]\\s*)(.*)$");
 	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -427,11 +427,18 @@ public final class BackendConfigurationService {
 				current.options().getHeader(), redactedCurrent.options().getHeader()));
 		proposal.options().setFooter(restoreCommentSecrets(proposal.options().getFooter(),
 				current.options().getFooter(), redactedCurrent.options().getFooter()));
-		for (String path : new ArrayList<>(proposal.getKeys(true))) {
-			proposal.setComments(path, restoreCommentSecrets(proposal.getComments(path), current.getComments(path),
-					redactedCurrent.getComments(path)));
-			proposal.setInlineComments(path, restoreCommentSecrets(proposal.getInlineComments(path),
-					current.getInlineComments(path), redactedCurrent.getInlineComments(path)));
+		Set<String> proposalPaths = new LinkedHashSet<>(proposal.getKeys(true));
+		Set<String> paths = new LinkedHashSet<>(redactedCurrent.getKeys(true));
+		paths.addAll(proposalPaths);
+		for (String path : paths) {
+			List<String> comments = restoreCommentSecrets(proposal.getComments(path), current.getComments(path),
+					redactedCurrent.getComments(path));
+			List<String> inlineComments = restoreCommentSecrets(proposal.getInlineComments(path),
+					current.getInlineComments(path), redactedCurrent.getInlineComments(path));
+			if (proposalPaths.contains(path)) {
+				proposal.setComments(path, comments);
+				proposal.setInlineComments(path, inlineComments);
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -39,6 +39,7 @@ public final class BackendConfigurationService {
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
 			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _-]?key|authorization|webhook[ _-]?url)"
 					+ "\\b\\s*[:=]\\s*)(.*)$");
+	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
 
 	private final Path dataDirectory;
 	private final ApplyAction reload;
@@ -357,17 +358,20 @@ public final class BackendConfigurationService {
 
 	private static void sanitizeCommentMetadata(YamlConfiguration yaml, Set<String> secretValues) {
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
-			yaml.setComments(path, sanitizeComments(yaml.getComments(path), secretValues));
-			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), secretValues));
+			yaml.setComments(path, sanitizeComments(yaml.getComments(path), secretValues, secret(path)));
+			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), secretValues, secret(path)));
 		}
 	}
 
-	private static List<String> sanitizeComments(List<String> comments, Set<String> secretValues) {
+	private static List<String> sanitizeComments(List<String> comments, Set<String> secretValues, boolean secretPath) {
 		List<String> sanitized = new ArrayList<>(comments.size());
 		for (String original : comments) {
 			String comment = original;
-			for (String value : secretValues) comment = comment.replace(value, REDACTED);
+			for (String value : secretValues) {
+				if (value.length() >= 8) comment = comment.replace(value, REDACTED);
+			}
 			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);
+			if (secretPath) comment = SECRET_PATH_URL.matcher(comment).replaceAll("$1" + REDACTED);
 			sanitized.add(comment);
 		}
 		return sanitized;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -37,8 +37,8 @@ public final class BackendConfigurationService {
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
-			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
-					+ "\\b\\s*[:=]\\s*)(.*)$");
+			"(?i)([\"']?\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
+					+ "\\b[\"']?\\s*[:=]\\s*)(.*)$");
 	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)(\\burl\\b\\s*[:=]\\s*)(.*)$");
 
 	private final Path dataDirectory;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -354,7 +354,9 @@ public final class BackendConfigurationService {
 			}
 		}
 		sanitizeCommentMetadata(yaml, secretValues);
-		return yaml.saveToString();
+		String masked = yaml.saveToString();
+		ensureBounded(masked);
+		return masked;
 	}
 
 	private static void addSecretValues(Set<String> values, String value) {
@@ -435,6 +437,13 @@ public final class BackendConfigurationService {
 
 	private static List<String> restoreCommentSecrets(List<String> proposed, List<String> current,
 			List<String> redactedCurrent) {
+		for (int index = 0; index < redactedCurrent.size(); index++) {
+			String redacted = redactedCurrent.get(index);
+			if (redacted.contains(REDACTED)
+					&& (index >= proposed.size() || !redacted.equals(proposed.get(index)))) {
+				throw new IllegalArgumentException("redacted comment placeholders must not be edited or moved");
+			}
+		}
 		List<String> restored = new ArrayList<>(proposed.size());
 		for (int index = 0; index < proposed.size(); index++) {
 			String comment = proposed.get(index);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.bukkit.configuration.ConfigurationSection;
@@ -38,7 +37,8 @@ public final class BackendConfigurationService {
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
-			"(?i)(\\b(?:password|token|secret|credential|api[ _-]?key)\\b\\s*[:=]\\s*)([^\\s#]+)");
+			"(?i)(\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _-]?key|authorization|webhook[ _-]?url)"
+					+ "\\b\\s*[:=]\\s*)(.*)$");
 
 	private final Path dataDirectory;
 	private final ApplyAction reload;
@@ -351,37 +351,26 @@ public final class BackendConfigurationService {
 				yaml.set(path, REDACTED);
 			}
 		}
-		return sanitizeComments(yaml.saveToString(), secretValues);
+		sanitizeCommentMetadata(yaml, secretValues);
+		return yaml.saveToString();
 	}
 
-	private static String sanitizeComments(String content, Set<String> secretValues) {
-		StringBuilder sanitized = new StringBuilder(content.length());
-		for (String line : content.split("\\n", -1)) {
-			int commentStart = commentStart(line);
-			if (commentStart >= 0) {
-				String comment = line.substring(commentStart);
-				for (String value : secretValues) comment = comment.replace(value, REDACTED);
-				Matcher matcher = COMMENT_SECRET.matcher(comment);
-				comment = matcher.replaceAll("$1" + REDACTED);
-				line = line.substring(0, commentStart) + comment;
-			}
-			sanitized.append(line).append('\n');
+	private static void sanitizeCommentMetadata(YamlConfiguration yaml, Set<String> secretValues) {
+		for (String path : new ArrayList<>(yaml.getKeys(true))) {
+			yaml.setComments(path, sanitizeComments(yaml.getComments(path), secretValues));
+			yaml.setInlineComments(path, sanitizeComments(yaml.getInlineComments(path), secretValues));
 		}
-		return sanitized.substring(0, sanitized.length() - 1);
 	}
 
-	private static int commentStart(String line) {
-		boolean singleQuoted = false;
-		boolean doubleQuoted = false;
-		for (int index = 0; index < line.length(); index++) {
-			char current = line.charAt(index);
-			if (current == '\'' && !doubleQuoted) singleQuoted = !singleQuoted;
-			else if (current == '"' && !singleQuoted && (index == 0 || line.charAt(index - 1) != '\\')) {
-				doubleQuoted = !doubleQuoted;
-			} else if (current == '#' && !singleQuoted && !doubleQuoted
-					&& (index == 0 || Character.isWhitespace(line.charAt(index - 1)))) return index;
+	private static List<String> sanitizeComments(List<String> comments, Set<String> secretValues) {
+		List<String> sanitized = new ArrayList<>(comments.size());
+		for (String original : comments) {
+			String comment = original;
+			for (String value : secretValues) comment = comment.replace(value, REDACTED);
+			comment = COMMENT_SECRET.matcher(comment).replaceAll("$1" + REDACTED);
+			sanitized.add(comment);
 		}
-		return -1;
+		return sanitized;
 	}
 
 	private static YamlConfiguration resolveSecrets(YamlConfiguration proposal, YamlConfiguration current) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -348,12 +348,17 @@ public final class BackendConfigurationService {
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
 			if (!(yaml.get(path) instanceof ConfigurationSection) && secret(path)) {
 				Object value = yaml.get(path);
-				if (value != null && !String.valueOf(value).isBlank()) secretValues.add(String.valueOf(value));
+				if (value != null) addSecretValues(secretValues, String.valueOf(value));
 				yaml.set(path, REDACTED);
 			}
 		}
 		sanitizeCommentMetadata(yaml, secretValues);
 		return yaml.saveToString();
+	}
+
+	private static void addSecretValues(Set<String> values, String value) {
+		if (!value.isBlank()) values.add(value);
+		value.lines().map(String::trim).filter(line -> !line.isBlank()).forEach(values::add);
 	}
 
 	private static void sanitizeCommentMetadata(YamlConfiguration yaml, Set<String> secretValues) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -44,7 +44,8 @@ public final class BackendControlConnector implements AutoCloseable {
 	private static final int MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 	private static final long SHUTDOWN_TIMEOUT_SECONDS = 65;
 	private static final Pattern NODE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]{0,63}");
-	private static final Set<String> CAPABILITIES = Set.of("config.files.v1", "config.quick-setup.v1");
+	private static final Set<String> CAPABILITIES = Set.of("config.files.v1", "config.file-comments.v1",
+			"config.quick-setup.v1");
 
 	private final VotingPluginMain plugin;
 	private final Path dataDirectory;
@@ -530,7 +531,7 @@ public final class BackendControlConnector implements AutoCloseable {
 		return body;
 	}
 
-	private static void addCapabilities(JsonObject body) {
+	static void addCapabilities(JsonObject body) {
 		JsonArray capabilities = new JsonArray();
 		CAPABILITIES.stream().sorted().forEach(capabilities::add);
 		body.add("capabilities", capabilities);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -156,6 +156,43 @@ class BackendConfigurationServiceTest {
 		assertFalse(read.content().contains("real-comment-secret"));
 	}
 
+	@Test void redactsAndRestoresCredentialCommentBlockScalars() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# Password: |\n# literal-comment-secret\n"
+				+ "# Token: >-\n# folded-comment-secret\n"
+				+ "# ApiKey: |2+\n# indented-comment-secret\nFeature: false\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		assertFalse(read.content().contains("literal-comment-secret"));
+		assertFalse(read.content().contains("folded-comment-secret"));
+		assertFalse(read.content().contains("indented-comment-secret"));
+
+		String proposal = read.content().replace("Feature: false", "Feature: true");
+		BackendConfigurationService.Preview preview = service.preview("Config.yml", proposal);
+		assertTrue(preview.resolvedContent().contains("literal-comment-secret"));
+		assertTrue(preview.resolvedContent().contains("folded-comment-secret"));
+		assertTrue(preview.resolvedContent().contains("indented-comment-secret"));
+		assertFalse(preview.resolvedContent().contains(BackendConfigurationService.REDACTED));
+
+		service.apply("Config.yml", proposal, read.revision());
+		String applied = Files.readString(config);
+		assertTrue(applied.contains("literal-comment-secret"));
+		assertTrue(applied.contains("folded-comment-secret"));
+		assertTrue(applied.contains("indented-comment-secret"));
+		assertTrue(applied.contains("Feature: true"));
+	}
+
+	@Test void rejectsChangedRedactedCommentPlaceholders() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "# Password: comment-secret\nFeature: false\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		String changed = read.content().replace("Password: " + BackendConfigurationService.REDACTED,
+				"Password changed: " + BackendConfigurationService.REDACTED);
+
+		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", changed));
+	}
+
 	@Test void redactsQuotedCredentialKeysInComments() throws Exception {
 		Path config = directory.resolve("Config.yml");
 		Files.writeString(config, "# \"Password\": quoted-comment-secret\nFeature: false\n");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -146,6 +146,16 @@ class BackendConfigurationServiceTest {
 		assertFalse(read.content().contains("beta-secret-part"));
 	}
 
+	@Test void redactsCredentialValuesContinuedOnTheNextCommentLine() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# Password:\n# real-comment-secret\nFeature: false\n");
+
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("real-comment-secret"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -134,6 +134,18 @@ class BackendConfigurationServiceTest {
 		assertTrue(read.content().contains("# This is true when enabled"));
 	}
 
+	@Test void redactsIndividualLinesFromMultilineSecretsInComments() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "Password: |\n  alpha-secret-part\n  beta-secret-part\n"
+				+ "# rotate alpha-secret-part soon\nFeature: false\n");
+
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("alpha-secret-part"));
+		assertFalse(read.content().contains("beta-secret-part"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -80,6 +80,22 @@ class BackendConfigurationServiceTest {
 		assertTrue(applied.contains("# End of owner notes"));
 	}
 
+	@Test void redactsSecretsRepeatedOrDefinedInsideComments() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# Password: commented-secret\n"
+				+ "Database:\n"
+				+ "  Password: active-secret # rotate active-secret soon\n"
+				+ "Feature: true # Token=comment-token\n");
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("commented-secret"));
+		assertFalse(read.content().contains("active-secret"));
+		assertFalse(read.content().contains("comment-token"));
+		assertTrue(read.content().contains("# Password: " + BackendConfigurationService.REDACTED));
+		assertTrue(read.content().contains("# rotate " + BackendConfigurationService.REDACTED + " soon"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -113,6 +113,17 @@ class BackendConfigurationServiceTest {
 		assertTrue(Files.readString(config).contains("# Password: this is message text"));
 	}
 
+	@Test void redactsWebhookUrlCommentsWithoutReplacingShortSecretsInProse() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "Password: true\nDiscordWebhook:\n  URL: '' # URL: https://old-secret.invalid/hook\n"
+				+ "Feature: false # This is true when enabled\n");
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("old-secret.invalid"));
+		assertTrue(read.content().contains("# This is true when enabled"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -84,7 +84,7 @@ class BackendConfigurationServiceTest {
 		Path config = directory.resolve("Config.yml");
 		Files.writeString(config, "# Password: commented-secret\n"
 				+ "Database:\n"
-				+ "  Password: active-secret # rotate active-secret soon\n"
+				+ "  Password: abc1234 # rotate abc1234 soon\n"
 				+ "Feature: true # Token=comment-token\n"
 				+ "Other: true # Authorization: Bearer old-token\n"
 				+ "Hook: true # WebhookURL: https://example.invalid/private hook\n"
@@ -93,13 +93,21 @@ class BackendConfigurationServiceTest {
 				.read("Config.yml");
 
 		assertFalse(read.content().contains("commented-secret"));
-		assertFalse(read.content().contains("active-secret"));
+		assertFalse(read.content().contains("abc1234"));
 		assertFalse(read.content().contains("comment-token"));
 		assertFalse(read.content().contains("Bearer old-token"));
 		assertFalse(read.content().contains("example.invalid"));
 		assertFalse(read.content().contains("two words"));
 		assertTrue(read.content().contains("# Password: " + BackendConfigurationService.REDACTED));
 		assertTrue(read.content().contains("# rotate " + BackendConfigurationService.REDACTED + " soon"));
+	}
+
+	@Test void redactsSecretsInCommentOnlyDocuments() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "# Password: header-secret\n# owner footer\n");
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+		assertFalse(read.content().contains("header-secret"));
+		assertTrue(read.content().contains(BackendConfigurationService.REDACTED));
 	}
 
 	@Test void doesNotRewriteHashTextInsideBlockScalars() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -210,6 +210,31 @@ class BackendConfigurationServiceTest {
 		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", changed));
 	}
 
+	@Test void rejectsRemovedOrReplacedRedactedCommentPlaceholders() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "# Password: comment-secret\nFeature: false\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		String removed = read.content().lines().filter(line -> !line.contains(BackendConfigurationService.REDACTED))
+				.collect(java.util.stream.Collectors.joining("\n")) + "\n";
+		String replaced = read.content().replace("Password: " + BackendConfigurationService.REDACTED,
+				"ordinary owner note");
+
+		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", removed));
+		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", replaced));
+	}
+
+	@Test void rejectsMaskedDocumentsThatExpandPastTheSizeLimit() throws Exception {
+		String repeatedSecret = "abc1234 ".repeat(20_000);
+		String raw = "Password: abc1234\n# " + repeatedSecret + "\nFeature: false\n";
+		assertTrue(raw.getBytes(java.nio.charset.StandardCharsets.UTF_8).length
+				< BackendConfigurationService.MAX_CONTENT_BYTES);
+		Files.writeString(directory.resolve("Config.yml"), raw);
+
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		assertThrows(IllegalArgumentException.class, () -> service.read("Config.yml"));
+	}
+
 	@Test void reportsCommentOnlyChangesInPreview() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "# original owner note\nFeature: false # old inline note\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -44,6 +44,42 @@ class BackendConfigurationServiceTest {
 		assertTrue(Files.isRegularFile(directory.resolve("Config.yml.control-backup")));
 	}
 
+	@Test void fullFileEditingPreservesCommentsWhileSecretsRemainRedacted() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# VotingPlugin owner notes\n"
+				+ "Database:\n"
+				+ "  # Never expose this value\n"
+				+ "  Password: keep-me # database credential\n"
+				+ "Feature: false # toggle from Control\n"
+				+ "# End of owner notes\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		assertFalse(read.content().contains("keep-me"));
+		assertTrue(read.content().contains(BackendConfigurationService.REDACTED));
+		assertTrue(read.content().contains("# VotingPlugin owner notes"));
+		assertTrue(read.content().contains("# Never expose this value"));
+		assertTrue(read.content().contains("# database credential"));
+		assertTrue(read.content().contains("# toggle from Control"));
+		assertTrue(read.content().contains("# End of owner notes"));
+
+		String proposal = read.content().replace("Feature: false", "Feature: true");
+		BackendConfigurationService.Preview preview = service.preview("Config.yml", proposal);
+		assertTrue(preview.resolvedContent().contains("# VotingPlugin owner notes"));
+		assertTrue(preview.resolvedContent().contains("# database credential"));
+		assertFalse(preview.resolvedContent().contains(BackendConfigurationService.REDACTED));
+
+		service.apply("Config.yml", proposal, read.revision());
+		String applied = Files.readString(config);
+		assertTrue(applied.contains("Password: keep-me"));
+		assertTrue(applied.contains("Feature: true"));
+		assertTrue(applied.contains("# VotingPlugin owner notes"));
+		assertTrue(applied.contains("# Never expose this value"));
+		assertTrue(applied.contains("# database credential"));
+		assertTrue(applied.contains("# toggle from Control"));
+		assertTrue(applied.contains("# End of owner notes"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -85,15 +85,32 @@ class BackendConfigurationServiceTest {
 		Files.writeString(config, "# Password: commented-secret\n"
 				+ "Database:\n"
 				+ "  Password: active-secret # rotate active-secret soon\n"
-				+ "Feature: true # Token=comment-token\n");
+				+ "Feature: true # Token=comment-token\n"
+				+ "Other: true # Authorization: Bearer old-token\n"
+				+ "Hook: true # WebhookURL: https://example.invalid/private hook\n"
+				+ "Quoted: true # DatabasePassword: \"two words\"\n");
 		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
 				.read("Config.yml");
 
 		assertFalse(read.content().contains("commented-secret"));
 		assertFalse(read.content().contains("active-secret"));
 		assertFalse(read.content().contains("comment-token"));
+		assertFalse(read.content().contains("Bearer old-token"));
+		assertFalse(read.content().contains("example.invalid"));
+		assertFalse(read.content().contains("two words"));
 		assertTrue(read.content().contains("# Password: " + BackendConfigurationService.REDACTED));
 		assertTrue(read.content().contains("# rotate " + BackendConfigurationService.REDACTED + " soon"));
+	}
+
+	@Test void doesNotRewriteHashTextInsideBlockScalars() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "Message: |\n  # Password: this is message text\nFeature: false\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		assertTrue(read.content().contains("# Password: this is message text"));
+		service.apply("Config.yml", read.content().replace("Feature: false", "Feature: true"), read.revision());
+		assertTrue(Files.readString(config).contains("# Password: this is message text"));
 	}
 
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -123,12 +123,14 @@ class BackendConfigurationServiceTest {
 
 	@Test void redactsWebhookUrlCommentsWithoutReplacingShortSecretsInProse() throws Exception {
 		Path config = directory.resolve("Config.yml");
-		Files.writeString(config, "Password: true\nDiscordWebhook:\n  URL: '' # URL: https://old-secret.invalid/hook\n"
+		Files.writeString(config, "Password: true\n# DiscordWebhook.URL: https://dotted-secret.invalid/hook\n"
+				+ "DiscordWebhook:\n  URL: '' # URL: https://old-secret.invalid/hook\n"
 				+ "Feature: false # This is true when enabled\n");
 		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
 				.read("Config.yml");
 
 		assertFalse(read.content().contains("old-secret.invalid"));
+		assertFalse(read.content().contains("dotted-secret.invalid"));
 		assertTrue(read.content().contains("# This is true when enabled"));
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -223,6 +223,16 @@ class BackendConfigurationServiceTest {
 		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", replaced));
 	}
 
+	@Test void rejectsRemovingAKeyThatOwnsARedactedComment() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"),
+				"Feature: false # Password: inline-comment-secret\nOther: true\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document read = service.read("Config.yml");
+
+		assertTrue(read.content().contains(BackendConfigurationService.REDACTED));
+		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", "Other: true\n"));
+	}
+
 	@Test void rejectsMaskedDocumentsThatExpandPastTheSizeLimit() throws Exception {
 		String repeatedSecret = "abc1234 ".repeat(20_000);
 		String raw = "Password: abc1234\n# " + repeatedSecret + "\nFeature: false\n";

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -219,7 +219,6 @@ class BackendConfigurationServiceTest {
 				.replace("original owner note", "updated owner note")
 				.replace("old inline note", "updated inline note"));
 
-		assertTrue(preview.changes().contains("changed header comments"));
 		assertTrue(preview.changes().contains("changed comments Feature"));
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -156,6 +156,16 @@ class BackendConfigurationServiceTest {
 		assertFalse(read.content().contains("real-comment-secret"));
 	}
 
+	@Test void redactsQuotedCredentialKeysInComments() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# \"Password\": quoted-comment-secret\nFeature: false\n");
+
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("quoted-comment-secret"));
+	}
+
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "Feature: false\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -124,7 +124,7 @@ class BackendConfigurationServiceTest {
 	@Test void redactsWebhookUrlCommentsWithoutReplacingShortSecretsInProse() throws Exception {
 		Path config = directory.resolve("Config.yml");
 		Files.writeString(config, "Password: true\n# DiscordWebhook.URL: https://dotted-secret.invalid/hook\n"
-				+ "DiscordWebhook:\n  URL: '' # URL: https://old-secret.invalid/hook\n"
+				+ "DiscordWebhook:\n  URL: '' # \"URL\": https://old-secret.invalid/hook\n"
 				+ "Feature: false # This is true when enabled\n");
 		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
 				.read("Config.yml");
@@ -154,6 +154,23 @@ class BackendConfigurationServiceTest {
 				.read("Config.yml");
 
 		assertFalse(read.content().contains("real-comment-secret"));
+	}
+
+	@Test void redactsEveryLineOfCredentialCommentBlockScalars() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# Password: |\n# first-comment-secret\n# second-comment-secret\n#\n"
+				+ "# owner note\nFeature: false\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.Document read = service.read("Config.yml");
+		assertFalse(read.content().contains("first-comment-secret"));
+		assertFalse(read.content().contains("second-comment-secret"));
+		assertTrue(read.content().contains("owner note"));
+
+		BackendConfigurationService.Preview preview = service.preview("Config.yml",
+				read.content().replace("Feature: false", "Feature: true"));
+		assertTrue(preview.resolvedContent().contains("first-comment-secret"));
+		assertTrue(preview.resolvedContent().contains("second-comment-secret"));
 	}
 
 	@Test void redactsAndRestoresCredentialCommentBlockScalars() throws Exception {
@@ -191,6 +208,19 @@ class BackendConfigurationServiceTest {
 				"Password changed: " + BackendConfigurationService.REDACTED);
 
 		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", changed));
+	}
+
+	@Test void reportsCommentOnlyChangesInPreview() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "# original owner note\nFeature: false # old inline note\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document read = service.read("Config.yml");
+
+		BackendConfigurationService.Preview preview = service.preview("Config.yml", read.content()
+				.replace("original owner note", "updated owner note")
+				.replace("old inline note", "updated inline note"));
+
+		assertTrue(preview.changes().contains("changed header comments"));
+		assertTrue(preview.changes().contains("changed comments Feature"));
 	}
 
 	@Test void redactsQuotedCredentialKeysInComments() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
@@ -48,6 +48,20 @@ class BackendControlConnectorProtocolTest {
 		assertDoesNotThrow(() -> BackendControlConnector.requireFileCapability(true));
 	}
 
+	@Test void registrationAdvertisesCommentPreservingFilesAsAnOptionalCapability() {
+		JsonObject registration = new JsonObject();
+		BackendControlConnector.addCapabilities(registration);
+
+		JsonArray advertised = registration.getAsJsonArray("capabilities");
+		assertTrue(advertised.asList().stream()
+				.anyMatch(value -> "config.file-comments.v1".equals(value.getAsString())));
+		JsonArray required = registration.getAsJsonArray("requiredCapabilities");
+		assertTrue(required.asList().stream()
+				.anyMatch(value -> "config.files.v1".equals(value.getAsString())));
+		assertFalse(required.asList().stream()
+				.anyMatch(value -> "config.file-comments.v1".equals(value.getAsString())));
+	}
+
 	@Test void heartbeatRetainsOmittedCapabilitiesAndHonorsExplicitReplacement() {
 		JsonObject omitted = new JsonObject();
 		assertTrue(BackendControlConnector.negotiatedCapability(omitted, "config.files.v1", true));


### PR DESCRIPTION
## Summary

- explicitly enable Bukkit YAML comment parsing for every hosted Control read, preview, and apply
- preserve header, block, inline, and footer comments while secret values remain redacted
- advertise optional `config.file-comments.v1` support alongside the existing `config.files.v1` operation capability
- keep comment preservation optional in capability negotiation so existing Control releases remain compatible

## Safety

- existing revision checks, preview approval, atomic persistence, backups, reload, and rollback behavior are unchanged
- tests verify that the real secret never enters the editor payload and is restored only during apply

## Validation

- `git diff --check`
- focused service and connector protocol regressions added
- local Maven is unavailable in the workspace; GitHub CI is the authoritative build