### PR TITLE
Fix VoteUpdate crash for unresolved service sites

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouter.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouter.java
@@ -99,7 +99,7 @@ public class BackendProxyMessageRouter {
 		});
 	}
 
-	private void handleVoteUpdate(JsonEnvelope msg) {
+	void handleVoteUpdate(JsonEnvelope msg) {
 		VotingPluginWire.VoteUpdate update = VotingPluginWire.readVoteUpdate(msg);
 		String playerUuid = update.uuid;
 		if (playerUuid == null || playerUuid.isEmpty()) {
@@ -121,7 +121,13 @@ public class BackendProxyMessageRouter {
 		user.offVote();
 
 		if (update.service != null && !update.service.isEmpty() && update.time > 0) {
-			user.setTime(plugin.getVoteSiteManager().getVoteSite(update.service, true), update.time);
+			VoteSite voteSite = plugin.getVoteSiteManager().getVoteSite(update.service, true);
+			if (voteSite == null) {
+				plugin.getLogger().warning("Ignoring VoteUpdate last vote time for unknown service site: "
+						+ update.service);
+			} else {
+				user.setTime(voteSite, update.time);
+			}
 		} else if (update.service != null && !update.service.isEmpty() && update.time <= 0
 				&& plugin.getBungeeSettings().isBungeeDebug()) {
 			plugin.debug("Invalid last vote time received from bungee: " + update.time);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouter.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouter.java
@@ -123,8 +123,8 @@ public class BackendProxyMessageRouter {
 		if (update.service != null && !update.service.isEmpty() && update.time > 0) {
 			VoteSite voteSite = plugin.getVoteSiteManager().getVoteSite(update.service, true);
 			if (voteSite == null) {
-				plugin.getLogger().warning("Ignoring VoteUpdate last vote time for unknown service site: "
-						+ update.service);
+				plugin.getLogger().warning("Ignoring VoteUpdate last vote time for unresolved or disabled service site: "
+						+ ServiceSiteValidator.sanitizeForLog(update.service));
 			} else {
 				user.setTime(voteSite, update.time);
 			}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouterTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouterTest.java
@@ -56,10 +56,11 @@ class BackendProxyMessageRouterTest {
 	@Test
 	void ignoresLastVoteTimeForUnknownServiceSite() {
 		router.handleVoteUpdate(VotingPluginWire.voteUpdate(PLAYER_UUID.toString(), 1, 10,
-				"unknown.example", LAST_VOTE_TIME, ""));
+				"unknown.example\nforged-entry", LAST_VOTE_TIME, ""));
 
 		verify(user, never()).setTime(any(), anyLong());
-		verify(logger).warning("Ignoring VoteUpdate last vote time for unknown service site: unknown.example");
+		verify(logger).warning("Ignoring VoteUpdate last vote time for unresolved or disabled service site: "
+				+ "unknown.example?forged-entry");
 		verify(plugin).setUpdate(true);
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouterTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/backendproxy/messaging/BackendProxyMessageRouterTest.java
@@ -1,0 +1,78 @@
+package com.bencodez.votingplugin.backendproxy.messaging;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.backendproxy.cache.ProcessedVoteCache;
+import com.bencodez.votingplugin.backendproxy.global.BackendGlobalDataSync;
+import com.bencodez.votingplugin.backendproxy.presence.BackendPresenceManager;
+import com.bencodez.votingplugin.backendproxy.voteparty.BackendVotePartySync;
+import com.bencodez.votingplugin.proxy.VotingPluginWire;
+import com.bencodez.votingplugin.user.UserManager;
+import com.bencodez.votingplugin.user.VotingPluginUser;
+import com.bencodez.votingplugin.votesites.VoteSite;
+import com.bencodez.votingplugin.votesites.VoteSiteManager;
+
+class BackendProxyMessageRouterTest {
+
+	private static final UUID PLAYER_UUID = UUID.fromString("e5baec32-9b2c-4fc8-9aed-0e0285e3c33d");
+	private static final long LAST_VOTE_TIME = 1_788_201_600_000L;
+
+	private VotingPluginMain plugin;
+	private VoteSiteManager voteSiteManager;
+	private VotingPluginUser user;
+	private Logger logger;
+	private BackendProxyMessageRouter router;
+
+	@BeforeEach
+	void setUp() {
+		plugin = mock(VotingPluginMain.class);
+		voteSiteManager = mock(VoteSiteManager.class);
+		UserManager userManager = mock(UserManager.class);
+		user = mock(VotingPluginUser.class);
+		logger = mock(Logger.class);
+
+		when(plugin.getVoteSiteManager()).thenReturn(voteSiteManager);
+		when(plugin.getVotingPluginUserManager()).thenReturn(userManager);
+		when(plugin.getLogger()).thenReturn(logger);
+		when(userManager.getVotingPluginUser(PLAYER_UUID)).thenReturn(user);
+
+		router = new BackendProxyMessageRouter(plugin, mock(BackendPresenceManager.class),
+				mock(BackendGlobalDataSync.class), mock(BackendVotePartySync.class),
+				mock(ProcessedVoteCache.class));
+	}
+
+	@Test
+	void ignoresLastVoteTimeForUnknownServiceSite() {
+		router.handleVoteUpdate(VotingPluginWire.voteUpdate(PLAYER_UUID.toString(), 1, 10,
+				"unknown.example", LAST_VOTE_TIME, ""));
+
+		verify(user, never()).setTime(any(), anyLong());
+		verify(logger).warning("Ignoring VoteUpdate last vote time for unknown service site: unknown.example");
+		verify(plugin).setUpdate(true);
+	}
+
+	@Test
+	void appliesLastVoteTimeForKnownServiceSite() {
+		VoteSite voteSite = mock(VoteSite.class);
+		when(voteSiteManager.getVoteSite("known.example", true)).thenReturn(voteSite);
+
+		router.handleVoteUpdate(VotingPluginWire.voteUpdate(PLAYER_UUID.toString(), 1, 10,
+				"known.example", LAST_VOTE_TIME, ""));
+
+		verify(user).setTime(voteSite, LAST_VOTE_TIME);
+		verify(logger, never()).warning(any(String.class));
+		verify(plugin).setUpdate(true);
+	}
+}


### PR DESCRIPTION
## Summary

- resolve the incoming `VoteUpdate` service site before updating a player's last-vote time
- skip only the last-vote-time update when the site is unresolved or disabled, while preserving the rest of the proxy update
- sanitize the untrusted service-site value before including it in the warning log
- add regression coverage for both unresolved and valid service sites

## Why

`VoteSiteManager#getVoteSite(...)` can return `null` for an unknown or disabled service site. Passing that value to `VotingPluginUser#setTime(...)` leaves the backend proxy update path vulnerable to a null dereference. The handler now emits a bounded, single-line warning and continues processing the rest of the update.

## Verification

- `mvn org.apache.maven.plugins:maven-surefire-plugin:3.5.4:test` — 498 tests passed
- `mvn package -DskipTests` — shaded JAR built successfully
- `git diff --check` — clean
- Gitleaks scan of the complete patch — no leaks found
