### PR TITLE
Fix VoteSites sync with credential comments

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -84,10 +84,15 @@ public final class BackendConfigurationService {
 	}
 
 	public ApplyResult apply(String fileName, String proposedContent, String expectedRevision) throws IOException {
+		return apply(fileName, proposedContent, expectedRevision, true);
+	}
+
+	private ApplyResult apply(String fileName, String proposedContent, String expectedRevision,
+			boolean restoreRedactedSecrets) throws IOException {
 		Path target = resolve(fileName);
 		String current = readRaw(target, false);
 		if (expectedRevision == null || !revision(current).equals(expectedRevision)) throw new StaleRevisionException();
-		Preview preview = preview(fileName, proposedContent, current);
+		Preview preview = preview(fileName, proposedContent, current, restoreRedactedSecrets);
 		Path backup = target.resolveSibling(target.getFileName() + ".control-backup");
 		Path staging = Files.createTempFile(target.getParent(), ".control-", ".yml");
 		Path backupStaging = Files.createTempFile(target.getParent(), ".control-backup-", ".yml");
@@ -180,8 +185,15 @@ public final class BackendConfigurationService {
 	}
 
 	private Preview preview(String fileName, String proposedContent, String current) {
+		return preview(fileName, proposedContent, current, true);
+	}
+
+	private Preview preview(String fileName, String proposedContent, String current,
+			boolean restoreRedactedSecrets) {
 		YamlConfiguration currentYaml = parse(current);
-		YamlConfiguration resolvedYaml = resolveSecrets(parse(proposedContent), currentYaml);
+		YamlConfiguration proposedYaml = parse(proposedContent);
+		YamlConfiguration resolvedYaml = restoreRedactedSecrets
+				? resolveSecrets(proposedYaml, currentYaml) : proposedYaml;
 		if ("BungeeSettings.yml".equals(fileName) && resolvedYaml.contains("BungeeMethod")) {
 			resolvedYaml.set("BungeeMethod", canonicalBungeeMethod(resolvedYaml.getString("BungeeMethod")));
 		}
@@ -214,7 +226,9 @@ public final class BackendConfigurationService {
 			throw new StaleRevisionException();
 		}
 		QuickProposal proposal = quickProposal(preset, options, fileName, current);
-		ApplyResult applied = apply(proposal.fileName(), proposal.content(), revision(current));
+		// Quick proposals are generated from this fresh, unmasked server snapshot.
+		// Editor placeholder restoration must remain limited to client-authored YAML.
+		ApplyResult applied = apply(proposal.fileName(), proposal.content(), revision(current), false);
 		if (!"sync-vote-sites".equals(preset)) return applied;
 		Document document = applied.document();
 		String installed = readRaw(resolve(fileName), false);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -623,6 +623,10 @@ class BackendConfigurationServiceTest {
 		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("sync-vote-sites",
 				Map.of("sourceContent", source));
 		assertTrue(preview.proposal().content().contains("target-comment-secret"));
+		BackendConfigurationService.Document editorSnapshot = service.read("VoteSites.yml");
+		assertFalse(editorSnapshot.content().contains("target-comment-secret"));
+		assertThrows(IllegalArgumentException.class, () -> service.apply("VoteSites.yml",
+				preview.proposal().content(), editorSnapshot.revision()));
 
 		service.applyQuickSetup("sync-vote-sites", Map.of("sourceContent", source), preview.revision());
 		String applied = Files.readString(voteSites);


### PR DESCRIPTION
## Summary

- apply trusted quick-setup proposals without routing them through client-editor placeholder restoration
- preserve target credential comments during VoteSites synchronization
- keep normal editor placeholder validation strict and add a regression assertion for that boundary

## Validation

- `git diff --check`
- focused regression: `BackendConfigurationServiceTest.voteSitesSyncPreservesTargetCredentialComments`
- GitHub CI is authoritative because this workspace cannot resolve Maven Central

## AI disclosure

This focused fix was developed with OpenAI Codex assistance.