### PR TITLE
Add reward-safe VoteSites synchronization

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
@@ -35,6 +37,8 @@ public final class BackendConfigurationService {
 	public static final int MAX_CONTENT_BYTES = 512 * 1024;
 	private static final Set<String> TOP_LEVEL = Set.of("Config.yml", "VoteSites.yml", "SpecialRewards.yml",
 			"GUI.yml", "Shop.yml", "BungeeSettings.yml");
+	private static final Pattern COMMENT_SECRET = Pattern.compile(
+			"(?i)(\\b(?:password|token|secret|credential|api[ _-]?key)\\b\\s*[:=]\\s*)([^\\s#]+)");
 
 	private final Path dataDirectory;
 	private final ApplyAction reload;
@@ -394,10 +398,45 @@ public final class BackendConfigurationService {
 	}
 
 	private static String mask(YamlConfiguration yaml) {
+		Set<String> secretValues = new HashSet<>();
 		for (String path : new ArrayList<>(yaml.getKeys(true))) {
-			if (!(yaml.get(path) instanceof ConfigurationSection) && secret(path)) yaml.set(path, REDACTED);
+			if (!(yaml.get(path) instanceof ConfigurationSection) && secret(path)) {
+				Object value = yaml.get(path);
+				if (value != null && !String.valueOf(value).isBlank()) secretValues.add(String.valueOf(value));
+				yaml.set(path, REDACTED);
+			}
 		}
-		return yaml.saveToString();
+		return sanitizeComments(yaml.saveToString(), secretValues);
+	}
+
+	private static String sanitizeComments(String content, Set<String> secretValues) {
+		StringBuilder sanitized = new StringBuilder(content.length());
+		for (String line : content.split("\\n", -1)) {
+			int commentStart = commentStart(line);
+			if (commentStart >= 0) {
+				String comment = line.substring(commentStart);
+				for (String value : secretValues) comment = comment.replace(value, REDACTED);
+				Matcher matcher = COMMENT_SECRET.matcher(comment);
+				comment = matcher.replaceAll("$1" + REDACTED);
+				line = line.substring(0, commentStart) + comment;
+			}
+			sanitized.append(line).append('\n');
+		}
+		return sanitized.substring(0, sanitized.length() - 1);
+	}
+
+	private static int commentStart(String line) {
+		boolean singleQuoted = false;
+		boolean doubleQuoted = false;
+		for (int index = 0; index < line.length(); index++) {
+			char current = line.charAt(index);
+			if (current == '\'' && !doubleQuoted) singleQuoted = !singleQuoted;
+			else if (current == '"' && !singleQuoted && (index == 0 || line.charAt(index - 1) != '\\')) {
+				doubleQuoted = !doubleQuoted;
+			} else if (current == '#' && !singleQuoted && !doubleQuoted
+					&& (index == 0 || Character.isWhitespace(line.charAt(index - 1)))) return index;
+		}
+		return -1;
 	}
 
 	private static YamlConfiguration resolveSecrets(YamlConfiguration proposal, YamlConfiguration current) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -316,10 +316,10 @@ public final class BackendConfigurationService {
 
 	private boolean caseInsensitiveYmlFiles() throws IOException {
 		Path config = resolve("Config.yml");
-		if (!Files.exists(config)) return true;
+		if (!Files.exists(config)) return false;
 		YamlConfiguration settings = parse(readRaw(config, false));
 		String key = matchingKey(settings, "CaseInsensitiveYMLFiles", true);
-		return key == null || settings.getBoolean(key, true);
+		return key != null && settings.getBoolean(key, false);
 	}
 
 	private static void mergeVoteSites(YamlConfiguration source, YamlConfiguration target, boolean ignoreCase) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -243,6 +243,7 @@ public final class BackendConfigurationService {
 		if ("sync-vote-sites".equals(preset)) {
 			String sourceContent = options == null ? null : options.get("sourceContent");
 			YamlConfiguration source = parse(sourceContent);
+			removeRedactedCommentMetadata(source);
 			mergeVoteSites(source, yaml, caseInsensitiveYmlFiles());
 			String merged = yaml.saveToString();
 			ensureBounded(merged);
@@ -387,11 +388,35 @@ public final class BackendConfigurationService {
 				target.setInlineComments(targetPath, source.getInlineComments(key));
 				mergeNonRewardValues(section, target, targetPath, ignoreCase);
 			} else if (!REDACTED.equals(value)) {
+				ConfigurationSection protectedTarget = target.getConfigurationSection(targetPath);
+				if (protectedTarget != null && containsRewardDescendant(protectedTarget)) continue;
 				target.set(targetPath, value);
 				target.setComments(targetPath, source.getComments(key));
 				target.setInlineComments(targetPath, source.getInlineComments(key));
 			}
 		}
+	}
+
+	private static boolean containsRewardDescendant(ConfigurationSection section) {
+		for (String key : section.getKeys(false)) {
+			if (rewardKey(key)) return true;
+			Object value = section.get(key);
+			if (value instanceof ConfigurationSection child && containsRewardDescendant(child)) return true;
+		}
+		return false;
+	}
+
+	private static void removeRedactedCommentMetadata(YamlConfiguration source) {
+		source.options().setHeader(withoutRedactedComments(source.options().getHeader()));
+		source.options().setFooter(withoutRedactedComments(source.options().getFooter()));
+		for (String path : new ArrayList<>(source.getKeys(true))) {
+			source.setComments(path, withoutRedactedComments(source.getComments(path)));
+			source.setInlineComments(path, withoutRedactedComments(source.getInlineComments(path)));
+		}
+	}
+
+	private static List<String> withoutRedactedComments(List<String> comments) {
+		return comments.stream().filter(comment -> !comment.contains(REDACTED)).toList();
 	}
 
 	private static String matchingKey(ConfigurationSection section, String expected, boolean ignoreCase) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -224,8 +224,7 @@ public final class BackendConfigurationService {
 
 	private String quickSetupRevision(String preset, String current) throws IOException {
 		if (!"sync-vote-sites".equals(preset)) return revision(current);
-		String policy = Files.exists(resolve("Config.yml")) ? readRaw(resolve("Config.yml"), false) : "";
-		return revision(current + "\0" + policy);
+		return revision(current + "\0CaseInsensitiveYMLFiles=" + caseInsensitiveYmlFiles());
 	}
 
 	private static String quickSetupFile(String preset) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -205,7 +205,8 @@ public final class BackendConfigurationService {
 
 	private static String quickSetupFile(String preset) {
 		if ("standalone".equals(preset) || "proxy-backend".equals(preset)) return "BungeeSettings.yml";
-		if ("vote-site".equals(preset) || "easy-reward".equals(preset)) return "VoteSites.yml";
+		if ("vote-site".equals(preset) || "easy-reward".equals(preset)
+				|| "sync-vote-sites".equals(preset)) return "VoteSites.yml";
 		if ("common-settings".equals(preset)) return "Config.yml";
 		if ("vote-party".equals(preset)) return "SpecialRewards.yml";
 		throw new IllegalArgumentException("quick setup preset is unsupported");
@@ -214,6 +215,12 @@ public final class BackendConfigurationService {
 	private QuickProposal quickProposal(String preset, Map<String, String> options, String fileName,
 			String current) {
 		YamlConfiguration yaml = parse(current);
+		if ("sync-vote-sites".equals(preset)) {
+			String sourceContent = options == null ? null : options.get("sourceContent");
+			YamlConfiguration source = parse(sourceContent);
+			mergeVoteSites(source, yaml);
+			return new QuickProposal(fileName, yaml.saveToString());
+		}
 		if ("standalone".equals(preset) || "proxy-backend".equals(preset)) {
 			boolean proxy = "proxy-backend".equals(preset);
 			yaml.set("UseBungeecord", proxy);
@@ -278,6 +285,54 @@ public final class BackendConfigurationService {
 			return new QuickProposal(fileName, yaml.saveToString());
 		}
 		throw new IllegalArgumentException("quick setup preset is unsupported");
+	}
+
+	private static void mergeVoteSites(YamlConfiguration source, YamlConfiguration target) {
+		ConfigurationSection sourceSites = source.getConfigurationSection("VoteSites");
+		if (sourceSites == null) throw new IllegalArgumentException("source VoteSites.yml has no VoteSites section");
+		ConfigurationSection targetSites = target.getConfigurationSection("VoteSites");
+		if (targetSites == null) targetSites = target.createSection("VoteSites");
+		target.setComments("VoteSites", source.getComments("VoteSites"));
+		target.setInlineComments("VoteSites", source.getInlineComments("VoteSites"));
+		for (String site : sourceSites.getKeys(false)) {
+			ConfigurationSection sourceSite = sourceSites.getConfigurationSection(site);
+			if (sourceSite == null) throw new IllegalArgumentException("source vote site " + site + " is not a section");
+			String targetPath = "VoteSites." + site;
+			if (target.getConfigurationSection(targetPath) == null) {
+				target.set(targetPath, null);
+				target.createSection(targetPath);
+			}
+			target.setComments(targetPath, sourceSites.getComments(site));
+			target.setInlineComments(targetPath, sourceSites.getInlineComments(site));
+			mergeNonRewardValues(sourceSite, target, targetPath);
+		}
+	}
+
+	private static void mergeNonRewardValues(ConfigurationSection source, YamlConfiguration target,
+			String targetParent) {
+		for (String key : source.getKeys(false)) {
+			if (rewardKey(key)) continue;
+			String targetPath = targetParent + "." + key;
+			Object value = source.get(key);
+			if (value instanceof ConfigurationSection section) {
+				if (target.getConfigurationSection(targetPath) == null) {
+					target.set(targetPath, null);
+					target.createSection(targetPath);
+				}
+				target.setComments(targetPath, source.getComments(key));
+				target.setInlineComments(targetPath, source.getInlineComments(key));
+				mergeNonRewardValues(section, target, targetPath);
+			} else if (!REDACTED.equals(value)) {
+				target.set(targetPath, value);
+				target.setComments(targetPath, source.getComments(key));
+				target.setInlineComments(targetPath, source.getInlineComments(key));
+			}
+		}
+	}
+
+	private static boolean rewardKey(String key) {
+		String normalized = key.replace("-", "").replace("_", "").toLowerCase(Locale.ROOT);
+		return normalized.contains("reward");
 	}
 
 	private Path resolve(String fileName) throws IOException {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -324,6 +324,7 @@ public final class BackendConfigurationService {
 	}
 
 	private static void mergeVoteSites(YamlConfiguration source, YamlConfiguration target, boolean ignoreCase) {
+		List<String> targetSecretValues = commentSecretReplacements(target);
 		String sourceRootKey = matchingKey(source, "VoteSites", true);
 		ConfigurationSection sourceSites = sourceRootKey == null ? null : source.getConfigurationSection(sourceRootKey);
 		if (sourceSites == null) throw new IllegalArgumentException("source VoteSites.yml has no VoteSites section");
@@ -337,8 +338,11 @@ public final class BackendConfigurationService {
 		if (targetRootKey == null) targetRootKey = sourceRootKey;
 		ConfigurationSection targetSites = target.getConfigurationSection(targetRootKey);
 		if (targetSites == null) targetSites = target.createSection(targetRootKey);
-		target.setComments(targetRootKey, source.getComments(sourceRootKey));
-		target.setInlineComments(targetRootKey, source.getInlineComments(sourceRootKey));
+		target.setComments(targetRootKey, sourceCommentsUnlessTargetProtected(target.getComments(targetRootKey),
+				source.getComments(sourceRootKey), targetSecretValues, secret(targetRootKey)));
+		target.setInlineComments(targetRootKey, sourceCommentsUnlessTargetProtected(
+				target.getInlineComments(targetRootKey), source.getInlineComments(sourceRootKey), targetSecretValues,
+				secret(targetRootKey)));
 		for (String site : mergeableSites) {
 			ConfigurationSection sourceSite = sourceSites.getConfigurationSection(site);
 			if (sourceSite == null) throw new IllegalArgumentException("source vote site " + site + " is not a section");
@@ -349,9 +353,12 @@ public final class BackendConfigurationService {
 				target.set(targetPath, null);
 				target.createSection(targetPath);
 			}
-			target.setComments(targetPath, sourceSites.getComments(site));
-			target.setInlineComments(targetPath, sourceSites.getInlineComments(site));
-			mergeNonRewardValues(sourceSite, target, targetPath, ignoreCase);
+			target.setComments(targetPath, sourceCommentsUnlessTargetProtected(target.getComments(targetPath),
+					sourceSites.getComments(site), targetSecretValues, secret(targetPath)));
+			target.setInlineComments(targetPath, sourceCommentsUnlessTargetProtected(
+					target.getInlineComments(targetPath), sourceSites.getInlineComments(site), targetSecretValues,
+					secret(targetPath)));
+			mergeNonRewardValues(sourceSite, target, targetPath, ignoreCase, targetSecretValues);
 		}
 	}
 
@@ -369,7 +376,7 @@ public final class BackendConfigurationService {
 	}
 
 	private static void mergeNonRewardValues(ConfigurationSection source, YamlConfiguration target,
-			String targetParent, boolean ignoreCase) {
+			String targetParent, boolean ignoreCase, List<String> targetSecretValues) {
 		for (String key : source.getKeys(false)) {
 			if (rewardKey(key)) continue;
 			ConfigurationSection targetSection = target.getConfigurationSection(targetParent);
@@ -384,17 +391,43 @@ public final class BackendConfigurationService {
 					target.set(targetPath, null);
 					target.createSection(targetPath);
 				}
-				target.setComments(targetPath, source.getComments(key));
-				target.setInlineComments(targetPath, source.getInlineComments(key));
-				mergeNonRewardValues(section, target, targetPath, ignoreCase);
+				target.setComments(targetPath, sourceCommentsUnlessTargetProtected(target.getComments(targetPath),
+						source.getComments(key), targetSecretValues, secret(targetPath)));
+				target.setInlineComments(targetPath, sourceCommentsUnlessTargetProtected(
+						target.getInlineComments(targetPath), source.getInlineComments(key), targetSecretValues,
+						secret(targetPath)));
+				mergeNonRewardValues(section, target, targetPath, ignoreCase, targetSecretValues);
 			} else if (!REDACTED.equals(value)) {
 				ConfigurationSection protectedTarget = target.getConfigurationSection(targetPath);
 				if (protectedTarget != null && containsRewardDescendant(protectedTarget)) continue;
+				List<String> targetComments = target.getComments(targetPath);
+				List<String> targetInlineComments = target.getInlineComments(targetPath);
 				target.set(targetPath, value);
-				target.setComments(targetPath, source.getComments(key));
-				target.setInlineComments(targetPath, source.getInlineComments(key));
+				target.setComments(targetPath, sourceCommentsUnlessTargetProtected(targetComments,
+						source.getComments(key), targetSecretValues, secret(targetPath)));
+				target.setInlineComments(targetPath, sourceCommentsUnlessTargetProtected(
+						targetInlineComments, source.getInlineComments(key), targetSecretValues,
+						secret(targetPath)));
 			}
 		}
+	}
+
+	private static List<String> commentSecretReplacements(YamlConfiguration target) {
+		Set<String> values = new HashSet<>();
+		for (String path : target.getKeys(true)) {
+			Object value = target.get(path);
+			if (!(value instanceof ConfigurationSection) && value != null && secret(path)) {
+				addSecretValues(values, String.valueOf(value));
+			}
+		}
+		return values.stream().filter(BackendConfigurationService::safeSecretValue)
+				.sorted(java.util.Comparator.comparingInt(String::length).reversed()).toList();
+	}
+
+	private static List<String> sourceCommentsUnlessTargetProtected(List<String> targetComments,
+			List<String> sourceComments, List<String> targetSecretValues, boolean secretPath) {
+		return targetComments.equals(sanitizeComments(targetComments, targetSecretValues, secretPath))
+				? sourceComments : targetComments;
 	}
 
 	private static boolean containsRewardDescendant(ConfigurationSection section) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -45,7 +45,7 @@ public final class BackendControlConnector implements AutoCloseable {
 	private static final long SHUTDOWN_TIMEOUT_SECONDS = 65;
 	private static final Pattern NODE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]{0,63}");
 	private static final Set<String> CAPABILITIES = Set.of("config.files.v1", "config.file-comments.v1",
-			"config.quick-setup.v1");
+			"config.quick-setup.v1", "config.vote-sites-sync.v1");
 
 	private final VotingPluginMain plugin;
 	private final Path dataDirectory;
@@ -682,7 +682,11 @@ public final class BackendControlConnector implements AutoCloseable {
 			config.addProperty("domain", "quick-setup");
 			config.addProperty("preset", preset);
 			JsonObject values = new JsonObject();
-			options.forEach(values::addProperty);
+			options.forEach((name, value) -> {
+				// The source document is an input to the merge, not result data. It
+				// may be large and must not be retained or echoed by Control.
+				if (!"sourceContent".equals(name)) values.addProperty(name, value);
+			});
 			config.add("options", values);
 			return new TaskResult(true, "OK", "Operation completed", revision, config, List.copyOf(changes),
 					reloaded, false, restartConnector);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -66,6 +66,7 @@ public final class BackendControlConnector implements AutoCloseable {
 	private volatile boolean registered;
 	private volatile boolean operationsAccepted;
 	private volatile boolean quickSetupsAccepted;
+	private volatile boolean voteSitesSyncAccepted;
 	private volatile int failures;
 	private volatile ScheduledFuture<?> scheduled;
 	private volatile Future<?> activeReload;
@@ -176,6 +177,7 @@ public final class BackendControlConnector implements AutoCloseable {
 			}
 			operationsAccepted = negotiatedCapability(node, "config.files.v1", operationsAccepted);
 			quickSetupsAccepted = negotiatedCapability(node, "config.quick-setup.v1", quickSetupsAccepted);
+			voteSitesSyncAccepted = negotiatedCapability(node, "config.vote-sites-sync.v1", voteSitesSyncAccepted);
 			try {
 				requireFileCapability(operationsAccepted);
 			} catch (ConnectorException incompatible) {
@@ -220,6 +222,7 @@ public final class BackendControlConnector implements AutoCloseable {
 		// A registration must explicitly establish required capabilities. Heartbeats may omit the unchanged set.
 		operationsAccepted = false;
 		quickSetupsAccepted = false;
+		voteSitesSyncAccepted = false;
 		JsonObject body = sessionBody();
 		body.addProperty("nodeId", settings.nodeId());
 		body.addProperty("displayName", settings.nodeId());
@@ -486,6 +489,9 @@ public final class BackendControlConnector implements AutoCloseable {
 			throws IOException {
 		if ("READ".equals(type)) return TaskResult.failure("UNSUPPORTED_TASK", "Quick setups cannot be read");
 		String preset = string(configuration, "preset");
+		if (!quickSetupCapabilityAccepted(preset, quickSetupsAccepted, voteSitesSyncAccepted)) {
+			return TaskResult.failure("UNSUPPORTED_TASK", "VoteSites sync was not negotiated");
+		}
 		Map<String, String> options = options(configuration.getAsJsonObject("options"));
 		if ("PREVIEW".equals(type)) {
 			BackendConfigurationService.QuickPreview preview = configurations.previewQuickSetup(preset, options);
@@ -502,6 +508,11 @@ public final class BackendControlConnector implements AutoCloseable {
 					"Config.yml".equals(applied.document().fileName()));
 		}
 		return TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported");
+	}
+
+	static boolean quickSetupCapabilityAccepted(String preset, boolean quickSetupsAccepted,
+			boolean voteSitesSyncAccepted) {
+		return quickSetupsAccepted && (!"sync-vote-sites".equals(preset) || voteSitesSyncAccepted);
 	}
 
 	private Response send(String method, String path, JsonObject body) throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -1,6 +1,7 @@
 package com.bencodez.votingplugin.control;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -530,6 +531,23 @@ class BackendConfigurationServiceTest {
 		assertEquals(List.of("keep"), proposal.getStringList("votesites.pmc.Rewards.Commands"));
 		assertEquals(1, proposal.getKeys(false).size());
 		assertEquals(1, proposal.getConfigurationSection("votesites").getKeys(false).size());
+	}
+
+	@Test void voteSitesSyncRevisionTracksOnlyTheCasingPolicyFromConfig() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "CaseInsensitiveYMLFiles: true\nMessage: before\n");
+		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  PMC:\n    Name: Target\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		Map<String, String> source = Map.of("sourceContent", "VoteSites:\n  PMC:\n    Name: Source\n");
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites", source);
+		Files.writeString(config, "CaseInsensitiveYMLFiles: true\nMessage: independently edited\n");
+		assertDoesNotThrow(() -> service.applyQuickSetup("sync-vote-sites", source, preview.revision()));
+
+		BackendConfigurationService.QuickPreview policyPreview = service.previewQuickSetup("sync-vote-sites", source);
+		Files.writeString(config, "CaseInsensitiveYMLFiles: false\nMessage: independently edited\n");
+		assertThrows(BackendConfigurationService.StaleRevisionException.class,
+				() -> service.applyQuickSetup("sync-vote-sites", source, policyPreview.revision()));
 	}
 
 	@Test void voteSitesSyncDropsUnrestorableSourceCredentialComments() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -508,6 +508,25 @@ class BackendConfigurationServiceTest {
 		assertEquals(1, proposal.getConfigurationSection("votesites").getKeys(false).size());
 	}
 
+	@Test void voteSitesSyncDropsUnrestorableSourceCredentialComments() throws Exception {
+		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  PMC:\n    Name: Target\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		String source = "VoteSites:\n  # Password: " + BackendConfigurationService.REDACTED + "\n"
+				+ "  # public source note\n  PMC:\n    Name: Source # Token: "
+				+ BackendConfigurationService.REDACTED + "\n";
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", source));
+
+		assertFalse(preview.proposal().content().contains(BackendConfigurationService.REDACTED));
+		assertTrue(preview.proposal().content().contains("public source note"));
+		BackendConfigurationService.ApplyResult applied = service.applyQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", source), preview.revision());
+		YamlConfiguration installed = new YamlConfiguration();
+		installed.loadFromString(applied.document().content());
+		assertEquals("Source", installed.getString("VoteSites.PMC.Name"));
+	}
+
 	@Test void voteSitesSyncKeepsDistinctKeysWhenCaseInsensitiveFilesAreDisabled() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "caseinsensitiveymlfiles: false\n");
 		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  PMC:\n    Name: Upper target\n"
@@ -558,6 +577,22 @@ class BackendConfigurationServiceTest {
 
 		assertEquals("Source", proposal.getString("VoteSites.Example.Name"));
 		assertEquals("keep", proposal.getString("VoteSites.Example.Metadata"));
+	}
+
+	@Test void voteSitesSyncDoesNotReplaceTargetSectionsContainingRewardDescendants() throws Exception {
+		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  Example:\n    Name: Target\n"
+				+ "    Metadata:\n      Owner: keep\n      Rewards:\n        Commands: ['target reward']\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites", Map.of(
+				"sourceContent", "VoteSites:\n  Example:\n    Name: Source\n    Metadata: source scalar\n"));
+		YamlConfiguration proposal = new YamlConfiguration();
+		proposal.loadFromString(preview.proposal().content());
+
+		assertEquals("Source", proposal.getString("VoteSites.Example.Name"));
+		assertEquals("keep", proposal.getString("VoteSites.Example.Metadata.Owner"));
+		assertEquals(List.of("target reward"),
+				proposal.getStringList("VoteSites.Example.Metadata.Rewards.Commands"));
 	}
 
 	@Test void fullBungeeSettingsRejectsUnknownTransportMethods() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -271,6 +271,79 @@ class BackendConfigurationServiceTest {
 		assertTrue(mqtt.proposal().content().contains("BungeeMethod: MQTT"));
 	}
 
+	@Test void voteSitesSyncAddsAndUpdatesDefinitionsWithoutTouchingRewardsOrTargetOnlySites() throws Exception {
+		Path voteSites = directory.resolve("VoteSites.yml");
+		Files.writeString(voteSites, "VoteSites:\n"
+				+ "  PMC:\n"
+				+ "    Name: Target name\n"
+				+ "    VoteURL: https://target.example/vote\n"
+				+ "    Rewards:\n"
+				+ "      Commands: ['target reward']\n"
+				+ "    WaitUntilVoteDelayRewards:\n"
+				+ "      Commands: ['target rejected reward']\n"
+				+ "  TargetOnly:\n"
+				+ "    Name: Keep me\n"
+				+ "EverySiteReward:\n"
+				+ "  Commands: ['target every-site reward']\n");
+		String source = "# Source network sites\n"
+				+ "VoteSites:\n"
+				+ "  # Planet Minecraft settings\n"
+				+ "  PMC:\n"
+				+ "    Name: Source name # synchronized field\n"
+				+ "    VoteURL: https://source.example/vote\n"
+				+ "    DisplayItem:\n"
+				+ "      Material: EMERALD\n"
+				+ "    Rewards:\n"
+				+ "      Commands: ['source reward']\n"
+				+ "    WaitUntilVoteDelayRewards:\n"
+				+ "      Commands: ['source rejected reward']\n"
+				+ "  NewSite:\n"
+				+ "    Name: Added site\n"
+				+ "    VoteURL: https://new.example/vote\n"
+				+ "    Rewards:\n"
+				+ "      Commands: ['source new reward']\n"
+				+ "EverySiteReward:\n"
+				+ "  Commands: ['source every-site reward']\n";
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document before = service.read("VoteSites.yml");
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", source));
+		YamlConfiguration proposal = new YamlConfiguration();
+		proposal.options().parseComments(true);
+		proposal.loadFromString(preview.proposal().content());
+		assertEquals("Source name", proposal.getString("VoteSites.PMC.Name"));
+		assertEquals("EMERALD", proposal.getString("VoteSites.PMC.DisplayItem.Material"));
+		assertEquals(List.of("target reward"), proposal.getStringList("VoteSites.PMC.Rewards.Commands"));
+		assertEquals(List.of("target rejected reward"),
+				proposal.getStringList("VoteSites.PMC.WaitUntilVoteDelayRewards.Commands"));
+		assertEquals("Keep me", proposal.getString("VoteSites.TargetOnly.Name"));
+		assertEquals("Added site", proposal.getString("VoteSites.NewSite.Name"));
+		assertFalse(proposal.contains("VoteSites.NewSite.Rewards"));
+		assertEquals(List.of("target every-site reward"), proposal.getStringList("EverySiteReward.Commands"));
+		assertTrue(preview.proposal().content().contains("# Planet Minecraft settings"));
+		assertTrue(preview.proposal().content().contains("# synchronized field"));
+		assertTrue(preview.changes().stream().noneMatch(change -> change.toLowerCase().contains("reward")));
+
+		service.applyQuickSetup("sync-vote-sites", Map.of("sourceContent", source), before.revision());
+		String applied = Files.readString(voteSites);
+		assertTrue(applied.contains("target reward"));
+		assertFalse(applied.contains("source reward"));
+		assertTrue(applied.contains("TargetOnly"));
+		assertTrue(applied.contains("NewSite"));
+		assertTrue(applied.contains("# Planet Minecraft settings"));
+	}
+
+	@Test void voteSitesSyncRejectsMalformedOrMissingSourceSections() throws Exception {
+		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites: {}\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		assertThrows(IllegalArgumentException.class, () -> service.previewQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", "not: [yaml")));
+		assertThrows(IllegalArgumentException.class, () -> service.previewQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", "Other: value\n")));
+	}
+
 	@Test void fullBungeeSettingsRejectsUnknownTransportMethods() throws Exception {
 		Files.writeString(directory.resolve("BungeeSettings.yml"),
 				"UseBungeecord: true\nServer: lobby\nBungeeMethod: PLUGINMESSAGING\n");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -611,6 +611,21 @@ class BackendConfigurationServiceTest {
 		assertEquals("Lower target", proposal.getString("VoteSites.pmc.Name"));
 	}
 
+	@Test void voteSitesSyncDefaultsToCaseSensitiveKeysWhenThePolicyIsAbsent() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "Message: no casing policy configured\n");
+		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  PMC:\n    Name: Upper target\n"
+				+ "  pmc:\n    Name: Lower target\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites", Map.of(
+				"sourceContent", "VoteSites:\n  PMC:\n    Name: Updated upper\n"));
+		YamlConfiguration proposal = new YamlConfiguration();
+		proposal.loadFromString(preview.proposal().content());
+
+		assertEquals("Updated upper", proposal.getString("VoteSites.PMC.Name"));
+		assertEquals("Lower target", proposal.getString("VoteSites.pmc.Name"));
+	}
+
 	@Test void voteSitesSyncRejectsMalformedOrMissingSourceSections() throws Exception {
 		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites: {}\n");
 		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -79,6 +78,22 @@ class BackendConfigurationServiceTest {
 		assertTrue(applied.contains("# database credential"));
 		assertTrue(applied.contains("# toggle from Control"));
 		assertTrue(applied.contains("# End of owner notes"));
+	}
+
+	@Test void redactsSecretsRepeatedOrDefinedInsideComments() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# Password: commented-secret\n"
+				+ "Database:\n"
+				+ "  Password: active-secret # rotate active-secret soon\n"
+				+ "Feature: true # Token=comment-token\n");
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("commented-secret"));
+		assertFalse(read.content().contains("active-secret"));
+		assertFalse(read.content().contains("comment-token"));
+		assertTrue(read.content().contains("# Password: " + BackendConfigurationService.REDACTED));
+		assertTrue(read.content().contains("# rotate " + BackendConfigurationService.REDACTED + " soon"));
 	}
 
 	@Test void rejectsStaleInvalidAndUnmanagedWrites() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -526,6 +526,23 @@ class BackendConfigurationServiceTest {
 		assertEquals("Source", installed.getString("VoteSites.PMC.Name"));
 	}
 
+	@Test void voteSitesSyncPreservesTargetCredentialComments() throws Exception {
+		Path voteSites = directory.resolve("VoteSites.yml");
+		Files.writeString(voteSites, "VoteSites:\n  PMC:\n"
+				+ "    Name: Target # Password: target-comment-secret\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		String source = "VoteSites:\n  PMC:\n    Name: Source # public source comment\n";
+
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites",
+				Map.of("sourceContent", source));
+		assertTrue(preview.proposal().content().contains("target-comment-secret"));
+
+		service.applyQuickSetup("sync-vote-sites", Map.of("sourceContent", source), preview.revision());
+		String applied = Files.readString(voteSites);
+		assertTrue(applied.contains("Name: Source"));
+		assertTrue(applied.contains("target-comment-secret"));
+	}
+
 	@Test void voteSitesSyncKeepsDistinctKeysWhenCaseInsensitiveFilesAreDisabled() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "caseinsensitiveymlfiles: false\n");
 		Files.writeString(directory.resolve("VoteSites.yml"), "VoteSites:\n  PMC:\n    Name: Upper target\n"

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
@@ -55,6 +55,8 @@ class BackendControlConnectorProtocolTest {
 		JsonArray advertised = registration.getAsJsonArray("capabilities");
 		assertTrue(advertised.asList().stream()
 				.anyMatch(value -> "config.file-comments.v1".equals(value.getAsString())));
+		assertTrue(advertised.asList().stream()
+				.anyMatch(value -> "config.vote-sites-sync.v1".equals(value.getAsString())));
 		JsonArray required = registration.getAsJsonArray("requiredCapabilities");
 		assertTrue(required.asList().stream()
 				.anyMatch(value -> "config.files.v1".equals(value.getAsString())));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
@@ -76,6 +76,13 @@ class BackendControlConnectorProtocolTest {
 		assertTrue(BackendControlConnector.negotiatedCapability(explicit, "config.quick-setup.v1", false));
 	}
 
+	@Test void voteSitesSyncRequiresBothNegotiatedCapabilities() {
+		assertFalse(BackendControlConnector.quickSetupCapabilityAccepted("sync-vote-sites", true, false));
+		assertFalse(BackendControlConnector.quickSetupCapabilityAccepted("sync-vote-sites", false, true));
+		assertTrue(BackendControlConnector.quickSetupCapabilityAccepted("sync-vote-sites", true, true));
+		assertTrue(BackendControlConnector.quickSetupCapabilityAccepted("common-settings", true, false));
+	}
+
 	@Test void shutdownWaitsForTheClaimedBackendOperation() throws Exception {
 		var executor = Executors.newSingleThreadScheduledExecutor();
 		CompletableFuture<Void> operation = new CompletableFuture<>();


### PR DESCRIPTION
> Stacked on #1587; review and merge that prerequisite first.

## Summary

- advertise optional `config.vote-sites-sync.v1` support
- add a `sync-vote-sites` backend operation that add/updates site definitions from a source document
- recursively skip every reward-named subtree and leave `EverySiteReward` untouched
- preserve target-only sites, target secrets, and target reward data by default
- retain source comments on synchronized definition fields
- omit the source YAML from operation result payloads

## Safety

- sync uses the existing read → preview → explicit approval → apply workflow
- no target site or field is deleted when it is absent from the source
- source redaction markers are never written over target secrets

## Validation

- `git diff --check`
- focused merge, reward-isolation, comment, invalid-source, and capability tests added
- GitHub CI is authoritative because Maven is unavailable locally