### PR TITLE
Add Control proxy configuration management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ The allow-listed kinds are `overview`, `vote-site-health`, `player`, `vote-log-s
 Maintain these global bounds unless a versioned contract deliberately replaces them:
 
 - result JSON: 512 KiB;
-- general result rows: 100 (diagnostics may report up to 128 detected plugin names);
+- general result rows: 100 (including detected plugin names in diagnostics);
 - top lists: 20;
 - lookback: 365 days;
 - exact player lookup only;

--- a/VotingPlugin/pom.xml
+++ b/VotingPlugin/pom.xml
@@ -70,6 +70,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
@@ -88,6 +93,10 @@
                                 <exclusion>
                                     <groupId>com.velocitypowered</groupId>
                                     <artifactId>velocity-brigadier</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                    <groupId>org.yaml</groupId>
+                                    <artifactId>snakeyaml</artifactId>
                                 </exclusion>
                             </exclusions>
                         </path>
@@ -163,6 +172,10 @@
                         <relocation>
                             <pattern>io.leangen.geantyref</pattern>
                             <shadedPattern>${project.groupId}.simpleapi.geantyref</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.yaml.snakeyaml</pattern>
+                            <shadedPattern>${project.groupId}.votingplugin.snakeyaml</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>
@@ -254,6 +267,12 @@
         </repository>
     </repositories>
     <dependencies>
+        <!-- Must precede Spigot, which embeds an older SnakeYAML API on its provided compile path. -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.6</version>
+        </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -1244,6 +1244,14 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		}
 	}
 
+	/** Applies only proxy communication settings without reloading unrelated Bukkit configuration. */
+	public synchronized void reloadBackendProxyMethodFromControl() {
+		bungeeSettings.reloadData();
+		getOptions().setServer(bungeeSettings.getServer());
+		updateAdvancedCoreHook();
+		restartBackendProxyHandler();
+	}
+
 	/** Keeps one plugin-message listener for the plugin lifetime and atomically swaps its active backend handler. */
 	public synchronized void activateBackendPluginMessageHandler(GlobalMessageHandler target) {
 		backendPluginMessageTarget.set(target);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -96,6 +96,11 @@ public final class BackendConfigurationService {
 
 	private ApplyResult apply(String fileName, String proposedContent, String expectedRevision,
 			boolean restoreRedactedSecrets) throws IOException {
+		return apply(fileName, proposedContent, expectedRevision, restoreRedactedSecrets, reload);
+	}
+
+	private ApplyResult apply(String fileName, String proposedContent, String expectedRevision,
+			boolean restoreRedactedSecrets, ApplyAction applyAction) throws IOException {
 		Path target = resolve(fileName);
 		String current = readRaw(target, false);
 		if (expectedRevision == null || !revision(current).equals(expectedRevision)) throw new StaleRevisionException();
@@ -120,11 +125,11 @@ public final class BackendConfigurationService {
 				installed = true;
 				throw published;
 			}
-			reload.run(fileName);
+			applyAction.run(fileName);
 			String applied = readRaw(target, false);
 			String installedRevision = revision(preview.resolvedContent());
 			if (!revision(applied).equals(installedRevision)) {
-				reconcileConcurrentEdit(fileName, target);
+				reconcileConcurrentEdit(fileName, target, applyAction);
 				throw new StaleRevisionException();
 			}
 			return new ApplyResult(new Document(fileName, mask(parse(applied)), revision(applied)),
@@ -146,7 +151,7 @@ public final class BackendConfigurationService {
 						// still reload it so runtime and disk cannot diverge.
 						failure.addSuppressed(published);
 					}
-					reload.run(fileName);
+					applyAction.run(fileName);
 					rolledBack = true;
 				} catch (Exception rollbackFailure) {
 					failure.addSuppressed(rollbackFailure);
@@ -159,10 +164,10 @@ public final class BackendConfigurationService {
 		}
 	}
 
-	private void reconcileConcurrentEdit(String fileName, Path target) throws Exception {
+	private void reconcileConcurrentEdit(String fileName, Path target, ApplyAction applyAction) throws Exception {
 		for (int attempt = 0; attempt < 3; attempt++) {
 			String snapshotRevision = revision(readRaw(target, false));
-			reload.run(fileName);
+			applyAction.run(fileName);
 			if (revision(readRaw(target, false)).equals(snapshotRevision)) return;
 		}
 		throw new StaleRevisionException();
@@ -330,6 +335,11 @@ public final class BackendConfigurationService {
 
 	public ApplyResult applyQuickSetup(String preset, Map<String, String> options, String expectedRevision)
 			throws IOException {
+		return applyQuickSetup(preset, options, expectedRevision, reload);
+	}
+
+	ApplyResult applyQuickSetup(String preset, Map<String, String> options, String expectedRevision,
+			ApplyAction applyAction) throws IOException {
 		String fileName = quickSetupFile(preset, options);
 		String current = readRaw(resolve(fileName), false);
 		if (expectedRevision == null || !quickSetupRevision(preset, current).equals(expectedRevision)) {
@@ -338,7 +348,7 @@ public final class BackendConfigurationService {
 		QuickProposal proposal = quickProposal(preset, options, fileName, current);
 		// Quick proposals are generated from this fresh, unmasked server snapshot.
 		// Editor placeholder restoration must remain limited to client-authored YAML.
-		ApplyResult applied = apply(proposal.fileName(), proposal.content(), revision(current), false);
+		ApplyResult applied = apply(proposal.fileName(), proposal.content(), revision(current), false, applyAction);
 		if (!"sync-vote-sites".equals(preset)) return applied;
 		Document document = applied.document();
 		String installed = readRaw(resolve(fileName), false);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendConfigurationService.java
@@ -47,7 +47,7 @@ public final class BackendConfigurationService {
 			"WaitUntilVoteDelay", "PermissionToView", "IgnoreCanVote", "VoteDelayDailyHour", "VoteDelayMin",
 			"GiveOffline");
 	private static final Pattern COMMENT_SECRET = Pattern.compile(
-			"(?i)([\"']?\\b(?:[\\w-]*(?:password|secret)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
+			"(?i)([\"']?\\b(?:[\\w-]*(?:password|secret|user(?:name)?)[\\w-]*|token|api[ _.-]?key|authorization|[\\w.-]*webhook[ _.-]?url)"
 					+ "\\b[\"']?\\s*[:=]\\s*)(.*)$");
 	private static final Pattern SECRET_PATH_URL = Pattern.compile("(?i)([\"']?\\burl\\b[\"']?\\s*[:=]\\s*)(.*)$");
 	private static final Pattern BLOCK_SCALAR_INDICATOR = Pattern.compile("[|>](?:[+-][1-9]?|[1-9][+-]?)?");
@@ -920,6 +920,7 @@ public final class BackendConfigurationService {
 
 	private static void restoreCommentSecrets(YamlConfiguration proposal, YamlConfiguration current,
 			YamlConfiguration redactedCurrent) {
+		validateRedactedCommentOwners(proposal, redactedCurrent);
 		proposal.options().setHeader(restoreCommentSecrets(proposal.options().getHeader(),
 				current.options().getHeader(), redactedCurrent.options().getHeader()));
 		proposal.options().setFooter(restoreCommentSecrets(proposal.options().getFooter(),
@@ -937,6 +938,31 @@ public final class BackendConfigurationService {
 				proposal.setInlineComments(path, inlineComments);
 			}
 		}
+	}
+
+	private static void validateRedactedCommentOwners(YamlConfiguration proposal, YamlConfiguration redactedCurrent) {
+		Map<String, List<String>> expected = redactedCommentsByOwner(redactedCurrent);
+		Map<String, List<String>> actual = redactedCommentsByOwner(proposal);
+		if (!expected.equals(actual)) {
+			throw new IllegalArgumentException("redacted comment placeholders must not be edited or moved");
+		}
+	}
+
+	private static Map<String, List<String>> redactedCommentsByOwner(YamlConfiguration yaml) {
+		Map<String, List<String>> markers = new LinkedHashMap<>();
+		addRedactedCommentOwner(markers, "header", yaml.options().getHeader());
+		addRedactedCommentOwner(markers, "footer", yaml.options().getFooter());
+		for (String path : yaml.getKeys(true)) {
+			addRedactedCommentOwner(markers, "comments:" + path, yaml.getComments(path));
+			addRedactedCommentOwner(markers, "inline-comments:" + path, yaml.getInlineComments(path));
+		}
+		return markers;
+	}
+
+	private static void addRedactedCommentOwner(Map<String, List<String>> markers, String owner,
+			List<String> comments) {
+		List<String> ownerMarkers = comments.stream().filter(comment -> comment.contains(REDACTED)).toList();
+		if (!ownerMarkers.isEmpty()) markers.put(owner, ownerMarkers);
 	}
 
 	private static List<String> restoreCommentSecrets(List<String> proposed, List<String> current,

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -111,14 +111,21 @@ public final class BackendControlConnector implements AutoCloseable {
 	}
 
 	private void reloadConfiguration(String fileName) throws Exception {
+		reloadOnServerThread(() -> {
+			plugin.reloadFromControl();
+			if ("BungeeSettings.yml".equals(fileName)) plugin.restartBackendProxyHandler();
+		});
+	}
+
+	private void reloadProxyMethod(String ignored) throws Exception {
+		reloadOnServerThread(plugin::reloadBackendProxyMethodFromControl);
+	}
+
+	private void reloadOnServerThread(Runnable action) throws Exception {
 		Future<?> reload;
 		synchronized (operationLifecycle) {
 			if (closed) throw new IllegalStateException("Bukkit Control connector is stopping");
-			reload = plugin.getServer().getScheduler().callSyncMethod(plugin, () -> {
-				plugin.reloadFromControl();
-				if ("BungeeSettings.yml".equals(fileName)) plugin.restartBackendProxyHandler();
-				return null;
-			});
+			reload = plugin.getServer().getScheduler().callSyncMethod(plugin, () -> { action.run(); return null; });
 			activeReload = reload;
 		}
 		try {
@@ -504,10 +511,20 @@ public final class BackendControlConnector implements AutoCloseable {
 	private void persistIntent(UUID operationId, TaskResult anticipated, String attemptId) throws IOException {
 		JsonObject result = anticipated.json();
 		result.addProperty("attemptId", attemptId);
+		StoredResult previous;
 		synchronized (completed) {
-			completed.put(operationId, new StoredResult(result, anticipated.restartConnector(), false, false));
+			previous = completed.put(operationId,
+					new StoredResult(result, anticipated.restartConnector(), false, false));
 		}
-		persistCompleted();
+		try {
+			persistCompleted();
+		} catch (IOException failure) {
+			synchronized (completed) {
+				if (previous == null) completed.remove(operationId);
+				else completed.put(operationId, previous);
+			}
+			throw failure;
+		}
 	}
 
 	private void prepareWriteAheadIntents() throws IOException {
@@ -527,7 +544,17 @@ public final class BackendControlConnector implements AutoCloseable {
 				}
 			}
 		}
-		if (changed) persistCompleted();
+		if (changed) {
+			try {
+				persistCompleted();
+			} catch (IOException failure) {
+				synchronized (completed) {
+					completed.clear();
+					completed.putAll(snapshot);
+				}
+				throw failure;
+			}
+		}
 	}
 
 	static StoredResult abortedIntent(StoredResult pending) {
@@ -633,8 +660,8 @@ public final class BackendControlConnector implements AutoCloseable {
 		if ("APPLY".equals(type)) {
 			BackendConfigurationService.Preview preview = configurations.preview(fileName, content);
 			persistIntent(operationId,
-					TaskResult.file(configurations.proposedDocument(preview), preview.changes(), true, false,
-							"Config.yml".equals(fileName)), string(task, "attemptId"));
+					TaskResult.fileIntent(fileName, configurations.proposedDocument(preview).revision(),
+							preview.changes(), "Config.yml".equals(fileName)), string(task, "attemptId"));
 			BackendConfigurationService.ApplyResult applied = configurations.apply(fileName, content,
 					string(task, "expectedRevision"));
 			return TaskResult.file(applied.document(), applied.changes(), true, applied.rolledBack(),
@@ -664,8 +691,10 @@ public final class BackendControlConnector implements AutoCloseable {
 					TaskResult.quick(preset, options, configurations.proposedQuickSetupRevision(preset, preview), preview.changes(),
 							true, "Config.yml".equals(preview.proposal().fileName())), string(task, "attemptId"));
 			BackendConfigurationService.ApplyResult applied = configurations.applyQuickSetup(preset, options,
-					string(task, "expectedRevision"));
-			return TaskResult.quick(preset, options, applied.document().revision(), applied.changes(), true,
+					string(task, "expectedRevision"), "proxy-method".equals(preset)
+							? this::reloadProxyMethod : this::reloadConfiguration);
+			return TaskResult.quick(preset, options, applied.document().revision(), applied.changes(),
+					!"proxy-method".equals(preset),
 					"Config.yml".equals(applied.document().fileName()));
 		}
 		return TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported");
@@ -902,10 +931,20 @@ public final class BackendControlConnector implements AutoCloseable {
 					List.copyOf(changes), reloaded, rolledBack, restartConnector);
 		}
 
+		private static TaskResult fileIntent(String fileName, String revision, List<String> changes,
+				boolean restartConnector) {
+			JsonObject config = new JsonObject();
+			config.addProperty("domain", "file");
+			config.addProperty("fileName", fileName);
+			return new TaskResult(true, "OK", "Configuration apply is pending", revision, config,
+					List.copyOf(changes), true, false, restartConnector);
+		}
+
 		private static TaskResult quick(String preset, Map<String, String> options, String revision,
 				List<String> changes, boolean reloaded) {
 			return quick(preset, options, revision, changes, reloaded, false);
 		}
+
 		private static TaskResult quick(String preset, Map<String, String> options, String revision,
 				List<String> changes, boolean reloaded, boolean restartConnector) {
 			JsonObject config = new JsonObject();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -702,7 +702,7 @@ public final class BackendControlConnector implements AutoCloseable {
 					string(task, "expectedRevision"), "proxy-method".equals(preset)
 							? this::reloadProxyMethod : this::reloadConfiguration);
 			return TaskResult.quick(preset, options, applied.document().revision(), applied.changes(),
-					!"proxy-method".equals(preset),
+					true,
 					"Config.yml".equals(applied.document().fileName()));
 		}
 		return TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/BackendControlConnector.java
@@ -397,9 +397,10 @@ public final class BackendControlConnector implements AutoCloseable {
 			result = completed.get(operationId);
 		}
 		if (result != null) {
-			if (!result.committed() && !result.claimRequired() && !anticipatedResultIsInstalled(result)) {
-				result = null;
-			} else {
+			if (!result.committed() && !result.claimRequired()) {
+				result = committedInstalledForAttempt(configurations, result, string(task, "attemptId"));
+			}
+			if (result != null) {
 				result = committedForAttempt(result, string(task, "attemptId"));
 				synchronized (completed) { completed.put(operationId, result); }
 				persistCompleted();
@@ -534,9 +535,9 @@ public final class BackendControlConnector implements AutoCloseable {
 		for (Map.Entry<UUID, StoredResult> entry : snapshot.entrySet()) {
 			StoredResult pending = entry.getValue();
 			if (pending.committed() || pending.claimRequired()) continue;
-			StoredResult recovered = anticipatedResultIsInstalled(pending)
-					? committedForAttempt(pending, string(pending.result(), "attemptId"))
-					: abortedIntent(pending);
+			StoredResult recovered = committedInstalledForAttempt(configurations, pending,
+					string(pending.result(), "attemptId"));
+			if (recovered == null) recovered = abortedIntent(pending);
 			synchronized (completed) {
 				if (completed.get(entry.getKey()) == pending) {
 					completed.put(entry.getKey(), recovered);
@@ -564,20 +565,27 @@ public final class BackendControlConnector implements AutoCloseable {
 		return new StoredResult(result, false, true, false);
 	}
 
-	private boolean anticipatedResultIsInstalled(StoredResult pending) throws IOException {
+	static StoredResult committedInstalledForAttempt(BackendConfigurationService configurations,
+			StoredResult pending, String attemptId) throws IOException {
 		JsonObject result = pending.result();
-		if (!result.has("revision") || !result.has("configuration")) return false;
+		if (!result.has("revision") || !result.has("configuration")) return null;
 		String revision = result.get("revision").getAsString();
 		JsonObject configuration = result.getAsJsonObject("configuration");
 		String domain = string(configuration, "domain");
 		if ("file".equals(domain)) {
-			return revision.equals(configurations.read(string(configuration, "fileName")).revision());
+			BackendConfigurationService.Document installed = configurations.read(string(configuration, "fileName"));
+			if (!revision.equals(installed.revision())) return null;
+			result = result.deepCopy();
+			result.getAsJsonObject("configuration").addProperty("content", installed.content());
+			result.addProperty("attemptId", attemptId);
+			return new StoredResult(result, pending.restartConnector(), true, false);
 		}
 		if ("quick-setup".equals(domain)) {
-			return revision.equals(configurations.currentQuickSetupRevision(string(configuration, "preset"),
-					options(configuration.getAsJsonObject("options"))));
+			if (!revision.equals(configurations.currentQuickSetupRevision(string(configuration, "preset"),
+					options(configuration.getAsJsonObject("options"))))) return null;
+			return committedForAttempt(pending, attemptId);
 		}
-		return false;
+		return null;
 	}
 
 	private static StoredResult committedForAttempt(StoredResult pending, String attemptId) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
@@ -315,6 +315,7 @@ public final class ControlInspectionService {
 				.forEach(count -> {
 			JsonObject row = new JsonObject();
 			row.addProperty("service", safe(count.service, 64));
+			row.addProperty("count", count.votes);
 			row.addProperty("votes", count.votes);
 			services.add(row);
 		});
@@ -326,6 +327,7 @@ public final class ControlInspectionService {
 				.forEach(count -> {
 			JsonObject row = new JsonObject();
 			row.addProperty("server", safe(count.server, 64));
+			row.addProperty("count", count.votes);
 			row.addProperty("votes", count.votes);
 			servers.add(row);
 		});

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
@@ -44,7 +44,7 @@ import com.google.gson.JsonParser;
 public final class ControlInspectionService {
 	public static final int SCHEMA_VERSION = 1;
 	public static final int MAX_DATA_BYTES = 512 * 1024;
-	private static final int MAX_ROWS = 100;
+	static final int MAX_ROWS = 100;
 	private static final int MAX_TOP_ROWS = 20;
 	private static final Comparator<ServiceHealth> SERVICE_HEALTH_ORDER = Comparator
 			.comparingLong(ServiceHealth::lastVoteTime).reversed()
@@ -453,14 +453,17 @@ public final class ControlInspectionService {
 		result.addProperty("profile", safe(plugin.getProfile(), 80));
 		result.addProperty("javaVersion", safe(System.getProperty("java.version", "unknown"), 80));
 		result.addProperty("backgroundTaskSeconds", plugin.getLastBackgroundTaskTimeTaken());
-		JsonArray detected = new JsonArray();
 		Plugin[] plugins = plugin.getServer().getPluginManager().getPlugins();
-		java.util.Arrays.stream(plugins).map(installed -> installed.getDescription().getName())
-				.filter(name -> name != null && !name.isBlank()).distinct().sorted(String.CASE_INSENSITIVE_ORDER)
-				.limit(128).forEach(name -> detected.add(safe(name, 80)));
+		List<String> detectedNames = java.util.Arrays.stream(plugins)
+				.map(installed -> installed.getDescription().getName())
+				.filter(name -> name != null && !name.isBlank()).distinct()
+				.sorted(String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder())).toList();
+		JsonArray detected = new JsonArray();
+		detectedNames.stream().limit(MAX_ROWS).forEach(name -> detected.add(safe(name, 80)));
 		result.add("detectedPlugins", detected);
+		result.addProperty("detectedPluginsTruncated", detectedNames.size() > MAX_ROWS);
 		JsonArray redacted = new JsonArray();
-		List.of("credentials", "database hosts and credentials", "Redis/MQTT hosts and credentials",
+		List.of("credentials", "database and transport hosts and credentials", "Control endpoints and paths",
 				"webhook URLs", "raw configuration", "raw logs", "player records")
 				.forEach(redacted::add);
 		result.add("omittedSensitiveData", redacted);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlInspectionService.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonParser;
 
 /**
  * Typed, read-only data surface used by VotingPlugin Control.
@@ -280,6 +281,18 @@ public final class ControlInspectionService {
 		result.add("lastVotes", lastVotes);
 		result.addProperty("lastVotesTruncated", lastVoteSnapshot.size() > MAX_ROWS);
 		result.addProperty("pendingOfflineVotes", Math.min(user.getOfflineVotes().size(), 100000));
+		try {
+			JsonObject exact = JsonParser.parseString(new ControlPlayerDataService(plugin).readLoaded(user).content())
+					.getAsJsonObject();
+			result.addProperty("storageRowAvailable", true);
+			result.addProperty("storage", exact.get("storage").getAsString());
+			result.add("columns", exact.getAsJsonArray("columns"));
+			result.addProperty("columnsTruncated", exact.get("columnsTruncated").getAsBoolean());
+		} catch (java.io.IOException failure) {
+			result.addProperty("storageRowAvailable", false);
+			result.add("columns", new JsonArray());
+			result.addProperty("columnsTruncated", false);
+		}
 		return result;
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
@@ -1,0 +1,104 @@
+package com.bencodez.votingplugin.control;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import com.bencodez.simpleapi.sql.data.DataValue;
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.user.VotingPluginUser;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/** Exact, bounded, read-only rendering of allow-listed VotingPlugin player fields. */
+final class ControlPlayerDataService {
+	private static final int MAX_CONTENT_BYTES = 512 * 1024;
+	private static final int MAX_VALUE_BYTES = 16 * 1024;
+	private static final int MAX_COLUMNS = 128;
+	private static final Set<String> SAFE_STRING_COLUMNS = Set.of("UUID", "PlayerName", "LastOnline",
+			"DayVoteStreakLastUpdate", "VoteRemindersLast");
+	private static final Set<String> SAFE_BOOLEAN_COLUMNS = Set.of("TopVoterIgnore", "Reminded", "DisableBroadcast");
+	private static final Set<String> SAFE_INTEGER_COLUMNS = Set.of("VotePartyVotes", "MonthTotal", "AllTimeTotal",
+			"DailyTotal", "WeeklyTotal", "Points", "DayVoteStreak", "BestDayVoteStreak", "WeekVoteStreak",
+			"BestWeekVoteStreak", "MonthVoteStreak", "BestMonthVoteStreak", "HighestDailyTotal",
+			"HighestMonthlyTotal", "HighestWeeklyTotal", "LastMonthTotal", "LastWeeklyTotal", "LastDailyTotal");
+	private static final Pattern SAFE_DYNAMIC_INTEGER_COLUMN = Pattern.compile(
+			"(?:MonthTotal_[0-9]{4}_[0-9]{1,2}|VoteShopLimit[A-Za-z0-9_-]{1,64})");
+	private final VotingPluginMain plugin;
+
+	ControlPlayerDataService(VotingPluginMain plugin) {
+		this.plugin = plugin;
+	}
+
+	Document readLoaded(VotingPluginUser user) throws IOException {
+		java.util.Objects.requireNonNull(user, "user");
+		if (user.getUserData() == null || plugin.getStorageType() == null) {
+			throw new IOException("player data storage is unavailable");
+		}
+		Map<String, DataValue> values = user.getUserData().getValues();
+		if (values == null) throw new IOException("player data storage is unavailable");
+		List<Map.Entry<String, DataValue>> columns = new ArrayList<>(values.entrySet());
+		columns.sort(Map.Entry.<String, DataValue>comparingByKey(String.CASE_INSENSITIVE_ORDER)
+				.thenComparing(Map.Entry.comparingByKey()));
+		JsonObject content = new JsonObject();
+		content.addProperty("uuid", user.getUUID());
+		content.addProperty("name", user.getPlayerName());
+		content.addProperty("storage", plugin.getStorageType().name());
+		JsonArray listed = new JsonArray();
+		boolean truncated = false;
+		for (Map.Entry<String, DataValue> entry : columns) {
+			String name = entry.getKey();
+			DataValue value = entry.getValue();
+			if (name == null || value == null || !safeColumn(name, value)) continue;
+			if (listed.size() >= MAX_COLUMNS) {
+				truncated = true;
+				break;
+			}
+			String rendered = render(value);
+			if (rendered.getBytes(StandardCharsets.UTF_8).length > MAX_VALUE_BYTES) {
+				truncated = true;
+				continue;
+			}
+			JsonObject column = new JsonObject();
+			column.addProperty("name", name);
+			column.addProperty("type", value.getType().name());
+			column.addProperty("value", rendered);
+			listed.add(column);
+		}
+		content.add("columns", listed);
+		content.addProperty("columnsTruncated", truncated);
+		String json = content.toString();
+		if (json.getBytes(StandardCharsets.UTF_8).length > MAX_CONTENT_BYTES) {
+			throw new IOException("player data exceeds Control limits");
+		}
+		return new Document(json);
+	}
+
+	private boolean safeColumn(String name, DataValue value) {
+		if (SAFE_STRING_COLUMNS.contains(name)) return value.isString();
+		if (SAFE_BOOLEAN_COLUMNS.contains(name)) {
+			if (value.isBoolean()) return true;
+			return value.isString() && value.getString() != null
+					&& value.getString().matches("(?i:true|false)");
+		}
+		if (SAFE_INTEGER_COLUMNS.contains(name)) return value.isInt();
+		if (SAFE_DYNAMIC_INTEGER_COLUMN.matcher(name).matches()) return value.isInt();
+		if (name.equals(plugin.getVotingPluginUserManager().getCoolDownCheckPath())) return value.isBoolean();
+		if (name.equals(plugin.getVotingPluginUserManager().getCoolDownCheckSitePath())) return value.isString();
+		return (name.equals(plugin.getVotingPluginUserManager().getGottenAllSitesDayPath())
+				|| name.equals(plugin.getVotingPluginUserManager().getGottenAlmostAllSitesDayPath())) && value.isInt();
+	}
+
+	private static String render(DataValue value) {
+		if (value.isInt()) return Integer.toString(value.getInt());
+		if (value.isBoolean()) return Boolean.toString(value.getBoolean());
+		String rendered = value.getString();
+		return rendered == null ? "" : rendered;
+	}
+
+	record Document(String content) { }
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
@@ -26,7 +26,7 @@ final class ControlPlayerDataService {
 			"BestWeekVoteStreak", "MonthVoteStreak", "BestMonthVoteStreak", "HighestDailyTotal",
 			"HighestMonthlyTotal", "HighestWeeklyTotal", "LastMonthTotal", "LastWeeklyTotal", "LastDailyTotal");
 	private static final Pattern SAFE_DYNAMIC_INTEGER_COLUMN = Pattern.compile(
-			"(?:MonthTotal_[0-9]{4}_[0-9]{1,2}|VoteShopLimit[A-Za-z0-9_-]{1,64})");
+			"(?:MonthTotal-(?:JANUARY|FEBRUARY|MARCH|APRIL|MAY|JUNE|JULY|AUGUST|SEPTEMBER|OCTOBER|NOVEMBER|DECEMBER)-[0-9]{4}|VoteShopLimit[A-Za-z0-9_-]{1,64})");
 	private final VotingPluginMain plugin;
 
 	ControlPlayerDataService(VotingPluginMain plugin) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
@@ -18,7 +18,6 @@ import com.google.gson.JsonObject;
 final class ControlPlayerDataService {
 	private static final int MAX_CONTENT_BYTES = 512 * 1024;
 	private static final int MAX_VALUE_BYTES = 16 * 1024;
-	private static final int MAX_COLUMNS = 128;
 	private static final Set<String> SAFE_STRING_COLUMNS = Set.of("UUID", "PlayerName", "LastOnline",
 			"DayVoteStreakLastUpdate", "VoteRemindersLast");
 	private static final Set<String> SAFE_BOOLEAN_COLUMNS = Set.of("TopVoterIgnore", "Reminded", "DisableBroadcast");
@@ -54,7 +53,7 @@ final class ControlPlayerDataService {
 			String name = entry.getKey();
 			DataValue value = entry.getValue();
 			if (name == null || value == null || !safeColumn(name, value)) continue;
-			if (listed.size() >= MAX_COLUMNS) {
+			if (listed.size() >= ControlInspectionService.MAX_ROWS) {
 				truncated = true;
 				break;
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlPlayerDataService.java
@@ -38,7 +38,14 @@ final class ControlPlayerDataService {
 		if (user.getUserData() == null || plugin.getStorageType() == null) {
 			throw new IOException("player data storage is unavailable");
 		}
-		Map<String, DataValue> values = user.getUserData().getValues();
+		// User-data updates (votes and shop purchases) mutate this map in place. Take
+		// the copy while holding the same monitor used by the data object so the
+		// inspection thread never iterates a live HashMap concurrently.
+		Map<String, DataValue> values;
+		synchronized (user.getUserData()) {
+			Map<String, DataValue> liveValues = user.getUserData().getValues();
+			values = liveValues == null ? null : new java.util.HashMap<>(liveValues);
+		}
 		if (values == null) throw new IOException("player data storage is unavailable");
 		List<Map.Entry<String, DataValue>> columns = new ArrayList<>(values.entrySet());
 		columns.sort(Map.Entry.<String, DataValue>comparingByKey(String.CASE_INSENSITIVE_ORDER)

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlRewardProposal.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/control/ControlRewardProposal.java
@@ -98,10 +98,12 @@ final class ControlRewardProposal {
 				throw new IllegalArgumentException("item material is invalid");
 			}
 			Material material = Material.matchMaterial(materialName);
-			// Modern Bukkit resolves item-ness through the live registry. The null-server
-			// path keeps the shared parser usable in isolated validation tests; production
-			// connector calls always have a server and therefore enforce isItem().
-			if (material == null || (org.bukkit.Bukkit.getServer() != null && !material.isItem())) {
+			// Modern Bukkit resolves item-ness through the live registry. Mockito-based
+			// unit tests can expose a non-null skeletal Server without registries, so only
+			// use the registry-backed check when the implementation identifies itself.
+			org.bukkit.Server server = org.bukkit.Bukkit.getServer();
+			boolean liveServer = server != null && server.getName() != null && !server.getName().isBlank();
+			if (material == null || (liveServer && !material.isItem())) {
 				throw new IllegalArgumentException("item material is invalid");
 			}
 			result.add(new Item(material.name(), boundedInt(item, "amount", 1, 1, 64)));

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -87,6 +88,7 @@ public final class ControlConnector implements AutoCloseable {
 	private volatile boolean closed;
 	private volatile boolean registered;
 	private volatile boolean configurationAccepted;
+	private volatile Set<String> acceptedCapabilities = Set.of();
 	private volatile int failures;
 	private volatile long snapshotSequence;
 	private volatile ScheduledFuture<?> scheduled;
@@ -400,9 +402,16 @@ public final class ControlConnector implements AutoCloseable {
 			if (!contains(accepted, "presence.snapshot")) {
 				throw new ProtocolException();
 			}
-			configurationAccepted = contains(accepted, CONFIGURATION_CAPABILITY)
-					|| contains(accepted, COMMUNICATION_TEST_CAPABILITY)
-					|| contains(accepted, PROXY_METHOD_CAPABILITY) || contains(accepted, PROXY_FILE_CAPABILITY);
+			LinkedHashSet<String> negotiated = new LinkedHashSet<>();
+			for (JsonElement capability : accepted) {
+				if (!capability.isJsonPrimitive() || !capability.getAsJsonPrimitive().isString()) {
+					throw new ProtocolException();
+				}
+				negotiated.add(capability.getAsString());
+			}
+			acceptedCapabilities = Set.copyOf(negotiated);
+			configurationAccepted = acceptedCapabilities.stream().anyMatch(Set.of(CONFIGURATION_CAPABILITY,
+					COMMUNICATION_TEST_CAPABILITY, PROXY_METHOD_CAPABILITY, PROXY_FILE_CAPABILITY)::contains);
 		}
 	}
 
@@ -717,10 +726,20 @@ public final class ControlConnector implements AutoCloseable {
 	private CompletableFuture<TaskResult> executeTask(UUID operationId, JsonObject task) {
 		JsonObject requested = task.getAsJsonObject("configuration");
 		if (isProxyFile(requested)) {
+			if (!acceptedCapabilities.contains(PROXY_FILE_CAPABILITY)) {
+				return completed(TaskResult.failure("UNSUPPORTED", "Proxy file control was not negotiated"));
+			}
 			return executeProxyFile(operationId, task, requested);
 		}
-		if (isCommunicationTest(requested)) return executeCommunicationTest(task, requested);
-		if (isProxyMethod(requested)) return executeProxyMethod(operationId, task, requested);
+		if (isCommunicationTest(requested)) return acceptedCapabilities.contains(COMMUNICATION_TEST_CAPABILITY)
+				? executeCommunicationTest(task, requested)
+				: completed(TaskResult.failure("UNSUPPORTED", "Communication testing was not negotiated"));
+		if (isProxyMethod(requested)) return acceptedCapabilities.contains(PROXY_METHOD_CAPABILITY)
+				? executeProxyMethod(operationId, task, requested)
+				: completed(TaskResult.failure("UNSUPPORTED", "Proxy method control was not negotiated"));
+		if (!acceptedCapabilities.contains(CONFIGURATION_CAPABILITY)) {
+			return completed(TaskResult.failure("UNSUPPORTED", "Proxy routing control was not negotiated"));
+		}
 		if (configurationService == null) return completed(TaskResult.failure("UNSUPPORTED", "Configuration control is unavailable"));
 		String type = requireString(task, "type");
 		try {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -824,7 +824,11 @@ public final class ControlConnector implements AutoCloseable {
 			String content = requireString(requested, "content");
 			ProxyConfigurationFileService.Preview preview = fileConfigurationService.preview(fileName, content);
 			if ("PREVIEW".equals(type)) {
-				return completed(TaskResult.file(fileConfigurationService.read(fileName), preview.changes(), false, false));
+				ProxyConfigurationFileService.Document current = fileConfigurationService.read(fileName);
+				if (!preview.revision().equals(current.revision())) {
+					throw new ProxyConfigurationFileService.StaleRevisionException();
+				}
+				return completed(TaskResult.file(current, preview.changes(), false, false));
 			}
 			if (!"APPLY".equals(type)) return completed(TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported"));
 			persistIntent(operationId, TaskResult.fileIntent(fileName,

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -50,13 +50,14 @@ import com.google.gson.JsonParser;
  */
 public final class ControlConnector implements AutoCloseable {
 	static final int PROTOCOL_VERSION = 1;
-	static final int MAX_RESPONSE_BYTES = 64 * 1024;
+	static final int MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 	private static final Pattern NODE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]{0,63}");
 	private static final Set<String> BASE_CAPABILITIES = Set.of("presence.snapshot");
 	private static final String CONFIGURATION_CAPABILITY = "config.proxy-routing.v1";
 	private static final String COMMUNICATION_TEST_CAPABILITY = "config.transport-test.v1";
 	private static final String COMMUNICATION_TEST_PRESET = "communication-test";
 	private static final String PROXY_METHOD_CAPABILITY = "config.proxy-method.v1";
+	private static final String PROXY_FILE_CAPABILITY = "config.proxy-files.v1";
 	private static final String PROXY_METHOD_PRESET = "proxy-method";
 	private static final String INTERNAL_OPERATION_TYPE = "_controlOperationType";
 	private static final long OPERATION_POLL_MILLIS = 1000;
@@ -72,6 +73,7 @@ public final class ControlConnector implements AutoCloseable {
 	private final LongSupplier jitterSource;
 	private final ProxyRoutingConfigurationService configurationService;
 	private final ProxyMethodConfigurationService methodConfigurationService;
+	private final ProxyConfigurationFileService fileConfigurationService;
 	private final Function<String, CompletableFuture<VotingPluginProxy.CommunicationTestResult>> communicationTest;
 	private final Runnable runtimeReplacement;
 	private final Path dataDirectory;
@@ -97,14 +99,14 @@ public final class ControlConnector implements AutoCloseable {
 			Supplier<List<ObservedBackend>> snapshotSource, Consumer<String> logger, UUID sessionId,
 			LongSupplier jitterSource) {
 		this(settings, scheduler, transport, snapshotSource, logger, sessionId, jitterSource, null,
-				null, null, false, null, null, null, null);
+				null, null, false, null, null, null, null, null);
 	}
 
 	ControlConnector(Settings settings, ScheduledExecutorService scheduler, Transport transport,
 			Supplier<List<ObservedBackend>> snapshotSource, Consumer<String> logger, UUID sessionId,
 			LongSupplier jitterSource, ProxyRoutingConfigurationService configurationService) {
 		this(settings, scheduler, transport, snapshotSource, logger, sessionId, jitterSource, configurationService,
-				null, null, false, null, null, null, null);
+				null, null, false, null, null, null, null, null);
 	}
 
 	ControlConnector(Settings settings, ScheduledExecutorService scheduler, Transport transport,
@@ -112,7 +114,7 @@ public final class ControlConnector implements AutoCloseable {
 			LongSupplier jitterSource, ProxyRoutingConfigurationService configurationService,
 			Map<UUID, StoredResult> recoveredTasks) {
 		this(settings, scheduler, transport, snapshotSource, logger, sessionId, jitterSource, configurationService,
-				null, null, false, null, null, null, null);
+				null, null, false, null, null, null, null, null);
 		completedTasks.putAll(recoveredTasks);
 	}
 
@@ -121,7 +123,8 @@ public final class ControlConnector implements AutoCloseable {
 			LongSupplier jitterSource, ProxyRoutingConfigurationService configurationService, Path dataDirectory,
 			Route route, boolean recovering, Runnable recoveryComplete,
 			Function<String, CompletableFuture<VotingPluginProxy.CommunicationTestResult>> communicationTest,
-			ProxyMethodConfigurationService methodConfigurationService, Runnable runtimeReplacement) {
+			ProxyMethodConfigurationService methodConfigurationService, Runnable runtimeReplacement,
+			ProxyConfigurationFileService fileConfigurationService) {
 		this.settings = Objects.requireNonNull(settings, "settings");
 		this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
 		this.transport = Objects.requireNonNull(transport, "transport");
@@ -133,6 +136,7 @@ public final class ControlConnector implements AutoCloseable {
 		this.methodConfigurationService = methodConfigurationService;
 		this.communicationTest = communicationTest;
 		this.runtimeReplacement = runtimeReplacement;
+		this.fileConfigurationService = fileConfigurationService;
 		this.dataDirectory = dataDirectory;
 		this.route = route;
 		this.recovering = recovering;
@@ -193,7 +197,7 @@ public final class ControlConnector implements AutoCloseable {
 				() -> ThreadLocalRandom.current().nextLong(), new ProxyRoutingConfigurationService(proxy), dataDirectory,
 				route, recovering, proxy::restartControlServicesAfterRecovery,
 				server -> proxy.testBackendCommunication(server, 5000L), new ProxyMethodConfigurationService(proxy),
-				() -> proxy.reloadCore(true));
+				() -> proxy.reloadCore(true), new ProxyConfigurationFileService(proxy));
 		if (recovered != null) connector.completedTasks.putAll(recovered.results());
 		return connector;
 	}
@@ -398,7 +402,7 @@ public final class ControlConnector implements AutoCloseable {
 			}
 			configurationAccepted = contains(accepted, CONFIGURATION_CAPABILITY)
 					|| contains(accepted, COMMUNICATION_TEST_CAPABILITY)
-					|| contains(accepted, PROXY_METHOD_CAPABILITY);
+					|| contains(accepted, PROXY_METHOD_CAPABILITY) || contains(accepted, PROXY_FILE_CAPABILITY);
 		}
 	}
 
@@ -633,10 +637,19 @@ public final class ControlConnector implements AutoCloseable {
 		JsonObject result = anticipated.json();
 		result.addProperty("attemptId", attemptId);
 		result.addProperty(INTERNAL_OPERATION_TYPE, "APPLY");
+		StoredResult previous;
 		synchronized (operationLifecycle) {
-			completedTasks.put(operationId, new StoredResult(result, false, false));
+			previous = completedTasks.put(operationId, new StoredResult(result, false, false));
 		}
-		persistCompleted();
+		try {
+			persistCompleted();
+		} catch (RuntimeException failure) {
+			synchronized (operationLifecycle) {
+				if (previous == null) completedTasks.remove(operationId);
+				else completedTasks.put(operationId, previous);
+			}
+			throw failure;
+		}
 	}
 
 	private void prepareWriteAheadIntents() {
@@ -656,7 +669,17 @@ public final class ControlConnector implements AutoCloseable {
 				}
 			}
 		}
-		if (changed) persistCompleted();
+		if (changed) {
+			try {
+				persistCompleted();
+			} catch (RuntimeException failure) {
+				synchronized (operationLifecycle) {
+					completedTasks.clear();
+					completedTasks.putAll(snapshot);
+				}
+				throw failure;
+			}
+		}
 	}
 
 	private static StoredResult abortedIntent(StoredResult pending) {
@@ -673,6 +696,14 @@ public final class ControlConnector implements AutoCloseable {
 		if (configuration != null && isProxyMethod(configuration) && methodConfigurationService != null) {
 			return result.get("revision").getAsString().equals(methodConfigurationService.read().revision());
 		}
+		if (isProxyFile(configuration) && fileConfigurationService != null) {
+			try {
+				return result.get("revision").getAsString().equals(
+						fileConfigurationService.read(requireString(configuration, "fileName")).revision());
+			} catch (IOException failure) {
+				return false;
+			}
+		}
 		return configurationService != null
 				&& result.get("revision").getAsString().equals(configurationService.read().revision());
 	}
@@ -685,6 +716,9 @@ public final class ControlConnector implements AutoCloseable {
 
 	private CompletableFuture<TaskResult> executeTask(UUID operationId, JsonObject task) {
 		JsonObject requested = task.getAsJsonObject("configuration");
+		if (isProxyFile(requested)) {
+			return executeProxyFile(operationId, task, requested);
+		}
 		if (isCommunicationTest(requested)) return executeCommunicationTest(task, requested);
 		if (isProxyMethod(requested)) return executeProxyMethod(operationId, task, requested);
 		if (configurationService == null) return completed(TaskResult.failure("UNSUPPORTED", "Configuration control is unavailable"));
@@ -758,6 +792,41 @@ public final class ControlConnector implements AutoCloseable {
 		}
 	}
 
+	private CompletableFuture<TaskResult> executeProxyFile(UUID operationId, JsonObject task, JsonObject requested) {
+		if (fileConfigurationService == null) {
+			return completed(TaskResult.failure("UNSUPPORTED", "Proxy file control is unavailable"));
+		}
+		String type = requireString(task, "type");
+		String fileName = requireString(requested, "fileName");
+		try {
+			if ("READ".equals(type)) {
+				return completed(TaskResult.file(fileConfigurationService.read(fileName), List.of(), false, false));
+			}
+			String content = requireString(requested, "content");
+			ProxyConfigurationFileService.Preview preview = fileConfigurationService.preview(fileName, content);
+			if ("PREVIEW".equals(type)) {
+				return completed(TaskResult.file(fileConfigurationService.read(fileName), preview.changes(), false, false));
+			}
+			if (!"APPLY".equals(type)) return completed(TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported"));
+			persistIntent(operationId, TaskResult.fileIntent(fileName,
+					ProxyConfigurationFileService.revision(preview.resolvedContent()), preview.changes()),
+					requireString(task, "attemptId"));
+			ProxyConfigurationFileService.ApplyResult applied = fileConfigurationService.apply(fileName, content,
+					requireString(task, "expectedRevision"));
+			return completed(TaskResult.file(applied.document(), applied.changes(), false, applied.rolledBack(),
+					"Proxy configuration saved; restart the proxy to activate general settings"));
+		} catch (ProxyConfigurationFileService.StaleRevisionException failure) {
+			return completed(TaskResult.failure("STALE_REVISION", "Proxy configuration changed after preview"));
+		} catch (ProxyConfigurationFileService.ApplyFailureException failure) {
+			return completed(new TaskResult(false, "APPLY_FAILED", "Proxy configuration could not be saved", null, null,
+					List.of(), false, failure.rolledBack()));
+		} catch (IllegalArgumentException failure) {
+			return completed(TaskResult.failure("VALIDATION_ERROR", failure.getMessage()));
+		} catch (IOException | RuntimeException failure) {
+			return completed(TaskResult.failure("APPLY_FAILED", "Proxy configuration operation failed"));
+		}
+	}
+
 	private CompletableFuture<TaskResult> executeCommunicationTest(JsonObject task, JsonObject requested) {
 		if (!"READ".equals(requireString(task, "type"))) {
 			return completed(TaskResult.failure("UNSUPPORTED_TASK", "Communication tests are read-only"));
@@ -797,6 +866,12 @@ public final class ControlConnector implements AutoCloseable {
 		return requested != null && requested.has("domain") && requested.has("preset")
 				&& "quick-setup".equals(requested.get("domain").getAsString())
 				&& PROXY_METHOD_PRESET.equals(requested.get("preset").getAsString());
+	}
+
+	private static boolean isProxyFile(JsonObject requested) {
+		return requested != null && requested.has("domain") && requested.get("domain").isJsonPrimitive()
+				&& requested.getAsJsonPrimitive("domain").isString()
+				&& "file".equals(requested.get("domain").getAsString());
 	}
 
 	private static CompletableFuture<TaskResult> completed(TaskResult result) {
@@ -868,6 +943,7 @@ public final class ControlConnector implements AutoCloseable {
 		if (configurationService != null) advertised.add(CONFIGURATION_CAPABILITY);
 		if (communicationTest != null) advertised.add(COMMUNICATION_TEST_CAPABILITY);
 		if (methodConfigurationService != null) advertised.add(PROXY_METHOD_CAPABILITY);
+		if (fileConfigurationService != null) advertised.add(PROXY_FILE_CAPABILITY);
 		body.add("capabilities", advertised);
 		JsonArray required = new JsonArray();
 		required.add("presence.snapshot");
@@ -1036,6 +1112,29 @@ public final class ControlConnector implements AutoCloseable {
 		private static TaskResult success(String revision, JsonObject configuration, List<String> changes,
 				boolean reloaded, String message) {
 			return new TaskResult(true, "OK", message, revision, configuration, changes, reloaded, false);
+		}
+		private static TaskResult file(ProxyConfigurationFileService.Document document, List<String> changes,
+				boolean reloaded, boolean rolledBack) {
+			return file(document, changes, reloaded, rolledBack, "Operation completed");
+		}
+
+		private static TaskResult file(ProxyConfigurationFileService.Document document, List<String> changes,
+				boolean reloaded, boolean rolledBack, String message) {
+			JsonObject configuration = new JsonObject();
+			configuration.addProperty("domain", "file");
+			configuration.addProperty("fileName", document.fileName());
+			configuration.addProperty("content", document.content());
+			return new TaskResult(true, "OK", message, document.revision(), configuration,
+					List.copyOf(changes), reloaded, rolledBack);
+		}
+
+		private static TaskResult fileIntent(String fileName, String revision, List<String> changes) {
+			JsonObject configuration = new JsonObject();
+			configuration.addProperty("domain", "file");
+			configuration.addProperty("fileName", fileName);
+			return new TaskResult(true, "OK",
+					"Proxy configuration saved; restart the proxy to activate general settings", revision, configuration,
+					List.copyOf(changes), false, false);
 		}
 		private static TaskResult failure(String code, String message) {
 			return new TaskResult(false, code, message == null ? "Operation failed" : message, null, null, List.of(), false, false);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -897,6 +897,12 @@ public final class ControlConnector implements AutoCloseable {
 			// claim must be acknowledged as a validation failure, not escape the operation
 			// future and leave the same lease blocking the configuration lane.
 			String type = requireString(task, "type");
+			Set<String> allowedFields;
+			if ("READ".equals(type)) allowedFields = Set.of("domain", "fileName");
+			else if ("PREVIEW".equals(type) || "APPLY".equals(type))
+				allowedFields = Set.of("domain", "fileName", "content");
+			else return completed(TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported"));
+			if (!allowedFields.equals(requested.keySet())) throw new MalformedResponseException();
 			String fileName = requireString(requested, "fileName");
 			if ("READ".equals(type)) {
 				return completed(TaskResult.file(fileConfigurationService.read(fileName), List.of(), false, false));

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -526,6 +526,7 @@ public final class ControlConnector implements AutoCloseable {
 		synchronized (operationLifecycle) {
 			result = completedTasks.get(operationId);
 		}
+		if (result != null && !capabilityAccepted(result)) return CompletableFuture.completedFuture(null);
 		if (result != null) {
 			if (!result.committed() && !result.claimRequired()) {
 				result = committedIfInstalled(result, requireString(task, "attemptId"));

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -613,7 +613,8 @@ public final class ControlConnector implements AutoCloseable {
 	private boolean hasLifecycleBlockingTasks() {
 		if (!registered) return !completedTasks.isEmpty();
 		return completedTasks.values().stream()
-				.anyMatch(pending -> !pending.committed() || capabilityAccepted(pending));
+				.anyMatch(pending -> !pending.committed() && !pending.claimRequired()
+						|| capabilityAccepted(pending));
 	}
 
 	static boolean requiresRuntimeReplacement(StoredResult result) {
@@ -659,6 +660,8 @@ public final class ControlConnector implements AutoCloseable {
 		JsonObject result = anticipated.json();
 		result.addProperty("attemptId", attemptId);
 		result.addProperty(INTERNAL_OPERATION_TYPE, "APPLY");
+		result.addProperty(INTERNAL_REQUIRED_CAPABILITY,
+				requiredCapability(result.getAsJsonObject("configuration")));
 		StoredResult previous;
 		synchronized (operationLifecycle) {
 			previous = completedTasks.put(operationId, new StoredResult(result, false, false));
@@ -708,6 +711,10 @@ public final class ControlConnector implements AutoCloseable {
 		JsonObject result = TaskResult.failure("RECOVERY_ABORTED",
 				"Configuration apply did not finish before node recovery").json();
 		result.addProperty("attemptId", requireString(pending.result(), "attemptId"));
+		JsonObject pendingResult = pending.result();
+		result.addProperty(INTERNAL_REQUIRED_CAPABILITY, pendingResult.has(INTERNAL_REQUIRED_CAPABILITY)
+				? pendingResult.get(INTERNAL_REQUIRED_CAPABILITY).getAsString()
+				: requiredCapability(pendingResult.getAsJsonObject("configuration")));
 		return new StoredResult(result, true, false);
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -61,6 +61,7 @@ public final class ControlConnector implements AutoCloseable {
 	private static final String PROXY_FILE_CAPABILITY = "config.proxy-files.v1";
 	private static final String PROXY_METHOD_PRESET = "proxy-method";
 	private static final String INTERNAL_OPERATION_TYPE = "_controlOperationType";
+	private static final String INTERNAL_REQUIRED_CAPABILITY = "_controlRequiredCapability";
 	private static final long OPERATION_POLL_MILLIS = 1000;
 	private static final long MAX_BACKOFF_MILLIS = TimeUnit.MINUTES.toMillis(5);
 	private static final long OPERATION_SHUTDOWN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(65);
@@ -541,6 +542,8 @@ public final class ControlConnector implements AutoCloseable {
 				JsonObject resultJson = executed.json();
 				resultJson.addProperty("attemptId", requireString(task, "attemptId"));
 				resultJson.addProperty(INTERNAL_OPERATION_TYPE, requireString(task, "type"));
+				resultJson.addProperty(INTERNAL_REQUIRED_CAPABILITY,
+						requiredCapability(task.getAsJsonObject("configuration")));
 				StoredResult completed = new StoredResult(resultJson, true, false);
 				synchronized (operationLifecycle) { completedTasks.put(operationId, completed); }
 				persistCompleted();
@@ -553,14 +556,15 @@ public final class ControlConnector implements AutoCloseable {
 	private boolean hasCompletedTask() {
 		prepareWriteAheadIntents();
 		synchronized (operationLifecycle) {
-			return completedTasks.values().stream().anyMatch(StoredResult::committed);
+			return completedTasks.values().stream().anyMatch(result -> result.committed() && capabilityAccepted(result));
 		}
 	}
 
 	private CompletableFuture<Void> submitCompletedResult() {
 		Map.Entry<UUID, StoredResult> pending;
 		synchronized (operationLifecycle) {
-			pending = completedTasks.entrySet().stream().filter(entry -> entry.getValue().committed())
+			pending = completedTasks.entrySet().stream()
+					.filter(entry -> entry.getValue().committed() && capabilityAccepted(entry.getValue()))
 					.findFirst().orElse(null);
 		}
 		if (pending == null) return CompletableFuture.completedFuture(null);
@@ -905,6 +909,21 @@ public final class ControlConnector implements AutoCloseable {
 				&& "file".equals(requested.get("domain").getAsString());
 	}
 
+	private boolean capabilityAccepted(StoredResult result) {
+		JsonObject body = result.result();
+		String required = body.has(INTERNAL_REQUIRED_CAPABILITY)
+				? body.get(INTERNAL_REQUIRED_CAPABILITY).getAsString()
+				: requiredCapability(body.getAsJsonObject("configuration"));
+		return acceptedCapabilities.contains(required);
+	}
+
+	private static String requiredCapability(JsonObject configuration) {
+		if (isProxyFile(configuration)) return PROXY_FILE_CAPABILITY;
+		if (isCommunicationTest(configuration)) return COMMUNICATION_TEST_CAPABILITY;
+		if (isProxyMethod(configuration)) return PROXY_METHOD_CAPABILITY;
+		return CONFIGURATION_CAPABILITY;
+	}
+
 	private static CompletableFuture<TaskResult> completed(TaskResult result) {
 		return CompletableFuture.completedFuture(result);
 	}
@@ -921,6 +940,7 @@ public final class ControlConnector implements AutoCloseable {
 	private Request resultRequest(UUID operationId, StoredResult result) {
 		JsonObject body = result.result().deepCopy();
 		body.remove(INTERNAL_OPERATION_TYPE);
+		body.remove(INTERNAL_REQUIRED_CAPABILITY);
 		body.addProperty("sessionId", sessionId.toString());
 		return new Request("POST", "/api/v1/nodes/" + settings.nodeId() + "/operations/" + operationId
 				+ "/result", body.toString());

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -151,18 +151,21 @@ public final class ControlConnector implements AutoCloseable {
 	/** Creates the production connector without reading a credential when the feature is disabled. */
 	public static ControlConnector create(VotingPluginProxy proxy) throws IOException {
 		Path dataDirectory = proxy.getDataFolderPlugin().toPath().toAbsolutePath().normalize();
-		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(dataDirectory);
 		VotingPluginProxyConfig config = proxy.getConfig();
+		ProxyControlResultStore.State recovered;
 		Settings settings;
 		Route route;
 		String credentialName;
-		boolean recovering = recovered != null && recovered.routeRequired();
-		if (recovering) {
+		if (!config.getControlEnabled()) {
+			// With Control disabled there is no current configured route. A required
+			// result may still be retried only against its own recorded coordinator;
+			// never select a released result or redirect it to another node.
+			recovered = ProxyControlResultStore.loadRequired(dataDirectory);
+			if (recovered == null) return null;
 			route = recovered.route();
 			settings = settings(route);
 			credentialName = route.credentialFile();
 		} else {
-			if (!config.getControlEnabled()) return null;
 			String configuredNodeId = config.getControlNodeId();
 			String nodeId = configuredNodeId == null || configuredNodeId.isBlank()
 					? config.getProxyServerName() : configuredNodeId.trim();
@@ -178,7 +181,17 @@ public final class ControlConnector implements AutoCloseable {
 					URI.create(endpointValue.trim()), config.getControlHeartbeatSeconds(),
 					config.getControlConnectTimeoutMillis(), config.getControlRequestTimeoutMillis());
 			route = route(settings, credentialName);
+			recovered = ProxyControlResultStore.loadPreferred(dataDirectory, route);
+			if (recovered != null && recovered.routeRequired()
+					&& !recovered.route().identity().equals(route.identity())) {
+				// Drain an older coordinator before returning to current configuration.
+				// completeRecoveryIfDrained() restarts this service to advance the queue.
+				route = recovered.route();
+				settings = settings(route);
+				credentialName = route.credentialFile();
+			}
 		}
+		boolean recovering = recovered != null && recovered.routeRequired();
 		String credential = ControlCredentialFile.read(dataDirectory, credentialName);
 		HttpControlTransport transport = new HttpControlTransport(settings.endpoint(), credential,
 				settings.connectTimeoutMillis(), settings.requestTimeoutMillis());

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -735,7 +735,7 @@ public final class ControlConnector implements AutoCloseable {
 				StoredResult committed = committedForAttempt(pending, attemptId);
 				committed.result().getAsJsonObject("configuration").addProperty("content", installed.content());
 				return committed;
-			} catch (IOException failure) {
+			} catch (IOException | RuntimeException failure) {
 				return null;
 			}
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -526,10 +526,12 @@ public final class ControlConnector implements AutoCloseable {
 			result = completedTasks.get(operationId);
 		}
 		if (result != null) {
-			if (!result.committed() && !result.claimRequired() && !anticipatedResultIsInstalled(result)) {
-				result = null;
+			if (!result.committed() && !result.claimRequired()) {
+				result = committedIfInstalled(result, requireString(task, "attemptId"));
 			} else {
 				result = committedForAttempt(result, requireString(task, "attemptId"));
+			}
+			if (result != null) {
 				synchronized (operationLifecycle) { completedTasks.put(operationId, result); }
 				persistCompleted();
 			}
@@ -668,9 +670,9 @@ public final class ControlConnector implements AutoCloseable {
 		for (Map.Entry<UUID, StoredResult> entry : snapshot.entrySet()) {
 			StoredResult pending = entry.getValue();
 			if (pending.committed() || pending.claimRequired()) continue;
-			StoredResult recovered = anticipatedResultIsInstalled(pending)
-					? committedForAttempt(pending, requireString(pending.result(), "attemptId"))
-					: abortedIntent(pending);
+			StoredResult recovered = committedIfInstalled(pending,
+					requireString(pending.result(), "attemptId"));
+			if (recovered == null) recovered = abortedIntent(pending);
 			synchronized (operationLifecycle) {
 				if (completedTasks.get(entry.getKey()) == pending) {
 					completedTasks.put(entry.getKey(), recovered);
@@ -698,23 +700,29 @@ public final class ControlConnector implements AutoCloseable {
 		return new StoredResult(result, true, false);
 	}
 
-	private boolean anticipatedResultIsInstalled(StoredResult pending) {
+	private StoredResult committedIfInstalled(StoredResult pending, String attemptId) {
 		JsonObject result = pending.result();
-		if (!result.has("revision")) return false;
+		if (!result.has("revision")) return null;
 		JsonObject configuration = result.getAsJsonObject("configuration");
 		if (configuration != null && isProxyMethod(configuration) && methodConfigurationService != null) {
-			return result.get("revision").getAsString().equals(methodConfigurationService.read().revision());
+			return result.get("revision").getAsString().equals(methodConfigurationService.read().revision())
+					? committedForAttempt(pending, attemptId) : null;
 		}
 		if (isProxyFile(configuration) && fileConfigurationService != null) {
 			try {
-				return result.get("revision").getAsString().equals(
-						fileConfigurationService.read(requireString(configuration, "fileName")).revision());
+				ProxyConfigurationFileService.Document installed = fileConfigurationService.read(
+						requireString(configuration, "fileName"));
+				if (!result.get("revision").getAsString().equals(installed.revision())) return null;
+				StoredResult committed = committedForAttempt(pending, attemptId);
+				committed.result().getAsJsonObject("configuration").addProperty("content", installed.content());
+				return committed;
 			} catch (IOException failure) {
-				return false;
+				return null;
 			}
 		}
 		return configurationService != null
-				&& result.get("revision").getAsString().equals(configurationService.read().revision());
+				&& result.get("revision").getAsString().equals(configurationService.read().revision())
+				? committedForAttempt(pending, attemptId) : null;
 	}
 
 	private static StoredResult committedForAttempt(StoredResult pending, String attemptId) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -842,9 +842,12 @@ public final class ControlConnector implements AutoCloseable {
 		if (fileConfigurationService == null) {
 			return completed(TaskResult.failure("UNSUPPORTED", "Proxy file control is unavailable"));
 		}
-		String type = requireString(task, "type");
-		String fileName = requireString(requested, "fileName");
 		try {
+			// Keep all negotiated task fields inside the durable-result boundary. A malformed
+			// claim must be acknowledged as a validation failure, not escape the operation
+			// future and leave the same lease blocking the configuration lane.
+			String type = requireString(task, "type");
+			String fileName = requireString(requested, "fileName");
 			if ("READ".equals(type)) {
 				return completed(TaskResult.file(fileConfigurationService.read(fileName), List.of(), false, false));
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -86,6 +86,7 @@ public final class ControlConnector implements AutoCloseable {
 	private final Map<UUID, StoredResult> completedTasks = new LinkedHashMap<>();
 	private final Object operationLifecycle = new Object();
 	private final AtomicBoolean inFlight = new AtomicBoolean();
+	private final AtomicBoolean recoveryCompleted = new AtomicBoolean();
 	private Runnable deferredReplacement;
 	private volatile boolean closed;
 	private volatile boolean registered;
@@ -155,8 +156,8 @@ public final class ControlConnector implements AutoCloseable {
 		Settings settings;
 		Route route;
 		String credentialName;
-		boolean recovering = recovered != null;
-		if (recovered != null) {
+		boolean recovering = recovered != null && recovered.routeRequired();
+		if (recovering) {
 			route = recovered.route();
 			settings = settings(route);
 			credentialName = route.credentialFile();
@@ -337,7 +338,14 @@ public final class ControlConnector implements AutoCloseable {
 			activeRequest = presence;
 			return presence.thenCompose(responseBody -> {
 				handlePresenceResponse(responseBody);
-				if (!configurationAccepted) return CompletableFuture.completedFuture(null);
+				if (!configurationAccepted) {
+					// A recovering connector may have only results for capabilities this
+					// session could not negotiate. There is no operation claim (and thus
+					// no 204) to release that drained recovery, so complete it after the
+					// registration/presence handshake instead.
+					completeRecoveryIfDrained();
+					return CompletableFuture.completedFuture(null);
+				}
 				if (hasCompletedTask()) return submitCompletedResult();
 				CompletableFuture<Response> claim = transport.send(claimRequest());
 				activeRequest = claim;
@@ -515,7 +523,13 @@ public final class ControlConnector implements AutoCloseable {
 	}
 
 	private CompletableFuture<Void> handleClaimResponse(Response response) {
-		if (response.statusCode == 204) return CompletableFuture.completedFuture(null);
+		if (response.statusCode == 204) {
+			// A recovered result may be filtered because this session did not negotiate
+			// its capability.  There is then nothing to acknowledge, so the empty
+			// claim itself is the point at which recovery can be released.
+			completeRecoveryIfDrained();
+			return CompletableFuture.completedFuture(null);
+		}
 		if (response.statusCode == 404) {
 			registered = false;
 			throw new RegistryLostException();
@@ -608,7 +622,25 @@ public final class ControlConnector implements AutoCloseable {
 			drained = !hasLifecycleBlockingTasks();
 			if (replaceRuntime) deferredReplacement = runtimeReplacement;
 		}
-		if (recovering && drained && recoveryComplete != null && !replaceRuntime) recoveryComplete.run();
+		if (drained && !replaceRuntime) completeRecoveryIfDrained();
+	}
+
+	private void completeRecoveryIfDrained() {
+		if (!recovering || recoveryComplete == null) return;
+		synchronized (operationLifecycle) {
+			if (hasLifecycleBlockingTasks()) return;
+		}
+		if (!recoveryCompleted.compareAndSet(false, true)) return;
+		try {
+			// Keep capability-filtered results durable, but release the old route so
+			// the replacement connector starts from current configuration instead of
+			// loading the same recovery route forever.
+			persistCompleted(false);
+		} catch (RuntimeException failure) {
+			recoveryCompleted.set(false);
+			throw failure;
+		}
+		recoveryComplete.run();
 	}
 
 	/** Results rejected by this negotiated session remain durable but do not prevent its lifecycle from draining. */
@@ -648,11 +680,15 @@ public final class ControlConnector implements AutoCloseable {
 	}
 
 	private void persistCompleted() {
+		persistCompleted(true);
+	}
+
+	private void persistCompleted(boolean routeRequired) {
 		if (dataDirectory == null || route == null) return;
 		Map<UUID, StoredResult> snapshot;
 		synchronized (operationLifecycle) { snapshot = new LinkedHashMap<>(completedTasks); }
 		try {
-			ProxyControlResultStore.save(dataDirectory, route, snapshot);
+			ProxyControlResultStore.save(dataDirectory, route, snapshot, routeRequired);
 		} catch (IOException e) {
 			throw new UnavailableException(e);
 		}
@@ -874,6 +910,8 @@ public final class ControlConnector implements AutoCloseable {
 		} catch (ProxyConfigurationFileService.ApplyFailureException failure) {
 			return completed(new TaskResult(false, "APPLY_FAILED", "Proxy configuration could not be saved", null, null,
 					List.of(), false, failure.rolledBack()));
+		} catch (MalformedResponseException failure) {
+			return completed(TaskResult.failure("VALIDATION_ERROR", "Proxy configuration task fields are invalid"));
 		} catch (IllegalArgumentException failure) {
 			return completed(TaskResult.failure("VALIDATION_ERROR", failure.getMessage()));
 		} catch (IOException | RuntimeException failure) {
@@ -990,7 +1028,8 @@ public final class ControlConnector implements AutoCloseable {
 	}
 
 	private static String requireString(JsonObject body, String name) {
-		if (body == null || !body.has(name) || !body.get(name).isJsonPrimitive()) throw new MalformedResponseException();
+		if (body == null || !body.has(name) || !body.get(name).isJsonPrimitive()
+				|| !body.getAsJsonPrimitive(name).isString()) throw new MalformedResponseException();
 		return body.get(name).getAsString();
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -52,6 +52,7 @@ import com.google.gson.JsonParser;
 public final class ControlConnector implements AutoCloseable {
 	static final int PROTOCOL_VERSION = 1;
 	static final int MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+	private static final int MAX_RESULT_TEXT_CHARS = 240;
 	private static final Pattern NODE_ID = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._-]{0,63}");
 	private static final Set<String> BASE_CAPABILITIES = Set.of("presence.snapshot");
 	private static final String CONFIGURATION_CAPABILITY = "config.proxy-routing.v1";
@@ -1006,6 +1007,26 @@ public final class ControlConnector implements AutoCloseable {
 		return body;
 	}
 
+	/** Keeps persisted and submitted result fields within Control's per-entry protocol bound. */
+	static String boundedResultMessage(String message) {
+		String safe = message == null ? "Operation failed" : message.replaceAll("\\p{Cntrl}", " ").trim();
+		if (safe.isBlank()) safe = "Operation failed";
+		if (safe.length() > MAX_RESULT_TEXT_CHARS) safe = safe.substring(0, MAX_RESULT_TEXT_CHARS - 3) + "...";
+		return safe;
+	}
+
+	static List<String> boundedResultChanges(List<String> changes) {
+		if (changes == null || changes.isEmpty()) return List.of();
+		List<String> safe = new ArrayList<>();
+		int retained = changes.size() > 20 ? 19 : changes.size();
+		for (int index = 0; index < retained; index++) {
+			String change = changes.get(index);
+			safe.add(boundedResultMessage(change == null ? "change omitted" : change));
+		}
+		if (changes.size() > 20) safe.add("additional changes omitted");
+		return List.copyOf(safe);
+	}
+
 	private void addCapabilities(JsonObject body) {
 		JsonArray advertised = new JsonArray();
 		BASE_CAPABILITIES.stream().sorted().forEach(advertised::add);
@@ -1159,6 +1180,11 @@ public final class ControlConnector implements AutoCloseable {
 
 	private record TaskResult(boolean success, String code, String message, String revision,
 			JsonObject configuration, List<String> changes, boolean reloaded, boolean rolledBack) {
+		private TaskResult {
+			message = boundedResultMessage(message);
+			changes = boundedResultChanges(changes);
+		}
+
 		private JsonObject json() {
 			JsonObject body = new JsonObject();
 			body.addProperty("success", success);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -267,7 +267,7 @@ public final class ControlConnector implements AutoCloseable {
 	public boolean deferReplacementUntilSafe(Runnable replacement) {
 		Objects.requireNonNull(replacement, "replacement");
 		synchronized (operationLifecycle) {
-			if (inFlight.get() || !completedTasks.isEmpty()) {
+			if (inFlight.get() || hasLifecycleBlockingTasks()) {
 				deferredReplacement = replacement;
 				return true;
 			}
@@ -280,7 +280,7 @@ public final class ControlConnector implements AutoCloseable {
 	/** Reserves a quiescent connector for a full runtime replacement without losing a claimed result. */
 	public boolean reserveRuntimeReplacement() {
 		synchronized (operationLifecycle) {
-			if (inFlight.get() || !completedTasks.isEmpty()) return false;
+			if (inFlight.get() || hasLifecycleBlockingTasks()) return false;
 			closed = true;
 			status = Status.STOPPED;
 			return true;
@@ -373,7 +373,7 @@ public final class ControlConnector implements AutoCloseable {
 		Runnable replacement = null;
 		synchronized (operationLifecycle) {
 			inFlight.set(false);
-			if (completedTasks.isEmpty() && deferredReplacement != null) {
+			if (!hasLifecycleBlockingTasks() && deferredReplacement != null) {
 				replacement = deferredReplacement;
 				deferredReplacement = null;
 			}
@@ -603,10 +603,17 @@ public final class ControlConnector implements AutoCloseable {
 		boolean drained;
 		boolean replaceRuntime = requiresRuntimeReplacement(result) && runtimeReplacement != null;
 		synchronized (operationLifecycle) {
-			drained = completedTasks.isEmpty();
+			drained = !hasLifecycleBlockingTasks();
 			if (replaceRuntime) deferredReplacement = runtimeReplacement;
 		}
 		if (recovering && drained && recoveryComplete != null && !replaceRuntime) recoveryComplete.run();
+	}
+
+	/** Results rejected by this negotiated session remain durable but do not prevent its lifecycle from draining. */
+	private boolean hasLifecycleBlockingTasks() {
+		if (!registered) return !completedTasks.isEmpty();
+		return completedTasks.values().stream()
+				.anyMatch(pending -> !pending.committed() || capabilityAccepted(pending));
 	}
 
 	static boolean requiresRuntimeReplacement(StoredResult result) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ControlConnector.java
@@ -908,8 +908,8 @@ public final class ControlConnector implements AutoCloseable {
 				return completed(TaskResult.file(fileConfigurationService.read(fileName), List.of(), false, false));
 			}
 			String content = requireString(requested, "content");
-			ProxyConfigurationFileService.Preview preview = fileConfigurationService.preview(fileName, content);
 			if ("PREVIEW".equals(type)) {
+				ProxyConfigurationFileService.Preview preview = fileConfigurationService.preview(fileName, content);
 				ProxyConfigurationFileService.Document current = fileConfigurationService.read(fileName);
 				if (!preview.revision().equals(current.revision())) {
 					throw new ProxyConfigurationFileService.StaleRevisionException();
@@ -917,11 +917,13 @@ public final class ControlConnector implements AutoCloseable {
 				return completed(TaskResult.file(current, preview.changes(), false, false));
 			}
 			if (!"APPLY".equals(type)) return completed(TaskResult.failure("UNSUPPORTED_TASK", "Task type is unsupported"));
+			ProxyConfigurationFileService.PreparedApply prepared = fileConfigurationService.prepareApply(fileName, content,
+					requireString(task, "expectedRevision"));
+			ProxyConfigurationFileService.Preview preview = prepared.preview();
 			persistIntent(operationId, TaskResult.fileIntent(fileName,
 					ProxyConfigurationFileService.revision(preview.resolvedContent()), preview.changes()),
 					requireString(task, "attemptId"));
-			ProxyConfigurationFileService.ApplyResult applied = fileConfigurationService.apply(fileName, content,
-					requireString(task, "expectedRevision"));
+			ProxyConfigurationFileService.ApplyResult applied = fileConfigurationService.apply(prepared);
 			return completed(TaskResult.file(applied.document(), applied.changes(), false, applied.rolledBack(),
 					"Proxy configuration saved; restart the proxy to activate general settings"));
 		} catch (ProxyConfigurationFileService.StaleRevisionException failure) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -267,22 +267,58 @@ final class ProxyConfigurationFileService {
 			Object value = entry.getValue();
 			String childPath = path + entry.getKey();
 			if (secret(childPath, entry.getKey(), value)) result.put(entry.getKey(), REDACTED);
-			else if (value instanceof Map<?, ?> map) result.put(entry.getKey(), mask((Map<String, Object>) map, childPath + "."));
-			else result.put(entry.getKey(), value);
+			else result.put(entry.getKey(), maskStructure(value, childPath));
 		}
 		return result;
 	}
 
-	private static void redactValues(Node node, Map<String, Object> source, String path, Set<String> values) {
-		if (!(node instanceof MappingNode mapping)) {
+	@SuppressWarnings("unchecked")
+	private static Object maskStructure(Object value, String path) {
+		if (value instanceof Map<?, ?> map) return mask((Map<String, Object>) map, path + ".");
+		if (value instanceof List<?> list) {
+			List<Object> result = new ArrayList<>();
+			for (int index = 0; index < list.size(); index++) {
+				Object item = list.get(index);
+				String itemPath = path + "[" + index + "]";
+				result.add(secret(itemPath, "", item) ? REDACTED : maskStructure(item, itemPath));
+			}
+			return List.copyOf(result);
+		}
+		return value;
+	}
+
+	private static void redactValues(Node node, Object source, String path, Set<String> values) {
+		if (node instanceof SequenceNode sequence && source instanceof List<?> list) {
+			redactComments(sequence, path, false, values, new LinkedHashMap<>());
+			List<Node> children = new ArrayList<>();
+			for (int index = 0; index < sequence.getValue().size(); index++) {
+				Node child = sequence.getValue().get(index);
+				Object value = index < list.size() ? list.get(index) : null;
+				String itemPath = path + "[" + index + "]";
+				if (secret(itemPath, "", value)) {
+					redactComments(child, itemPath, true, values, new LinkedHashMap<>());
+					child = marker(child);
+				} else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+					redactValues(child, value, value instanceof Map<?, ?> ? itemPath + "." : itemPath, values);
+				} else {
+					redactDescendantComments(child, itemPath, false, values, new LinkedHashMap<>());
+				}
+				children.add(child);
+			}
+			sequence.getValue().clear();
+			sequence.getValue().addAll(children);
+			return;
+		}
+		if (!(node instanceof MappingNode mapping) || !(source instanceof Map<?, ?> rawSource)) {
 			redactDescendantComments(node, path, false, values, new LinkedHashMap<>());
 			return;
 		}
+		@SuppressWarnings("unchecked") Map<String, Object> sourceMap = (Map<String, Object>) rawSource;
 		redactComments(mapping, path, false, values, new LinkedHashMap<>());
 		List<NodeTuple> tuples = new ArrayList<>();
 		for (NodeTuple tuple : mapping.getValue()) {
 			String key = key(tuple.getKeyNode());
-			Object value = source.get(key);
+			Object value = sourceMap.get(key);
 			String childPath = path + key;
 			boolean hidden = secret(childPath, key, value);
 			redactComments(tuple.getKeyNode(), childPath + "#key", hidden, values, new LinkedHashMap<>());
@@ -290,9 +326,8 @@ final class ProxyConfigurationFileService {
 			if (hidden) {
 				redactComments(child, childPath, true, values, new LinkedHashMap<>());
 				child = marker(child);
-			} else if (value instanceof Map<?, ?> nested) {
-				@SuppressWarnings("unchecked") Map<String, Object> nestedValues = (Map<String, Object>) nested;
-				redactValues(child, nestedValues, childPath + ".", values);
+			} else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+				redactValues(child, value, value instanceof Map<?, ?> ? childPath + "." : childPath, values);
 			} else {
 				redactDescendantComments(child, childPath, false, values, new LinkedHashMap<>());
 			}
@@ -324,40 +359,124 @@ final class ProxyConfigurationFileService {
 				@SuppressWarnings("unchecked") Map<String, Object> oldValues = (Map<String, Object>) oldMap;
 				@SuppressWarnings("unchecked") Map<String, Object> candidateValues = (Map<String, Object>) proposedMap;
 				validateRedactedValues(oldValues, candidateValues, childPath + ".");
+			} else if (old instanceof List<?> oldList) {
+				if (!(candidate instanceof List<?> proposedList)) {
+					if (containsSecrets(oldList, childPath)) {
+						throw new IllegalArgumentException("redacted placeholder is invalid");
+					}
+					continue;
+				}
+				validateRedactedList(oldList, proposedList, childPath);
+			} else if (REDACTED.equals(candidate)) {
+				throw new IllegalArgumentException("redacted placeholder is invalid");
+			}
+		}
+		for (Map.Entry<String, Object> entry : proposed.entrySet()) {
+			if (!current.containsKey(entry.getKey()) && containsMarker(entry.getValue())) {
+				throw new IllegalArgumentException("redacted placeholder is invalid");
 			}
 		}
 	}
 
 	@SuppressWarnings("unchecked")
-	private static boolean containsSecrets(Map<?, ?> source, String path) {
-		for (Map.Entry<?, ?> entry : source.entrySet()) {
-			if (!(entry.getKey() instanceof String key)) return true;
-			Object value = entry.getValue();
-			String childPath = path + key;
-			if (secret(childPath, key, value)) return true;
-			if (value instanceof Map<?, ?> nested && containsSecrets(nested, childPath + ".")) return true;
+	private static void validateRedactedList(List<?> current, List<?> proposed, String path) {
+		if (containsSecrets(current, path) && current.size() != proposed.size()) {
+			throw new IllegalArgumentException("redacted placeholder is invalid");
+		}
+		for (int index = 0; index < Math.min(current.size(), proposed.size()); index++) {
+			Object old = current.get(index);
+			Object candidate = proposed.get(index);
+			String itemPath = path + "[" + index + "]";
+			if (secret(itemPath, "", old)) {
+				if (candidate instanceof Map<?, ?> || candidate instanceof List<?>) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+			} else if (old instanceof Map<?, ?> oldMap) {
+				if (!(candidate instanceof Map<?, ?> candidateMap)) {
+					if (containsSecrets(oldMap, itemPath + ".")) throw new IllegalArgumentException("redacted placeholder is invalid");
+				} else {
+					validateRedactedValues((Map<String, Object>) oldMap, (Map<String, Object>) candidateMap, itemPath + ".");
+				}
+			} else if (old instanceof List<?> oldList) {
+				if (!(candidate instanceof List<?> candidateList)) {
+					if (containsSecrets(oldList, itemPath)) throw new IllegalArgumentException("redacted placeholder is invalid");
+				} else validateRedactedList(oldList, candidateList, itemPath);
+			} else if (REDACTED.equals(candidate)) {
+				throw new IllegalArgumentException("redacted placeholder is invalid");
+			}
+		}
+		for (int index = current.size(); index < proposed.size(); index++) {
+			if (containsMarker(proposed.get(index))) throw new IllegalArgumentException("redacted placeholder is invalid");
+		}
+	}
+
+	private static boolean containsSecrets(Object source, String path) {
+		if (source instanceof Map<?, ?> map) {
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				if (!(entry.getKey() instanceof String key)) return true;
+				Object value = entry.getValue();
+				String childPath = path + key;
+				if (secret(childPath, key, value) || containsSecrets(value,
+						value instanceof Map<?, ?> ? childPath + "." : childPath)) return true;
+			}
+		} else if (source instanceof List<?> list) {
+			for (int index = 0; index < list.size(); index++) {
+				Object value = list.get(index);
+				String itemPath = path + "[" + index + "]";
+				if (secret(itemPath, "", value) || containsSecrets(value,
+						value instanceof Map<?, ?> ? itemPath + "." : itemPath)) return true;
+			}
 		}
 		return false;
 	}
 
-	private static void restoreRedactedValues(Node proposed, Node current, Map<String, Object> currentValues,
-			Map<String, Object> proposedValues, String path) {
-		if (!(proposed instanceof MappingNode proposedMap) || !(current instanceof MappingNode currentMap)) return;
+	private static boolean containsMarker(Object value) {
+		if (REDACTED.equals(value)) return true;
+		if (value instanceof Map<?, ?> map) return map.values().stream().anyMatch(ProxyConfigurationFileService::containsMarker);
+		if (value instanceof List<?> list) return list.stream().anyMatch(ProxyConfigurationFileService::containsMarker);
+		return false;
+	}
+
+	private static void restoreRedactedValues(Node proposed, Node current, Object currentValues,
+			Object proposedValues, String path) {
+		if (proposed instanceof SequenceNode proposedSequence && current instanceof SequenceNode currentSequence
+				&& currentValues instanceof List<?> oldList && proposedValues instanceof List<?> candidateList) {
+			List<Node> restored = new ArrayList<>();
+			for (int index = 0; index < proposedSequence.getValue().size(); index++) {
+				Node value = proposedSequence.getValue().get(index);
+				Object old = index < oldList.size() ? oldList.get(index) : null;
+				Object candidate = index < candidateList.size() ? candidateList.get(index) : null;
+				String itemPath = path + "[" + index + "]";
+				if (index < currentSequence.getValue().size() && secret(itemPath, "", old) && REDACTED.equals(candidate)) {
+					value = restoreSecretNode(currentSequence.getValue().get(index), value);
+				} else if (index < currentSequence.getValue().size()
+						&& (old instanceof Map<?, ?> || old instanceof List<?>)) {
+					restoreRedactedValues(value, currentSequence.getValue().get(index), old, candidate,
+							old instanceof Map<?, ?> ? itemPath + "." : itemPath);
+				}
+				restored.add(value);
+			}
+			proposedSequence.getValue().clear();
+			proposedSequence.getValue().addAll(restored);
+			return;
+		}
+		if (!(proposed instanceof MappingNode proposedMap) || !(current instanceof MappingNode currentMap)
+				|| !(currentValues instanceof Map<?, ?> rawCurrent) || !(proposedValues instanceof Map<?, ?> rawProposed)) return;
+		@SuppressWarnings("unchecked") Map<String, Object> currentMapValues = (Map<String, Object>) rawCurrent;
+		@SuppressWarnings("unchecked") Map<String, Object> proposedMapValues = (Map<String, Object>) rawProposed;
 		Map<String, NodeTuple> currentTuples = tuples(currentMap);
 		List<NodeTuple> restored = new ArrayList<>();
 		for (NodeTuple tuple : proposedMap.getValue()) {
 			String key = key(tuple.getKeyNode());
-			Object old = currentValues.get(key);
+			Object old = currentMapValues.get(key);
 			String childPath = path + key;
 			Node value = tuple.getValueNode();
 			if (currentTuples.containsKey(key) && secret(childPath, key, old)
-					&& REDACTED.equals(proposedValues.get(key))) {
+					&& REDACTED.equals(proposedMapValues.get(key))) {
 				value = restoreSecretNode(currentTuples.get(key).getValueNode(), value);
-			} else if (old instanceof Map<?, ?> oldMap && proposedValues.get(key) instanceof Map<?, ?> proposedMapValue) {
-				@SuppressWarnings("unchecked") Map<String, Object> oldValues = (Map<String, Object>) oldMap;
-				@SuppressWarnings("unchecked") Map<String, Object> candidateValues = (Map<String, Object>) proposedMapValue;
+			} else if ((old instanceof Map<?, ?> || old instanceof List<?>) && currentTuples.containsKey(key)) {
 				restoreRedactedValues(value, currentTuples.containsKey(key) ? currentTuples.get(key).getValueNode() : value,
-						oldValues, candidateValues, childPath + ".");
+						old, proposedMapValues.get(key), old instanceof Map<?, ?> ? childPath + "." : childPath);
 			}
 			restored.add(new NodeTuple(tuple.getKeyNode(), value));
 		}
@@ -381,22 +500,33 @@ final class ProxyConfigurationFileService {
 		return marker;
 	}
 
-	private static Map<String, CommentLine> redactComments(Node node, Map<String, Object> source, String path,
+	private static Map<String, CommentLine> redactComments(Node node, Object source, String path,
 			Set<String> values) {
 		Map<String, CommentLine> result = new LinkedHashMap<>();
 		redactComments(node, path, false, values, result);
-		if (node instanceof MappingNode mapping) {
+		if (node instanceof MappingNode mapping && source instanceof Map<?, ?> rawSource) {
+			@SuppressWarnings("unchecked") Map<String, Object> sourceMap = (Map<String, Object>) rawSource;
 			for (NodeTuple tuple : mapping.getValue()) {
 				String key = key(tuple.getKeyNode());
-				Object value = source.get(key);
+				Object value = sourceMap.get(key);
 				String childPath = path + key;
 				boolean hidden = secret(childPath, key, value);
 				redactComments(tuple.getKeyNode(), childPath + "#key", hidden, values, result);
 				if (hidden) redactComments(tuple.getValueNode(), childPath, true, values, result);
-				else if (value instanceof Map<?, ?> nested) {
-					@SuppressWarnings("unchecked") Map<String, Object> nestedValues = (Map<String, Object>) nested;
-					result.putAll(redactComments(tuple.getValueNode(), nestedValues, childPath + ".", values));
+				else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+					result.putAll(redactComments(tuple.getValueNode(), value,
+							value instanceof Map<?, ?> ? childPath + "." : childPath, values));
 				} else redactDescendantComments(tuple.getValueNode(), childPath, false, values, result);
+			}
+		} else if (node instanceof SequenceNode sequence && source instanceof List<?> list) {
+			for (int index = 0; index < sequence.getValue().size(); index++) {
+				Node child = sequence.getValue().get(index);
+				Object value = index < list.size() ? list.get(index) : null;
+				String itemPath = path + "[" + index + "]";
+				if (secret(itemPath, "", value)) redactComments(child, itemPath, true, values, result);
+				else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+					result.putAll(redactComments(child, value, value instanceof Map<?, ?> ? itemPath + "." : itemPath, values));
+				} else redactDescendantComments(child, itemPath, false, values, result);
 			}
 		}
 		return result;
@@ -409,11 +539,14 @@ final class ProxyConfigurationFileService {
 			for (NodeTuple tuple : mapping.getValue()) {
 				String key = key(tuple.getKeyNode());
 				redactDescendantComments(tuple.getKeyNode(), path + key + "#key", sensitiveContext, values, redacted);
-				redactDescendantComments(tuple.getValueNode(), path + key, sensitiveContext, values, redacted);
+				Node child = tuple.getValueNode();
+				redactDescendantComments(child, path + key + (child instanceof MappingNode ? "." : ""),
+						sensitiveContext, values, redacted);
 			}
 		} else if (node instanceof SequenceNode sequence) {
 			for (int index = 0; index < sequence.getValue().size(); index++) {
-				redactDescendantComments(sequence.getValue().get(index), path + "[" + index + "]", sensitiveContext,
+				Node child = sequence.getValue().get(index);
+				redactDescendantComments(child, path + "[" + index + "]" + (child instanceof MappingNode ? "." : ""), sensitiveContext,
 						values, redacted);
 			}
 		}
@@ -477,7 +610,8 @@ final class ProxyConfigurationFileService {
 			}
 		} else if (node instanceof SequenceNode sequence) {
 			for (int index = 0; index < sequence.getValue().size(); index++) {
-				collectComments(sequence.getValue().get(index), path + "[" + index + "]", result);
+				Node child = sequence.getValue().get(index);
+				collectComments(child, path + "[" + index + "]" + (child instanceof MappingNode ? "." : ""), result);
 			}
 		}
 	}
@@ -520,18 +654,30 @@ final class ProxyConfigurationFileService {
 		return values;
 	}
 
-	@SuppressWarnings("unchecked")
-	private static void collectSensitiveValues(Node node, Map<String, Object> source, String path, Set<String> values) {
-		if (!(node instanceof MappingNode mapping)) return;
-		for (NodeTuple tuple : mapping.getValue()) {
-			String key = key(tuple.getKeyNode());
-			Object value = source.get(key);
-			String childPath = path + key;
-			if (secret(childPath, key, value) && tuple.getValueNode() instanceof ScalarNode scalar
-					&& safeSecretValue(scalar.getValue())) {
-				values.add(scalar.getValue().trim());
-			} else if (value instanceof Map<?, ?> nested) {
-				collectSensitiveValues(tuple.getValueNode(), (Map<String, Object>) nested, childPath + ".", values);
+	private static void collectSensitiveValues(Node node, Object source, String path, Set<String> values) {
+		if (node instanceof MappingNode mapping && source instanceof Map<?, ?> sourceMap) {
+			for (NodeTuple tuple : mapping.getValue()) {
+				String key = key(tuple.getKeyNode());
+				Object value = sourceMap.get(key);
+				String childPath = path + key;
+				if (secret(childPath, key, value) && tuple.getValueNode() instanceof ScalarNode scalar
+						&& safeSecretValue(scalar.getValue())) {
+					values.add(scalar.getValue().trim());
+				} else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+					collectSensitiveValues(tuple.getValueNode(), value,
+							value instanceof Map<?, ?> ? childPath + "." : childPath, values);
+				}
+			}
+		} else if (node instanceof SequenceNode sequence && source instanceof List<?> list) {
+			for (int index = 0; index < sequence.getValue().size(); index++) {
+				Node child = sequence.getValue().get(index);
+				Object value = index < list.size() ? list.get(index) : null;
+				String itemPath = path + "[" + index + "]";
+				if (secret(itemPath, "", value) && child instanceof ScalarNode scalar && safeSecretValue(scalar.getValue())) {
+					values.add(scalar.getValue().trim());
+				} else if (value instanceof Map<?, ?> || value instanceof List<?>) {
+					collectSensitiveValues(child, value, value instanceof Map<?, ?> ? itemPath + "." : itemPath, values);
+				}
 			}
 		}
 	}
@@ -594,9 +740,44 @@ final class ProxyConfigurationFileService {
 				else if (old instanceof Map<?, ?> oldNested) oldValues = (Map<String, Object>) oldNested;
 				else throw new IllegalArgumentException("proxy configuration shape changed");
 				result.put(key, resolve((Map<String, Object>) nested, oldValues, childPath + "."));
+			} else if (value instanceof List<?> list) {
+				List<?> oldValues;
+				if (old == null) oldValues = List.of();
+				else if (old instanceof List<?> oldList) oldValues = oldList;
+				else throw new IllegalArgumentException("proxy configuration shape changed");
+				result.put(key, resolveList(list, oldValues, childPath));
 			} else result.put(key, value);
 		}
 		return result;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<Object> resolveList(List<?> proposed, List<?> current, String path) {
+		List<Object> result = new ArrayList<>();
+		for (int index = 0; index < proposed.size(); index++) {
+			Object value = proposed.get(index);
+			Object old = index < current.size() ? current.get(index) : null;
+			String itemPath = path + "[" + index + "]";
+			if (REDACTED.equals(value)) {
+				if (index >= current.size() || !secret(itemPath, "", old)) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+				result.add(old);
+			} else if (value instanceof Map<?, ?> map) {
+				Map<String, Object> oldValues;
+				if (old == null) oldValues = Map.of();
+				else if (old instanceof Map<?, ?> oldMap) oldValues = (Map<String, Object>) oldMap;
+				else throw new IllegalArgumentException("proxy configuration shape changed");
+				result.add(resolve((Map<String, Object>) map, oldValues, itemPath + "."));
+			} else if (value instanceof List<?> list) {
+				List<?> oldValues;
+				if (old == null) oldValues = List.of();
+				else if (old instanceof List<?> oldList) oldValues = oldList;
+				else throw new IllegalArgumentException("proxy configuration shape changed");
+				result.add(resolveList(list, oldValues, itemPath));
+			} else result.add(value);
+		}
+		return List.copyOf(result);
 	}
 
 	private static boolean secret(String path, String key, Object value) {
@@ -605,8 +786,11 @@ final class ProxyConfigurationFileService {
 				|| normalized.contains("apikey") || normalized.contains("authorization")
 				|| normalized.contains("webhookurl")) return true;
 		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
-		if (normalizedPath.startsWith("database.") || normalizedPath.startsWith("globaldata.")) {
-			return Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname")
+		if (infrastructurePath(normalizedPath, "database") || infrastructurePath(normalizedPath, "globaldata")
+				|| infrastructurePath(normalizedPath, "redis")
+				|| infrastructurePath(normalizedPath, "multiproxyredis")) {
+			return Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname",
+					"prefix", "dbindex")
 					.contains(normalized);
 		}
 		if (normalizedPath.startsWith("control.")) {
@@ -617,6 +801,10 @@ final class ProxyConfigurationFileService {
 			return lowered.startsWith("jdbc:") || lowered.matches("^[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*");
 		}
 		return false;
+	}
+
+	private static boolean infrastructurePath(String normalizedPath, String section) {
+		return normalizedPath.startsWith(section + ".") || normalizedPath.contains("." + section + ".");
 	}
 
 	private static void copyPermissions(Path source, Path destination) throws IOException {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -17,8 +17,10 @@ import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HexFormat;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -30,6 +32,8 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.comments.CommentLine;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.error.YAMLException;
+import org.yaml.snakeyaml.nodes.AnchorNode;
 import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.NodeTuple;
@@ -177,10 +181,8 @@ final class ProxyConfigurationFileService {
 	@SuppressWarnings("unchecked")
 	private static Map<String, Object> parse(String yaml) {
 		ensureBounded(yaml);
-		if (yaml.matches("(?s).*(?:^|[\\s\\[{,])(?:[&*][A-Za-z0-9_-]+|<<\\s*:).*")) {
-			throw new IllegalArgumentException("proxy configuration aliases are not supported");
-		}
 		LoaderOptions loaderOptions = loaderOptions();
+		rejectAliases(yaml, loaderOptions);
 		SafeConstructor constructor = new SafeConstructor(loaderOptions);
 		Object parsed;
 		try { parsed = new Yaml(constructor).load(yaml); }
@@ -192,6 +194,34 @@ final class ProxyConfigurationFileService {
 			result.put(key, normalize(entry.getValue(), 1));
 		}
 		return result;
+	}
+
+	private static void rejectAliases(String yaml, LoaderOptions loaderOptions) {
+		Node root;
+		try {
+			root = new Yaml(loaderOptions).compose(new StringReader(yaml));
+		} catch (YAMLException failure) {
+			throw new IllegalArgumentException("proxy configuration YAML is invalid");
+		}
+		rejectAliases(root, Collections.newSetFromMap(new IdentityHashMap<>()));
+	}
+
+	private static void rejectAliases(Node node, Set<Node> visited) {
+		if (node == null || !visited.add(node)) return;
+		if (node instanceof AnchorNode || node.getAnchor() != null) {
+			throw new IllegalArgumentException("proxy configuration aliases are not supported");
+		}
+		if (node instanceof MappingNode mapping) {
+			for (NodeTuple tuple : mapping.getValue()) {
+				if (Tag.MERGE.equals(tuple.getKeyNode().getTag())) {
+					throw new IllegalArgumentException("proxy configuration aliases are not supported");
+				}
+				rejectAliases(tuple.getKeyNode(), visited);
+				rejectAliases(tuple.getValueNode(), visited);
+			}
+		} else if (node instanceof SequenceNode sequence) {
+			sequence.getValue().forEach(child -> rejectAliases(child, visited));
+		}
 	}
 
 	private static Object normalize(Object value, int depth) {
@@ -796,9 +826,12 @@ final class ProxyConfigurationFileService {
 		if (infrastructurePath(normalizedPath, "mqtt")) {
 			return Set.of("clientid", "brokerurl", "username", "password", "prefix").contains(normalized);
 		}
-		if (infrastructurePath(normalizedPath, "multiproxysockethost")
+		if (infrastructurePath(normalizedPath, "bungeeserver")
+				|| infrastructurePath(normalizedPath, "spigotservers")
+				|| infrastructurePath(normalizedPath, "multiproxysockethost")
 				|| infrastructurePath(normalizedPath, "multiproxyservers")) {
-			return Set.of("host", "port").contains(normalized);
+			return !(value instanceof Map<?, ?>) && !(value instanceof List<?>)
+					&& Set.of("host", "port").contains(normalized);
 		}
 		if (infrastructurePath(normalizedPath, "control")) {
 			return normalized.endsWith("file") || normalized.endsWith("directory")

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -1,0 +1,692 @@
+package com.bencodez.votingplugin.proxy.control;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.comments.CommentLine;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import com.bencodez.votingplugin.proxy.VotingPluginProxy;
+import com.bencodez.votingplugin.util.DurableFiles;
+
+/** Strict, revisioned access to the proxy's single bungeeconfig.yml file. */
+final class ProxyConfigurationFileService {
+	static final String FILE_NAME = "bungeeconfig.yml";
+	static final String REDACTED = "__VOTINGPLUGIN_CONTROL_REDACTED__";
+	static final int MAX_BYTES = 512 * 1024;
+	private static final String REDACTED_COMMENT = " " + REDACTED;
+	private final Path target;
+	private final MoveAction mover;
+	private final TempFileAction tempFiles;
+
+	ProxyConfigurationFileService(VotingPluginProxy proxy) {
+		this(proxy.getDataFolderPlugin().toPath().toAbsolutePath().normalize().resolve(FILE_NAME),
+				ProxyConfigurationFileService::move, Files::createTempFile);
+	}
+
+	ProxyConfigurationFileService(Path target, MoveAction mover) {
+		this(target, mover, Files::createTempFile);
+	}
+
+	ProxyConfigurationFileService(Path target, MoveAction mover, TempFileAction tempFiles) {
+		this.target = target.toAbsolutePath().normalize();
+		this.mover = java.util.Objects.requireNonNull(mover, "mover");
+		this.tempFiles = java.util.Objects.requireNonNull(tempFiles, "tempFiles");
+	}
+
+	Document read(String fileName) throws IOException {
+		requireFile(fileName);
+		String raw = readRaw();
+		Map<String, Object> parsed = parse(raw);
+		return new Document(FILE_NAME, renderMasked(raw, parsed), revision(raw));
+	}
+
+	Preview preview(String fileName, String proposed) throws IOException {
+		requireFile(fileName);
+		String currentRaw = readRaw();
+		Map<String, Object> current = parse(currentRaw);
+		Map<String, Object> proposedValues = parse(proposed);
+		Map<String, Object> resolved = resolve(proposedValues, current, "");
+		validateRedactedValues(current, proposedValues, "");
+		Node currentTree = compose(currentRaw);
+		Node currentValuesTree = compose(currentRaw);
+		Map<String, CommentLine> redactedComments = redactComments(currentTree, current, "",
+				sensitiveValues(currentTree, current));
+		Node proposedTree = compose(proposed);
+		restoreRedactedComments(proposedTree, redactedComments);
+		restoreRedactedValues(proposedTree, currentValuesTree, current, proposedValues, "");
+		String content = serialize(proposedTree);
+		ensureBounded(content);
+		if (!resolved.equals(parse(content))) throw new IllegalArgumentException("proxy configuration content is invalid");
+		return new Preview(content, revision(currentRaw), changes(current, resolved));
+	}
+
+	ApplyResult apply(String fileName, String proposed, String expectedRevision) throws IOException {
+		requireFile(fileName);
+		String currentRaw = readRaw();
+		if (expectedRevision == null || !revision(currentRaw).equals(expectedRevision)) throw new StaleRevisionException();
+		Preview preview = preview(fileName, proposed);
+		Path backup = target.resolveSibling(FILE_NAME + ".control-backup");
+		Path stage = null;
+		Path backupStage = null;
+		boolean installed = false;
+		try {
+			stage = tempFiles.create(target.getParent(), ".control-proxy-", ".yml");
+			backupStage = tempFiles.create(target.getParent(), ".control-proxy-backup-", ".yml");
+			Files.writeString(stage, preview.resolvedContent, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING);
+			copyPermissions(target, stage);
+			parse(readStrict(stage));
+			if (Files.isSymbolicLink(backup)) throw new IOException("unsafe proxy configuration backup");
+			Files.writeString(backupStage, currentRaw, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING);
+			copyPermissions(target, backupStage);
+			if (!revision(readRaw()).equals(expectedRevision)) throw new StaleRevisionException();
+			mover.move(backupStage, backup);
+			if (!revision(readRaw()).equals(expectedRevision)) throw new StaleRevisionException();
+			try {
+				mover.move(stage, target);
+				installed = true;
+			} catch (DurableFiles.PublishedException published) {
+				installed = true;
+				throw published;
+			}
+			String applied = readRaw();
+			if (!revision(applied).equals(revision(preview.resolvedContent))) throw new StaleRevisionException();
+			return new ApplyResult(new Document(FILE_NAME, renderMasked(applied, parse(applied)), revision(applied)),
+					preview.changes, false);
+		} catch (StaleRevisionException stale) {
+			throw stale;
+		} catch (Exception failure) {
+			boolean rolledBack = false;
+			if (installed) {
+				try {
+					if (!revision(readRaw()).equals(revision(preview.resolvedContent))) {
+						throw new IOException("proxy configuration changed during rollback");
+					}
+					if (!Files.isRegularFile(backup, LinkOption.NOFOLLOW_LINKS)) {
+						throw new IOException("proxy configuration backup is unavailable");
+					}
+					Path rollback = tempFiles.create(target.getParent(), ".control-proxy-rollback-", ".yml");
+					try {
+						try (SeekableByteChannel source = Files.newByteChannel(backup,
+								Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS))) {
+							Files.copy(Channels.newInputStream(source), rollback, StandardCopyOption.REPLACE_EXISTING);
+						}
+						copyPermissions(backup, rollback);
+						mover.move(rollback, target);
+					} finally { Files.deleteIfExists(rollback); }
+					rolledBack = true;
+				} catch (Exception rollbackFailure) { failure.addSuppressed(rollbackFailure); }
+			}
+			throw new ApplyFailureException(rolledBack, failure);
+		} finally {
+			if (stage != null) Files.deleteIfExists(stage);
+			if (backupStage != null) Files.deleteIfExists(backupStage);
+		}
+	}
+
+	private String readRaw() throws IOException {
+		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS)) throw new IOException("proxy configuration is unavailable");
+		return readStrict(target);
+	}
+
+	private static String readStrict(Path path) throws IOException {
+		long size = Files.size(path);
+		if (size < 0 || size > MAX_BYTES) throw new IOException("proxy configuration exceeds limits");
+		byte[] bytes;
+		try (InputStream input = Files.newInputStream(path, LinkOption.NOFOLLOW_LINKS)) {
+			bytes = input.readNBytes(MAX_BYTES + 1);
+		}
+		if (bytes.length > MAX_BYTES) throw new IOException("proxy configuration exceeds limits");
+		try {
+			return StandardCharsets.UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT)
+					.onUnmappableCharacter(CodingErrorAction.REPORT).decode(java.nio.ByteBuffer.wrap(bytes)).toString();
+		} catch (CharacterCodingException failure) { throw new IOException("proxy configuration is not UTF-8", failure); }
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> parse(String yaml) {
+		ensureBounded(yaml);
+		if (yaml.matches("(?s).*(?:^|[\\s\\[{,])(?:[&*][A-Za-z0-9_-]+|<<\\s*:).*")) {
+			throw new IllegalArgumentException("proxy configuration aliases are not supported");
+		}
+		LoaderOptions loaderOptions = loaderOptions();
+		SafeConstructor constructor = new SafeConstructor(loaderOptions);
+		Object parsed;
+		try { parsed = new Yaml(constructor).load(yaml); }
+		catch (RuntimeException failure) { throw new IllegalArgumentException("proxy configuration YAML is invalid"); }
+		if (!(parsed instanceof Map<?, ?> root)) throw new IllegalArgumentException("proxy configuration must be a mapping");
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Map.Entry<?, ?> entry : root.entrySet()) {
+			if (!(entry.getKey() instanceof String key)) throw new IllegalArgumentException("proxy configuration keys must be strings");
+			result.put(key, normalize(entry.getValue(), 1));
+		}
+		return result;
+	}
+
+	private static Object normalize(Object value, int depth) {
+		if (depth > 50) throw new IllegalArgumentException("proxy configuration is too deeply nested");
+		if (value == null || value instanceof String || value instanceof Boolean || value instanceof Number) return value;
+		if (value instanceof Map<?, ?> map) {
+			Map<String, Object> result = new LinkedHashMap<>();
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				if (!(entry.getKey() instanceof String key)) throw new IllegalArgumentException("proxy configuration keys must be strings");
+				result.put(key, normalize(entry.getValue(), depth + 1));
+			}
+			return result;
+		}
+		if (value instanceof List<?> list) return list.stream().map(item -> normalize(item, depth + 1)).toList();
+		throw new IllegalArgumentException("proxy configuration contains an unsupported YAML value");
+	}
+
+	private static String renderMasked(String raw, Map<String, Object> parsed) {
+		Node tree = compose(raw);
+		redactValues(tree, parsed, "", sensitiveValues(tree, parsed));
+		String content = serialize(tree);
+		ensureBounded(content);
+		if (!mask(parsed).equals(parse(content))) throw new IllegalArgumentException("proxy configuration content is invalid");
+		return content;
+	}
+
+	private static Node compose(String yaml) {
+		// Construct first so comment parsing cannot bypass the strict SafeConstructor checks.
+		parse(yaml);
+		LoaderOptions options = loaderOptions();
+		options.setProcessComments(true);
+		try {
+			Node node = new Yaml(options, dumperOptions()).compose(new StringReader(yaml));
+			if (!(node instanceof MappingNode)) throw new IllegalArgumentException("proxy configuration must be a mapping");
+			return node;
+		} catch (RuntimeException failure) {
+			throw new IllegalArgumentException("proxy configuration YAML is invalid");
+		}
+	}
+
+	private static String serialize(Node node) {
+		StringWriter writer = new StringWriter();
+		new Yaml(dumperOptions()).serialize(node, writer);
+		return writer.toString();
+	}
+
+	private static LoaderOptions loaderOptions() {
+		LoaderOptions loaderOptions = new LoaderOptions();
+		loaderOptions.setAllowDuplicateKeys(false);
+		loaderOptions.setMaxAliasesForCollections(0);
+		loaderOptions.setNestingDepthLimit(50);
+		loaderOptions.setCodePointLimit(MAX_BYTES);
+		return loaderOptions;
+	}
+
+	private static DumperOptions dumperOptions() {
+		DumperOptions options = new DumperOptions();
+		options.setIndent(2);
+		options.setPrettyFlow(true);
+		options.setProcessComments(true);
+		return options;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> mask(Map<String, Object> source) {
+		return mask(source, "");
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> mask(Map<String, Object> source, String path) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : source.entrySet()) {
+			Object value = entry.getValue();
+			String childPath = path + entry.getKey();
+			if (secret(childPath, entry.getKey(), value)) result.put(entry.getKey(), REDACTED);
+			else if (value instanceof Map<?, ?> map) result.put(entry.getKey(), mask((Map<String, Object>) map, childPath + "."));
+			else result.put(entry.getKey(), value);
+		}
+		return result;
+	}
+
+	private static void redactValues(Node node, Map<String, Object> source, String path, Set<String> values) {
+		if (!(node instanceof MappingNode mapping)) {
+			redactDescendantComments(node, path, false, values, new LinkedHashMap<>());
+			return;
+		}
+		redactComments(mapping, path, false, values, new LinkedHashMap<>());
+		List<NodeTuple> tuples = new ArrayList<>();
+		for (NodeTuple tuple : mapping.getValue()) {
+			String key = key(tuple.getKeyNode());
+			Object value = source.get(key);
+			String childPath = path + key;
+			boolean hidden = secret(childPath, key, value);
+			redactComments(tuple.getKeyNode(), childPath + "#key", hidden, values, new LinkedHashMap<>());
+			Node child = tuple.getValueNode();
+			if (hidden) {
+				redactComments(child, childPath, true, values, new LinkedHashMap<>());
+				child = marker(child);
+			} else if (value instanceof Map<?, ?> nested) {
+				@SuppressWarnings("unchecked") Map<String, Object> nestedValues = (Map<String, Object>) nested;
+				redactValues(child, nestedValues, childPath + ".", values);
+			} else {
+				redactDescendantComments(child, childPath, false, values, new LinkedHashMap<>());
+			}
+			tuples.add(new NodeTuple(tuple.getKeyNode(), child));
+		}
+		mapping.setValue(tuples);
+	}
+
+	private static void validateRedactedValues(Map<String, Object> current, Map<String, Object> proposed, String path) {
+		for (Map.Entry<String, Object> entry : current.entrySet()) {
+			String key = entry.getKey();
+			Object old = entry.getValue();
+			String childPath = path + key;
+			if (secret(childPath, key, old)) {
+				if (!proposed.containsKey(key) || proposed.get(key) instanceof Map<?, ?>
+						|| proposed.get(key) instanceof List<?>) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+				continue;
+			}
+			Object candidate = proposed.get(key);
+			if (old instanceof Map<?, ?> oldMap) {
+				if (!(candidate instanceof Map<?, ?> proposedMap)) {
+					if (containsSecrets(oldMap, childPath + ".")) {
+						throw new IllegalArgumentException("redacted placeholder is invalid");
+					}
+					continue;
+				}
+				@SuppressWarnings("unchecked") Map<String, Object> oldValues = (Map<String, Object>) oldMap;
+				@SuppressWarnings("unchecked") Map<String, Object> candidateValues = (Map<String, Object>) proposedMap;
+				validateRedactedValues(oldValues, candidateValues, childPath + ".");
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static boolean containsSecrets(Map<?, ?> source, String path) {
+		for (Map.Entry<?, ?> entry : source.entrySet()) {
+			if (!(entry.getKey() instanceof String key)) return true;
+			Object value = entry.getValue();
+			String childPath = path + key;
+			if (secret(childPath, key, value)) return true;
+			if (value instanceof Map<?, ?> nested && containsSecrets(nested, childPath + ".")) return true;
+		}
+		return false;
+	}
+
+	private static void restoreRedactedValues(Node proposed, Node current, Map<String, Object> currentValues,
+			Map<String, Object> proposedValues, String path) {
+		if (!(proposed instanceof MappingNode proposedMap) || !(current instanceof MappingNode currentMap)) return;
+		Map<String, NodeTuple> currentTuples = tuples(currentMap);
+		List<NodeTuple> restored = new ArrayList<>();
+		for (NodeTuple tuple : proposedMap.getValue()) {
+			String key = key(tuple.getKeyNode());
+			Object old = currentValues.get(key);
+			String childPath = path + key;
+			Node value = tuple.getValueNode();
+			if (currentTuples.containsKey(key) && secret(childPath, key, old)
+					&& REDACTED.equals(proposedValues.get(key))) {
+				value = restoreSecretNode(currentTuples.get(key).getValueNode(), value);
+			} else if (old instanceof Map<?, ?> oldMap && proposedValues.get(key) instanceof Map<?, ?> proposedMapValue) {
+				@SuppressWarnings("unchecked") Map<String, Object> oldValues = (Map<String, Object>) oldMap;
+				@SuppressWarnings("unchecked") Map<String, Object> candidateValues = (Map<String, Object>) proposedMapValue;
+				restoreRedactedValues(value, currentTuples.containsKey(key) ? currentTuples.get(key).getValueNode() : value,
+						oldValues, candidateValues, childPath + ".");
+			}
+			restored.add(new NodeTuple(tuple.getKeyNode(), value));
+		}
+		proposedMap.setValue(restored);
+	}
+
+	private static Node restoreSecretNode(Node current, Node proposed) {
+		if (current instanceof ScalarNode oldScalar && proposed instanceof ScalarNode proposedScalar) {
+			ScalarNode restored = new ScalarNode(oldScalar.getTag(), oldScalar.getValue(), proposedScalar.getStartMark(),
+					proposedScalar.getEndMark(), oldScalar.getScalarStyle());
+			copyComments(proposedScalar, restored);
+			return restored;
+		}
+		return current;
+	}
+
+	private static Node marker(Node source) {
+		ScalarNode marker = new ScalarNode(Tag.STR, REDACTED, source.getStartMark(), source.getEndMark(),
+				DumperOptions.ScalarStyle.PLAIN);
+		copyComments(source, marker);
+		return marker;
+	}
+
+	private static Map<String, CommentLine> redactComments(Node node, Map<String, Object> source, String path,
+			Set<String> values) {
+		Map<String, CommentLine> result = new LinkedHashMap<>();
+		redactComments(node, path, false, values, result);
+		if (node instanceof MappingNode mapping) {
+			for (NodeTuple tuple : mapping.getValue()) {
+				String key = key(tuple.getKeyNode());
+				Object value = source.get(key);
+				String childPath = path + key;
+				boolean hidden = secret(childPath, key, value);
+				redactComments(tuple.getKeyNode(), childPath + "#key", hidden, values, result);
+				if (hidden) redactComments(tuple.getValueNode(), childPath, true, values, result);
+				else if (value instanceof Map<?, ?> nested) {
+					@SuppressWarnings("unchecked") Map<String, Object> nestedValues = (Map<String, Object>) nested;
+					result.putAll(redactComments(tuple.getValueNode(), nestedValues, childPath + ".", values));
+				} else redactDescendantComments(tuple.getValueNode(), childPath, false, values, result);
+			}
+		}
+		return result;
+	}
+
+	private static void redactDescendantComments(Node node, String path, boolean sensitiveContext, Set<String> values,
+			Map<String, CommentLine> redacted) {
+		redactComments(node, path, sensitiveContext, values, redacted);
+		if (node instanceof MappingNode mapping) {
+			for (NodeTuple tuple : mapping.getValue()) {
+				String key = key(tuple.getKeyNode());
+				redactDescendantComments(tuple.getKeyNode(), path + key + "#key", sensitiveContext, values, redacted);
+				redactDescendantComments(tuple.getValueNode(), path + key, sensitiveContext, values, redacted);
+			}
+		} else if (node instanceof SequenceNode sequence) {
+			for (int index = 0; index < sequence.getValue().size(); index++) {
+				redactDescendantComments(sequence.getValue().get(index), path + "[" + index + "]", sensitiveContext,
+						values, redacted);
+			}
+		}
+	}
+
+	private static void redactComments(Node node, String path, boolean sensitiveContext, Set<String> values,
+			Map<String, CommentLine> redacted) {
+		redactCommentList(node, path, "block", node.getBlockComments(), sensitiveContext, values, redacted);
+		redactCommentList(node, path, "inline", node.getInLineComments(), sensitiveContext, values, redacted);
+		redactCommentList(node, path, "end", node.getEndComments(), sensitiveContext, values, redacted);
+	}
+
+	private static void redactCommentList(Node node, String path, String kind, List<CommentLine> comments,
+			boolean sensitiveContext, Set<String> values, Map<String, CommentLine> redacted) {
+		if (comments == null) return;
+		List<CommentLine> replacement = new ArrayList<>(comments);
+		for (int index = 0; index < replacement.size(); index++) {
+			CommentLine line = replacement.get(index);
+			if (!sensitiveComment(line.getValue(), sensitiveContext, values)) continue;
+			String slot = commentSlot(path, kind, index);
+			redacted.put(slot, line);
+			replacement.set(index, new CommentLine(line.getStartMark(), line.getEndMark(), REDACTED_COMMENT,
+					line.getCommentType()));
+		}
+		setComments(node, kind, replacement);
+	}
+
+	private static void restoreRedactedComments(Node proposed, Map<String, CommentLine> expected) {
+		Map<String, CommentReference> comments = commentReferences(proposed, "");
+		for (Map.Entry<String, CommentLine> entry : expected.entrySet()) {
+			CommentReference reference = comments.get(entry.getKey());
+			if (reference == null || !REDACTED_COMMENT.equals(reference.line().getValue())) {
+				throw new IllegalArgumentException("redacted placeholder is invalid");
+			}
+			reference.replace(entry.getValue());
+		}
+		for (Map.Entry<String, CommentReference> entry : comments.entrySet()) {
+			if (REDACTED_COMMENT.equals(entry.getValue().line().getValue()) && !expected.containsKey(entry.getKey())) {
+				throw new IllegalArgumentException("redacted placeholder is invalid");
+			}
+		}
+	}
+
+	private static Map<String, CommentReference> commentReferences(Node root, String path) {
+		Map<String, CommentReference> result = new LinkedHashMap<>();
+		collectComments(root, path, result);
+		return result;
+	}
+
+	private static void collectComments(Node node, String path, Map<String, CommentReference> result) {
+		collectCommentReferences(node, path, "block", node.getBlockComments(), result);
+		collectCommentReferences(node, path, "inline", node.getInLineComments(), result);
+		collectCommentReferences(node, path, "end", node.getEndComments(), result);
+		if (node instanceof MappingNode mapping) {
+			for (NodeTuple tuple : mapping.getValue()) {
+				String key = key(tuple.getKeyNode());
+				String childPath = path + key;
+				collectComments(tuple.getKeyNode(), childPath + "#key", result);
+				collectComments(tuple.getValueNode(), tuple.getValueNode() instanceof MappingNode ? childPath + "." : childPath,
+						result);
+			}
+		} else if (node instanceof SequenceNode sequence) {
+			for (int index = 0; index < sequence.getValue().size(); index++) {
+				collectComments(sequence.getValue().get(index), path + "[" + index + "]", result);
+			}
+		}
+	}
+
+	private static void collectCommentReferences(Node node, String path, String kind, List<CommentLine> comments,
+			Map<String, CommentReference> result) {
+		if (comments == null) return;
+		for (int index = 0; index < comments.size(); index++) {
+			result.put(commentSlot(path, kind, index), new CommentReference(node, kind, index, comments.get(index)));
+		}
+	}
+
+	private static void setComments(Node node, String kind, List<CommentLine> comments) {
+		switch (kind) {
+		case "block" -> node.setBlockComments(comments);
+		case "inline" -> node.setInLineComments(comments);
+		case "end" -> node.setEndComments(comments);
+		default -> throw new IllegalArgumentException("invalid comment kind");
+		}
+	}
+
+	private static String commentSlot(String path, String kind, int index) {
+		return path + "|" + kind + "|" + index;
+	}
+
+	private static boolean sensitiveComment(String comment, boolean sensitiveContext, Set<String> values) {
+		if (sensitiveContext) return true;
+		String lowered = comment.toLowerCase(Locale.ROOT);
+		if (lowered.matches("(?s).*\\b(password|secret|token|api[ _-]?key|authorization|jdbc|webhook)\\b.*")
+				|| lowered.matches("(?s).*[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*")) return true;
+		for (String value : values) {
+			if (lowered.contains(value.toLowerCase(Locale.ROOT))) return true;
+		}
+		return false;
+	}
+
+	private static Set<String> sensitiveValues(Node node, Map<String, Object> source) {
+		Set<String> values = new java.util.LinkedHashSet<>();
+		collectSensitiveValues(node, source, "", values);
+		return values;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static void collectSensitiveValues(Node node, Map<String, Object> source, String path, Set<String> values) {
+		if (!(node instanceof MappingNode mapping)) return;
+		for (NodeTuple tuple : mapping.getValue()) {
+			String key = key(tuple.getKeyNode());
+			Object value = source.get(key);
+			String childPath = path + key;
+			if (secret(childPath, key, value) && tuple.getValueNode() instanceof ScalarNode scalar
+					&& safeSecretValue(scalar.getValue())) {
+				values.add(scalar.getValue().trim());
+			} else if (value instanceof Map<?, ?> nested) {
+				collectSensitiveValues(tuple.getValueNode(), (Map<String, Object>) nested, childPath + ".", values);
+			}
+		}
+	}
+
+	private static boolean safeSecretValue(Object value) {
+		if (value == null) return false;
+		String text = String.valueOf(value).trim();
+		return !text.isEmpty();
+	}
+
+	private static Map<String, NodeTuple> tuples(MappingNode node) {
+		Map<String, NodeTuple> result = new LinkedHashMap<>();
+		for (NodeTuple tuple : node.getValue()) result.put(key(tuple.getKeyNode()), tuple);
+		return result;
+	}
+
+	private static String key(Node node) {
+		if (!(node instanceof ScalarNode scalar)) throw new IllegalArgumentException("proxy configuration keys must be strings");
+		return scalar.getValue();
+	}
+
+	private static void copyComments(Node source, Node target) {
+		target.setBlockComments(copyCommentList(source.getBlockComments()));
+		target.setInLineComments(copyCommentList(source.getInLineComments()));
+		target.setEndComments(copyCommentList(source.getEndComments()));
+	}
+
+	private static List<CommentLine> copyCommentList(List<CommentLine> comments) {
+		return comments == null ? null : new ArrayList<>(comments);
+	}
+
+	private record CommentReference(Node node, String kind, int index, CommentLine line) {
+		void replace(CommentLine replacement) {
+			List<CommentLine> comments = switch (kind) {
+			case "block" -> node.getBlockComments();
+			case "inline" -> node.getInLineComments();
+			case "end" -> node.getEndComments();
+			default -> throw new IllegalArgumentException("invalid comment kind");
+			};
+			List<CommentLine> updated = new ArrayList<>(comments);
+			updated.set(index, replacement);
+			setComments(node, kind, updated);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, Object> resolve(Map<String, Object> proposed, Map<String, Object> current, String path) {
+		Map<String, Object> result = new LinkedHashMap<>();
+		for (Map.Entry<String, Object> entry : proposed.entrySet()) {
+			String key = entry.getKey();
+			Object value = entry.getValue();
+			Object old = current.get(key);
+			String childPath = path + key;
+			if (REDACTED.equals(value)) {
+				if (!secret(childPath, key, old) || !current.containsKey(key)) throw new IllegalArgumentException("redacted placeholder is invalid");
+				result.put(key, old);
+			} else if (value instanceof Map<?, ?> nested) {
+				Map<String, Object> oldValues;
+				if (old == null) oldValues = Map.of();
+				else if (old instanceof Map<?, ?> oldNested) oldValues = (Map<String, Object>) oldNested;
+				else throw new IllegalArgumentException("proxy configuration shape changed");
+				result.put(key, resolve((Map<String, Object>) nested, oldValues, childPath + "."));
+			} else result.put(key, value);
+		}
+		return result;
+	}
+
+	private static boolean secret(String path, String key, Object value) {
+		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+		if (normalized.contains("password") || normalized.contains("secret") || normalized.equals("token")
+				|| normalized.contains("apikey") || normalized.contains("authorization")
+				|| normalized.contains("webhookurl")) return true;
+		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+		if (normalizedPath.startsWith("database.") || normalizedPath.startsWith("globaldata.")) {
+			return Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname")
+					.contains(normalized);
+		}
+		if (normalizedPath.startsWith("control.")) {
+			return normalized.endsWith("file") || normalized.endsWith("directory");
+		}
+		if (value instanceof String text) {
+			String lowered = text.trim().toLowerCase(Locale.ROOT);
+			return lowered.startsWith("jdbc:") || lowered.matches("^[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*");
+		}
+		return false;
+	}
+
+	private static void copyPermissions(Path source, Path destination) throws IOException {
+		java.nio.file.attribute.PosixFileAttributeView sourceView = Files.getFileAttributeView(source,
+				java.nio.file.attribute.PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+		java.nio.file.attribute.PosixFileAttributeView destinationView = Files.getFileAttributeView(destination,
+				java.nio.file.attribute.PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+		if (sourceView != null && destinationView != null) {
+			destinationView.setPermissions(sourceView.readAttributes().permissions());
+		}
+	}
+
+	private static List<String> changes(Map<String, Object> before, Map<String, Object> after) {
+		Map<String, String> left = flatten(before, "");
+		Map<String, String> right = flatten(after, "");
+		Set<String> keys = new java.util.TreeSet<>(); keys.addAll(left.keySet()); keys.addAll(right.keySet());
+		List<String> result = new ArrayList<>();
+		for (String key : keys) {
+			if (java.util.Objects.equals(left.get(key), right.get(key))) continue;
+			result.add((left.containsKey(key) ? right.containsKey(key) ? "changed " : "removed " : "added ") + key);
+			if (result.size() == 20) break;
+		}
+		return List.copyOf(result);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, String> flatten(Map<String, Object> source, String prefix) {
+		Map<String, String> result = new LinkedHashMap<>();
+		source.entrySet().stream().sorted(Map.Entry.comparingByKey(Comparator.naturalOrder())).forEach(entry -> {
+			String path = prefix + entry.getKey();
+			if (entry.getValue() instanceof Map<?, ?> nested) result.putAll(flatten((Map<String, Object>) nested, path + "."));
+			else result.put(path, String.valueOf(entry.getValue()));
+		});
+		return result;
+	}
+
+	private static void move(Path source, Path destination) throws IOException {
+		try {
+			DurableFiles.forceFile(source);
+			Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			DurableFiles.forceMoveDirectories(source, destination);
+		} catch (java.nio.file.AtomicMoveNotSupportedException failure) {
+			throw new IOException("atomic proxy configuration activation is unsupported", failure);
+		}
+	}
+
+	private static void requireFile(String name) {
+		if (!FILE_NAME.equals(name)) throw new IllegalArgumentException("proxy configuration file is not managed");
+	}
+
+	private static void ensureBounded(String value) {
+		if (value == null || value.indexOf('\0') >= 0 || value.getBytes(StandardCharsets.UTF_8).length > MAX_BYTES) {
+			throw new IllegalArgumentException("proxy configuration content is invalid");
+		}
+	}
+
+	static String revision(String value) {
+		try { return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8))); }
+		catch (NoSuchAlgorithmException impossible) { throw new IllegalStateException(impossible); }
+	}
+
+	record Document(String fileName, String content, String revision) { }
+	record Preview(String resolvedContent, String revision, List<String> changes) { }
+	record ApplyResult(Document document, List<String> changes, boolean rolledBack) { }
+	@FunctionalInterface interface MoveAction { void move(Path source, Path destination) throws IOException; }
+	@FunctionalInterface interface TempFileAction { Path create(Path directory, String prefix, String suffix) throws IOException; }
+	@SuppressWarnings("serial") static final class StaleRevisionException extends RuntimeException { }
+	@SuppressWarnings("serial") static final class ApplyFailureException extends IOException {
+		private final boolean rolledBack;
+		private ApplyFailureException(boolean rolledBack, Throwable cause) { super(cause); this.rolledBack = rolledBack; }
+		boolean rolledBack() { return rolledBack; }
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -793,8 +793,16 @@ final class ProxyConfigurationFileService {
 					"prefix", "dbindex")
 					.contains(normalized);
 		}
-		if (normalizedPath.startsWith("control.")) {
-			return normalized.endsWith("file") || normalized.endsWith("directory");
+		if (infrastructurePath(normalizedPath, "mqtt")) {
+			return Set.of("clientid", "brokerurl", "username", "password", "prefix").contains(normalized);
+		}
+		if (infrastructurePath(normalizedPath, "multiproxysockethost")
+				|| infrastructurePath(normalizedPath, "multiproxyservers")) {
+			return Set.of("host", "port").contains(normalized);
+		}
+		if (infrastructurePath(normalizedPath, "control")) {
+			return normalized.endsWith("file") || normalized.endsWith("directory")
+					|| Set.of("endpoint", "host", "port").contains(normalized);
 		}
 		if (value instanceof String text) {
 			String lowered = text.trim().toLowerCase(Locale.ROOT);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -109,10 +109,21 @@ final class ProxyConfigurationFileService {
 	}
 
 	ApplyResult apply(String fileName, String proposed, String expectedRevision) throws IOException {
+		return apply(prepareApply(fileName, proposed, expectedRevision));
+	}
+
+	PreparedApply prepareApply(String fileName, String proposed, String expectedRevision) throws IOException {
 		requireFile(fileName);
 		String currentRaw = readRaw();
 		if (expectedRevision == null || !revision(currentRaw).equals(expectedRevision)) throw new StaleRevisionException();
 		Preview preview = previewAgainstSnapshot(proposed, currentRaw);
+		return new PreparedApply(currentRaw, expectedRevision, preview);
+	}
+
+	ApplyResult apply(PreparedApply prepared) throws IOException {
+		String currentRaw = prepared.currentRaw();
+		String expectedRevision = prepared.expectedRevision();
+		Preview preview = prepared.preview();
 		Path backup = target.resolveSibling(FILE_NAME + ".control-backup");
 		Path stage = null;
 		Path backupStage = null;
@@ -1083,6 +1094,7 @@ final class ProxyConfigurationFileService {
 				|| normalized.contains("privatekey") || normalized.contains("signingkey")
 				|| normalized.contains("authorization")
 				|| normalized.contains("webhookurl")) return true;
+		if (!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && compoundInfrastructureField(key)) return true;
 		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
 		if ((!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && rootDatabaseField(normalizedPath))
 				|| infrastructurePath(normalizedPath, "database")
@@ -1122,6 +1134,22 @@ final class ProxyConfigurationFileService {
 	private static String normalizeSecretName(String value) {
 		return value.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replace(".", "")
 				.replaceAll("\\s+", "");
+	}
+
+	private static boolean compoundInfrastructureField(String key) {
+		String words = key.replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
+				.replaceAll("([a-z0-9])([A-Z])", "$1 $2")
+				.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", " ").trim();
+		if (words.isEmpty()) return false;
+		String[] tokens = words.split(" +");
+		String last = tokens[tokens.length - 1];
+		if (tokens.length > 1 && Set.of("host", "endpoint", "address", "port", "broker", "database", "schema",
+				"socket", "uri", "url", "ipv4", "ipv6").contains(last)) return true;
+		if (tokens.length > 2 && "name".equals(last)
+				&& Set.of("host", "db").contains(tokens[tokens.length - 2])) return true;
+		String compact = words.replace(" ", "");
+		return Set.of("dburl", "dbport", "dbhost", "dbname", "apiurl", "apiuri", "redisport", "redishost",
+				"mysqlport", "mysqlhost", "mqttport", "mqtthost").contains(compact);
 	}
 
 	private static boolean rootDatabaseField(String normalizedPath) {
@@ -1236,6 +1264,7 @@ final class ProxyConfigurationFileService {
 
 	record Document(String fileName, String content, String revision) { }
 	record Preview(String resolvedContent, String revision, List<String> changes) { }
+	record PreparedApply(String currentRaw, String expectedRevision, Preview preview) { }
 	record ApplyResult(Document document, List<String> changes, boolean rolledBack) { }
 	@FunctionalInterface interface MoveAction { void move(Path source, Path destination) throws IOException; }
 	@FunctionalInterface interface TempFileAction { Path create(Path directory, String prefix, String suffix) throws IOException; }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -535,33 +535,40 @@ final class ProxyConfigurationFileService {
 	private static Map<String, CommentLine> redactComments(Node node, Object source, String path,
 			Set<String> values) {
 		Map<String, CommentLine> result = new LinkedHashMap<>();
-		redactComments(node, path, false, values, result);
-		if (node instanceof MappingNode mapping && source instanceof Map<?, ?> rawSource) {
-			@SuppressWarnings("unchecked") Map<String, Object> sourceMap = (Map<String, Object>) rawSource;
+		redactComments(node, source, path, "root", values, result);
+		return result;
+	}
+
+	private static void redactComments(Node node, Object source, String path, String location,
+			Set<String> values, Map<String, CommentLine> result) {
+		redactComments(node, location, false, values, result);
+		if (node instanceof MappingNode mapping && source instanceof Map<?, ?> sourceMap) {
 			for (NodeTuple tuple : mapping.getValue()) {
 				String key = key(tuple.getKeyNode());
 				Object value = sourceMap.get(key);
 				String childPath = path + key;
+				String childLocation = mapLocation(location, key);
 				boolean hidden = secret(childPath, key, value);
-				redactComments(tuple.getKeyNode(), childPath + "#key", hidden, values, result);
-				if (hidden) redactComments(tuple.getValueNode(), childPath, true, values, result);
+				redactComments(tuple.getKeyNode(), childLocation + "k", hidden, values, result);
+				if (hidden) redactComments(tuple.getValueNode(), childLocation + "v", true, values, result);
 				else if (value instanceof Map<?, ?> || value instanceof List<?>) {
-					result.putAll(redactComments(tuple.getValueNode(), value,
-							value instanceof Map<?, ?> ? childPath + "." : childPath, values));
-				} else redactDescendantComments(tuple.getValueNode(), childPath, false, values, result);
+					redactComments(tuple.getValueNode(), value,
+							value instanceof Map<?, ?> ? childPath + "." : childPath, childLocation + "v", values, result);
+				} else redactDescendantComments(tuple.getValueNode(), childLocation + "v", false, values, result);
 			}
 		} else if (node instanceof SequenceNode sequence && source instanceof List<?> list) {
 			for (int index = 0; index < sequence.getValue().size(); index++) {
 				Node child = sequence.getValue().get(index);
 				Object value = index < list.size() ? list.get(index) : null;
 				String itemPath = path + "[" + index + "]";
-				if (secret(itemPath, "", value)) redactComments(child, itemPath, true, values, result);
+				String itemLocation = sequenceLocation(location, index);
+				if (secret(itemPath, "", value)) redactComments(child, itemLocation, true, values, result);
 				else if (value instanceof Map<?, ?> || value instanceof List<?>) {
-					result.putAll(redactComments(child, value, value instanceof Map<?, ?> ? itemPath + "." : itemPath, values));
-				} else redactDescendantComments(child, itemPath, false, values, result);
+					redactComments(child, value, value instanceof Map<?, ?> ? itemPath + "." : itemPath,
+							itemLocation, values, result);
+				} else redactDescendantComments(child, itemLocation, false, values, result);
 			}
 		}
-		return result;
 	}
 
 	private static void redactDescendantComments(Node node, String path, boolean sensitiveContext, Set<String> values,
@@ -570,15 +577,16 @@ final class ProxyConfigurationFileService {
 		if (node instanceof MappingNode mapping) {
 			for (NodeTuple tuple : mapping.getValue()) {
 				String key = key(tuple.getKeyNode());
-				redactDescendantComments(tuple.getKeyNode(), path + key + "#key", sensitiveContext, values, redacted);
+				String childLocation = mapLocation(path, key);
+				redactDescendantComments(tuple.getKeyNode(), childLocation + "k", sensitiveContext, values, redacted);
 				Node child = tuple.getValueNode();
-				redactDescendantComments(child, path + key + (child instanceof MappingNode ? "." : ""),
+				redactDescendantComments(child, childLocation + "v",
 						sensitiveContext, values, redacted);
 			}
 		} else if (node instanceof SequenceNode sequence) {
 			for (int index = 0; index < sequence.getValue().size(); index++) {
 				Node child = sequence.getValue().get(index);
-				redactDescendantComments(child, path + "[" + index + "]" + (child instanceof MappingNode ? "." : ""), sensitiveContext,
+				redactDescendantComments(child, sequenceLocation(path, index), sensitiveContext,
 						values, redacted);
 			}
 		}
@@ -607,7 +615,7 @@ final class ProxyConfigurationFileService {
 	}
 
 	private static void restoreRedactedComments(Node proposed, Map<String, CommentLine> expected) {
-		Map<String, CommentReference> comments = commentReferences(proposed, "");
+		Map<String, CommentReference> comments = commentReferences(proposed, "root");
 		for (Map.Entry<String, CommentLine> entry : expected.entrySet()) {
 			CommentReference reference = comments.get(entry.getKey());
 			if (reference == null || !REDACTED_COMMENT.equals(reference.line().getValue())) {
@@ -635,15 +643,14 @@ final class ProxyConfigurationFileService {
 		if (node instanceof MappingNode mapping) {
 			for (NodeTuple tuple : mapping.getValue()) {
 				String key = key(tuple.getKeyNode());
-				String childPath = path + key;
-				collectComments(tuple.getKeyNode(), childPath + "#key", result);
-				collectComments(tuple.getValueNode(), tuple.getValueNode() instanceof MappingNode ? childPath + "." : childPath,
-						result);
+				String childLocation = mapLocation(path, key);
+				collectComments(tuple.getKeyNode(), childLocation + "k", result);
+				collectComments(tuple.getValueNode(), childLocation + "v", result);
 			}
 		} else if (node instanceof SequenceNode sequence) {
 			for (int index = 0; index < sequence.getValue().size(); index++) {
 				Node child = sequence.getValue().get(index);
-				collectComments(child, path + "[" + index + "]" + (child instanceof MappingNode ? "." : ""), result);
+				collectComments(child, sequenceLocation(path, index), result);
 			}
 		}
 	}
@@ -667,6 +674,14 @@ final class ProxyConfigurationFileService {
 
 	private static String commentSlot(String path, String kind, int index) {
 		return path + "|" + kind + "|" + index;
+	}
+
+	private static String mapLocation(String parent, String key) {
+		return parent + "m" + key.length() + ":" + key;
+	}
+
+	private static String sequenceLocation(String parent, int index) {
+		return parent + "s" + index + ":";
 	}
 
 	private static boolean sensitiveComment(String comment, boolean sensitiveContext, Set<String> values) {
@@ -817,6 +832,9 @@ final class ProxyConfigurationFileService {
 	@SuppressWarnings("unchecked")
 	private static boolean sameSecretSafeListOrder(Object proposed, Object current, String path) {
 		if (REDACTED.equals(proposed)) return true;
+		if (secret(path, "", current)) {
+			return proposed != null && !(proposed instanceof Map<?, ?>) && !(proposed instanceof List<?>);
+		}
 		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
 			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
 			String mapPath = path.endsWith(".") ? path : path + ".";

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -439,8 +439,10 @@ final class ProxyConfigurationFileService {
 			for (int index = 0; index < proposed.size(); index++) {
 				Object old = current.get(index);
 				String itemPath = path + "[" + index + "]";
-				if (secretBearingValue(old, itemPath)
-						&& !retainsRedactedMarkers(proposed.get(index), old, itemPath)) {
+				boolean retained = secret(itemPath, "", old)
+						? REDACTED.equals(proposed.get(index))
+						: retainsOrReplacesSecretValues(proposed.get(index), old, itemPath);
+				if (secretBearingValue(old, itemPath) && !retained) {
 					throw new IllegalArgumentException("redacted placeholder is invalid");
 				}
 			}
@@ -503,8 +505,13 @@ final class ProxyConfigurationFileService {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static boolean retainsRedactedMarkers(Object proposed, Object current, String path) {
-		if (secret(path, "", current)) return REDACTED.equals(proposed);
+	private static boolean retainsOrReplacesSecretValues(Object proposed, Object current, String path) {
+		// A retained secret position can either preserve its redaction marker or
+		// explicitly rotate to another scalar. List ordering and the public-only
+		// suffix checks still bind that replacement to its original position.
+		if (secret(path, "", current)) {
+			return proposed != null && !(proposed instanceof Map<?, ?>) && !(proposed instanceof List<?>);
+		}
 		if (current instanceof Map<?, ?> currentMap) {
 			if (!(proposed instanceof Map<?, ?> proposedMap)) return false;
 			String mapPath = path.endsWith(".") ? path : path + ".";
@@ -514,7 +521,7 @@ final class ProxyConfigurationFileService {
 				String childPath = mapPath + key;
 				if (!secretBearingValue(old, childPath)) continue;
 				if (!proposedMap.containsKey(key)
-						|| !retainsRedactedMarkers(proposedMap.get(key), old, childPath)) return false;
+						|| !retainsOrReplacesSecretValues(proposedMap.get(key), old, childPath)) return false;
 			}
 			return true;
 		}
@@ -524,7 +531,7 @@ final class ProxyConfigurationFileService {
 				Object old = currentList.get(index);
 				String itemPath = path + "[" + index + "]";
 				if (secretBearingValue(old, itemPath)
-						&& !retainsRedactedMarkers(proposedList.get(index), old, itemPath)) return false;
+						&& !retainsOrReplacesSecretValues(proposedList.get(index), old, itemPath)) return false;
 			}
 			for (int index = proposedList.size(); index < currentList.size(); index++) {
 				if (secretBearingValue(currentList.get(index), path + "[" + index + "]")) return false;
@@ -984,7 +991,9 @@ final class ProxyConfigurationFileService {
 						&& !hasUniqueStableIdentity(proposedList, currentList, i)) return false;
 				if (proposedList.size() < currentList.size()
 						&& secretBearingValue(currentList.get(i), path + "[" + i + "]")
-						&& !retainsRedactedMarkers(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
+						&& !(secret(path + "[" + i + "]", "", currentList.get(i))
+								? REDACTED.equals(proposedList.get(i))
+								: retainsOrReplacesSecretValues(proposedList.get(i), currentList.get(i), path + "[" + i + "]"))) return false;
 			}
 			if (proposedList.size() < currentList.size()) {
 				for (int i = proposedList.size(); i < currentList.size(); i++) {
@@ -1145,7 +1154,7 @@ final class ProxyConfigurationFileService {
 		String last = tokens[tokens.length - 1];
 		String compact = words.replace(" ", "");
 		if (compact.matches("^(database|db|mysql|redis|mqtt)(user|username)$")) return true;
-		if (tokens.length > 1 && Set.of("host", "endpoint", "address", "port", "broker", "database", "schema",
+		if (tokens.length > 1 && Set.of("host", "endpoint", "address", "port", "broker", "database", "schema", "server",
 				"socket", "uri", "url", "ipv4", "ipv6").contains(last)) return true;
 		if (tokens.length > 2 && "name".equals(last)
 				&& Set.of("host", "db").contains(tokens[tokens.length - 2])) return true;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -83,7 +83,10 @@ final class ProxyConfigurationFileService {
 
 	Preview preview(String fileName, String proposed) throws IOException {
 		requireFile(fileName);
-		String currentRaw = readRaw();
+		return previewAgainstSnapshot(proposed, readRaw());
+	}
+
+	Preview previewAgainstSnapshot(String proposed, String currentRaw) throws IOException {
 		Map<String, Object> current = parse(currentRaw);
 		Map<String, Object> proposedValues = parse(proposed);
 		Map<String, Object> resolved = resolve(proposedValues, current, "");
@@ -105,7 +108,7 @@ final class ProxyConfigurationFileService {
 		requireFile(fileName);
 		String currentRaw = readRaw();
 		if (expectedRevision == null || !revision(currentRaw).equals(expectedRevision)) throw new StaleRevisionException();
-		Preview preview = preview(fileName, proposed);
+		Preview preview = previewAgainstSnapshot(proposed, currentRaw);
 		Path backup = target.resolveSibling(FILE_NAME + ".control-backup");
 		Path stage = null;
 		Path backupStage = null;
@@ -1002,16 +1005,19 @@ final class ProxyConfigurationFileService {
 	}
 
 	private static boolean listEntryIdentityKey(String key) {
-		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
 		return Set.of("name", "id", "key", "server", "serverid", "clientid").contains(normalized);
 	}
 
 	private static boolean secret(String path, String key, Object value) {
-		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
-		if (normalized.contains("password") || normalized.contains("secret") || normalized.equals("token")
-				|| normalized.contains("apikey") || normalized.contains("authorization")
+		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
+		if (normalized.contains("password") || normalized.contains("passphrase") || normalized.contains("secret")
+				|| normalized.contains("token") || normalized.contains("credential")
+				|| normalized.contains("apikey") || normalized.contains("accesskey")
+				|| normalized.contains("privatekey") || normalized.contains("signingkey")
+				|| normalized.contains("authorization")
 				|| normalized.contains("webhookurl")) return true;
-		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
 		if ((!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && rootDatabaseField(normalizedPath))
 				|| infrastructurePath(normalizedPath, "database")
 				|| infrastructurePath(normalizedPath, "mysql") || infrastructurePath(normalizedPath, "globaldata")

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -993,7 +993,8 @@ final class ProxyConfigurationFileService {
 					&& Set.of("host", "port").contains(normalized);
 		}
 		if (infrastructurePath(normalizedPath, "control")) {
-			return normalized.endsWith("file") || normalized.endsWith("directory")
+			return "control.hosted.downloadurl".equals(normalizedPath)
+					|| normalized.endsWith("file") || normalized.endsWith("directory")
 					|| Set.of("endpoint", "host", "port").contains(normalized);
 		}
 		if (value instanceof String text) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -55,6 +55,10 @@ final class ProxyConfigurationFileService {
 	private static final Pattern LABELED_COMMENT_DETAIL = Pattern.compile("([A-Za-z0-9 _-]+)\\s*[:=]");
 	private static final Pattern BARE_NETWORK_ADDRESS = Pattern.compile(
 			"(?i)(?<![a-z0-9_-])(?:(?:\\d{1,3}\\.){3}\\d{1,3}|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,63}|(?=[0-9a-f:]*:[0-9a-f:]*:)[0-9a-f:]{3,})(?![a-z0-9_:-])");
+	private static final Pattern DELIMITER_FREE_INFRASTRUCTURE_HOST = Pattern.compile(
+			"(?i)\\b(?:host|hostname|endpoint|address|port|url|uri|server|broker|database|db|redis|mysql|mqtt|bungee|proxy|socket)\\b"
+					+ "(?:\\s+(?:is|at|on|through|via|to|for|named|called|connection|server|endpoint|host|hostname|address|port|url|uri|broker|database|db|redis|mysql|mqtt|bungee|proxy|socket)){0,3}"
+					+ "\\s+[a-z0-9](?:[a-z0-9_-]{0,61}[a-z0-9])?(?::\\d{1,5})?(?=\\s*(?:$|[\\s,;.)\\]}]))");
 	private final Path target;
 	private final MoveAction mover;
 	private final TempFileAction tempFiles;
@@ -420,7 +424,7 @@ final class ProxyConfigurationFileService {
 
 	@SuppressWarnings("unchecked")
 	private static void validateRedactedList(List<?> current, List<?> proposed, String path) {
-		if (containsSecrets(current, path) && current.size() != proposed.size()) {
+		if (containsSecrets(current, path) && proposed.size() < current.size()) {
 			throw new IllegalArgumentException("redacted placeholder is invalid");
 		}
 		for (int index = 0; index < Math.min(current.size(), proposed.size()); index++) {
@@ -698,6 +702,7 @@ final class ProxyConfigurationFileService {
 		if (lowered.matches("(?s).*\\b(password|passphrase|secret|token|credentials?|api[ _-]?key|access[ _-]?key|private[ _-]?key|client[ _-]?secret|signing[ _-]?key|authorization|jdbc|webhook)\\b.*")
 				|| lowered.matches("(?s).*[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*")
 				|| labeledSensitiveDetail(comment)
+				|| DELIMITER_FREE_INFRASTRUCTURE_HOST.matcher(comment).find()
 				|| BARE_NETWORK_ADDRESS.matcher(comment).find()
 				|| lowered.matches("(?s).*\\b(?:jdbc:[a-z][a-z0-9+.-]*:|[a-z][a-z0-9+.-]*://)[^\\s#]+.*")) return true;
 		for (String value : values) {
@@ -912,11 +917,14 @@ final class ProxyConfigurationFileService {
 					|| !sawNonSecret && sawSecret && allSecretsRedacted;
 		}
 		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
-			if (proposedList.size() != currentList.size()) return false;
-			for (int i = 0; i < proposedList.size(); i++) {
+			if (proposedList.size() < currentList.size()) return false;
+			for (int i = 0; i < currentList.size(); i++) {
 				if (!sameSecretSafeListOrder(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
 				if (hasNonSecretEdit(proposedList.get(i), currentList.get(i), path + "[" + i + "]")
 						&& !hasUniqueStableIdentity(proposedList, currentList, i)) return false;
+			}
+			for (int i = currentList.size(); i < proposedList.size(); i++) {
+				if (containsMarker(proposedList.get(i))) return false;
 			}
 			return true;
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -424,8 +424,20 @@ final class ProxyConfigurationFileService {
 
 	@SuppressWarnings("unchecked")
 	private static void validateRedactedList(List<?> current, List<?> proposed, String path) {
-		if (containsSecrets(current, path) && proposed.size() < current.size()) {
-			throw new IllegalArgumentException("redacted placeholder is invalid");
+		if (proposed.size() < current.size()) {
+			for (int index = 0; index < proposed.size(); index++) {
+				Object old = current.get(index);
+				String itemPath = path + "[" + index + "]";
+				if (secretBearingValue(old, itemPath)
+						&& !retainsRedactedMarkers(proposed.get(index), old, itemPath)) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+			}
+			for (int index = proposed.size(); index < current.size(); index++) {
+				if (secretBearingValue(current.get(index), path + "[" + index + "]")) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+			}
 		}
 		for (int index = 0; index < Math.min(current.size(), proposed.size()); index++) {
 			Object old = current.get(index);
@@ -472,6 +484,43 @@ final class ProxyConfigurationFileService {
 			}
 		}
 		return false;
+	}
+
+	private static boolean secretBearingValue(Object value, String path) {
+		return secret(path, "", value) || containsSecrets(value,
+				value instanceof Map<?, ?> ? path + "." : path);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static boolean retainsRedactedMarkers(Object proposed, Object current, String path) {
+		if (secret(path, "", current)) return REDACTED.equals(proposed);
+		if (current instanceof Map<?, ?> currentMap) {
+			if (!(proposed instanceof Map<?, ?> proposedMap)) return false;
+			String mapPath = path.endsWith(".") ? path : path + ".";
+			for (Map.Entry<?, ?> entry : currentMap.entrySet()) {
+				if (!(entry.getKey() instanceof String key)) return false;
+				Object old = entry.getValue();
+				String childPath = mapPath + key;
+				if (!secretBearingValue(old, childPath)) continue;
+				if (!proposedMap.containsKey(key)
+						|| !retainsRedactedMarkers(proposedMap.get(key), old, childPath)) return false;
+			}
+			return true;
+		}
+		if (current instanceof List<?> currentList) {
+			if (!(proposed instanceof List<?> proposedList) || proposedList.size() > currentList.size()) return false;
+			for (int index = 0; index < proposedList.size(); index++) {
+				Object old = currentList.get(index);
+				String itemPath = path + "[" + index + "]";
+				if (secretBearingValue(old, itemPath)
+						&& !retainsRedactedMarkers(proposedList.get(index), old, itemPath)) return false;
+			}
+			for (int index = proposedList.size(); index < currentList.size(); index++) {
+				if (secretBearingValue(currentList.get(index), path + "[" + index + "]")) return false;
+			}
+			return true;
+		}
+		return true;
 	}
 
 	private static boolean containsMarker(Object value) {
@@ -917,11 +966,20 @@ final class ProxyConfigurationFileService {
 					|| !sawNonSecret && sawSecret && allSecretsRedacted;
 		}
 		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
-			if (proposedList.size() < currentList.size()) return false;
-			for (int i = 0; i < currentList.size(); i++) {
+			int retained = Math.min(proposedList.size(), currentList.size());
+			for (int i = 0; i < retained; i++) {
 				if (!sameSecretSafeListOrder(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
 				if (hasNonSecretEdit(proposedList.get(i), currentList.get(i), path + "[" + i + "]")
 						&& !hasUniqueStableIdentity(proposedList, currentList, i)) return false;
+				if (proposedList.size() < currentList.size()
+						&& secretBearingValue(currentList.get(i), path + "[" + i + "]")
+						&& !retainsRedactedMarkers(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
+			}
+			if (proposedList.size() < currentList.size()) {
+				for (int i = proposedList.size(); i < currentList.size(); i++) {
+					if (secretBearingValue(currentList.get(i), path + "[" + i + "]")) return false;
+				}
+				return true;
 			}
 			for (int i = currentList.size(); i < proposedList.size(); i++) {
 				if (containsMarker(proposedList.get(i))) return false;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -838,7 +838,9 @@ final class ProxyConfigurationFileService {
 		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
 			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
 			String mapPath = path.endsWith(".") ? path : path + ".";
-			boolean hasIdentity = false;
+			boolean hasStableIdentity = false;
+			boolean sawNonSecret = false;
+			boolean allNonSecretsUnchanged = true;
 			boolean sawSecret = false;
 			boolean allSecretsRedacted = true;
 			for (Object rawKey : proposedMap.keySet()) {
@@ -849,19 +851,78 @@ final class ProxyConfigurationFileService {
 					sawSecret = true;
 					if (candidate instanceof Map<?, ?> || candidate instanceof List<?> || candidate == null) return false;
 					if (!REDACTED.equals(candidate)) allSecretsRedacted = false;
-				} else if (!sameSecretSafeListOrder(candidate, old, mapPath + key)) {
-					return false;
-				} else hasIdentity = true;
+				} else {
+					sawNonSecret = true;
+					boolean unchanged = sameSecretSafeListOrder(candidate, old, mapPath + key);
+					if (listEntryIdentityKey(key)) {
+						if (!unchanged) return false;
+						hasStableIdentity = true;
+					} else if (!unchanged) allNonSecretsUnchanged = false;
+				}
 			}
-			return hasIdentity || sawSecret && allSecretsRedacted;
+			return hasStableIdentity || sawNonSecret && allNonSecretsUnchanged
+					|| !sawNonSecret && sawSecret && allSecretsRedacted;
 		}
 		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
 			if (proposedList.size() != currentList.size()) return false;
-			for (int i = 0; i < proposedList.size(); i++)
+			for (int i = 0; i < proposedList.size(); i++) {
 				if (!sameSecretSafeListOrder(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
+				if (hasNonSecretEdit(proposedList.get(i), currentList.get(i), path + "[" + i + "]")
+						&& !hasUniqueStableIdentity(proposedList, currentList, i)) return false;
+			}
 			return true;
 		}
 		return java.util.Objects.equals(proposed, current);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static boolean hasNonSecretEdit(Object proposed, Object current, String path) {
+		if (secret(path, "", current)) return false;
+		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
+			for (Object rawKey : proposedMap.keySet()) {
+				String key = String.valueOf(rawKey);
+				Object old = currentMap.get(rawKey);
+				if (!secret(path + "." + key, key, old)
+						&& hasNonSecretEdit(proposedMap.get(rawKey), old, path + "." + key)) return true;
+			}
+			return false;
+		}
+		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
+			if (proposedList.size() != currentList.size()) return true;
+			for (int i = 0; i < proposedList.size(); i++)
+				if (hasNonSecretEdit(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return true;
+			return false;
+		}
+		return !java.util.Objects.equals(proposed, current);
+	}
+
+	private static boolean hasUniqueStableIdentity(List<?> proposed, List<?> current, int index) {
+		if (!(proposed.get(index) instanceof Map<?, ?> proposedMap)
+				|| !(current.get(index) instanceof Map<?, ?> currentMap)) return false;
+		for (Object rawKey : currentMap.keySet()) {
+			String key = String.valueOf(rawKey);
+			Object old = currentMap.get(rawKey);
+			if (!listEntryIdentityKey(key) || old == null || old instanceof Map<?, ?> || old instanceof List<?>
+					|| !java.util.Objects.equals(old, proposedMap.get(rawKey))) continue;
+			long currentMatches = current.stream().filter(item -> identityMatches(item, key, old)).count();
+			long proposedMatches = proposed.stream().filter(item -> identityMatches(item, key, old)).count();
+			if (currentMatches == 1 && proposedMatches == 1) return true;
+		}
+		return false;
+	}
+
+	private static boolean identityMatches(Object item, String key, Object value) {
+		if (!(item instanceof Map<?, ?> map)) return false;
+		for (Object rawKey : map.keySet()) {
+			if (String.valueOf(rawKey).equalsIgnoreCase(key)
+					&& java.util.Objects.equals(map.get(rawKey), value)) return true;
+		}
+		return false;
+	}
+
+	private static boolean listEntryIdentityKey(String key) {
+		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
+		return Set.of("name", "id", "key", "server", "serverid", "clientid").contains(normalized);
 	}
 
 	private static boolean secret(String path, String key, Object value) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -1128,7 +1128,11 @@ final class ProxyConfigurationFileService {
 				|| normalized.contains("privatekey") || normalized.contains("signingkey")
 				|| normalized.contains("authorization")) return true;
 		if (normalized.contains("webhook")) return !(value instanceof Map<?, ?>) && !(value instanceof List<?>);
-		if (!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && compoundInfrastructureField(key)) return true;
+		if (!(value instanceof Map<?, ?>) && !(value instanceof List<?>)) {
+			if (infrastructureListContext(path)) return true;
+			if (compoundInfrastructureField(key)
+					&& (!normalized.endsWith("server") || knownInfrastructureServerField(path, key))) return true;
+		}
 		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
 		if (value instanceof String text && normalizedPath.contains("webhook")) {
 			String lowered = text.trim().toLowerCase(Locale.ROOT);
@@ -1195,6 +1199,55 @@ final class ProxyConfigurationFileService {
 				"mysqlport", "mysqlhost", "mqttport", "mqtthost").contains(compact);
 	}
 
+	private static boolean knownInfrastructureServerField(String path, String key) {
+		String words = key.replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
+				.replaceAll("([a-z0-9])([A-Z])", "$1 $2")
+				.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", " ").trim();
+		String normalizedPath = normalizePath(path);
+		return infrastructurePath(normalizedPath, "database") || infrastructurePath(normalizedPath, "mysql")
+				|| infrastructurePath(normalizedPath, "redis") || infrastructurePath(normalizedPath, "multiproxyredis")
+				|| infrastructurePath(normalizedPath, "mqtt") || infrastructurePath(normalizedPath, "bungeeserver")
+				|| infrastructurePath(normalizedPath, "spigotservers")
+				|| infrastructurePath(normalizedPath, "multiproxysockethost")
+				|| infrastructurePath(normalizedPath, "multiproxyservers")
+				|| words.startsWith("database ") || words.startsWith("mysql ") || words.startsWith("redis ")
+				|| words.startsWith("mqtt ") || words.startsWith("bungee ") || words.startsWith("proxy ");
+	}
+
+	private static boolean infrastructureListContext(String path) {
+		String normalizedPath = normalizePath(path);
+		for (String field : Set.of("hosts", "users", "endpoints", "addresses", "ports", "servers", "brokers",
+				"databases", "schemas", "sockets", "uris", "urls")) {
+			String marker = field + "[";
+			int start = normalizedPath.indexOf(marker);
+			while (start >= 0) {
+				String containerPath = normalizedPath.substring(0, start + field.length());
+				if (containerPath.endsWith("." + field)) {
+					containerPath = containerPath.substring(0, containerPath.length() - field.length() - 1);
+				} else if (containerPath.equals(field)) {
+					containerPath = "";
+				} else {
+					start = normalizedPath.indexOf(marker, start + marker.length());
+					continue;
+				}
+				if (knownInfrastructurePath(containerPath)) return true;
+				start = normalizedPath.indexOf(marker, start + marker.length());
+			}
+		}
+		return false;
+	}
+
+	private static boolean knownInfrastructurePath(String path) {
+		return Set.of("database", "mysql", "redis", "multiproxyredis", "mqtt", "bungeeserver", "spigotservers",
+				"multiproxysockethost", "multiproxyservers", "control").stream()
+				.anyMatch(section -> path.equals(section) || path.startsWith(section + ".")
+						|| path.startsWith(section + "["));
+	}
+
+	private static String normalizePath(String path) {
+		return path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
+	}
+
 	private static boolean rootDatabaseField(String normalizedPath) {
 		return !normalizedPath.contains(".") && !normalizedPath.contains("[")
 				&& Set.of("host", "port", "database", "name", "user", "username", "password", "line", "driver", "poolname",
@@ -1202,7 +1255,9 @@ final class ProxyConfigurationFileService {
 	}
 
 	private static boolean infrastructurePath(String normalizedPath, String section) {
-		return normalizedPath.startsWith(section + ".") || normalizedPath.contains("." + section + ".");
+		return normalizedPath.startsWith(section + ".")
+				|| normalizedPath.startsWith(section + "[") || normalizedPath.contains("." + section + ".")
+				|| normalizedPath.contains("." + section + "[");
 	}
 
 	private static void copyPermissions(Path source, Path destination) throws IOException {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -905,7 +905,7 @@ final class ProxyConfigurationFileService {
 
 	private static boolean rootDatabaseField(String normalizedPath) {
 		return !normalizedPath.contains(".") && !normalizedPath.contains("[")
-				&& Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname",
+				&& Set.of("host", "port", "database", "name", "username", "password", "line", "driver", "poolname",
 						"prefix", "dbindex").contains(normalizedPath);
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -836,8 +836,11 @@ final class ProxyConfigurationFileService {
 			return proposed != null && !(proposed instanceof Map<?, ?>) && !(proposed instanceof List<?>);
 		}
 		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
-			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
 			String mapPath = path.endsWith(".") ? path : path + ".";
+			if (containsSecrets(currentMap, mapPath) && hasStableIdentity(proposedMap, currentMap)) {
+				return preservesSecretFields(proposedMap, currentMap, mapPath);
+			}
+			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
 			boolean hasStableIdentity = false;
 			boolean sawNonSecret = false;
 			boolean allNonSecretsUnchanged = true;
@@ -875,15 +878,51 @@ final class ProxyConfigurationFileService {
 		return java.util.Objects.equals(proposed, current);
 	}
 
+	private static boolean hasStableIdentity(Map<?, ?> proposed, Map<?, ?> current) {
+		for (Object rawKey : current.keySet()) {
+			String key = String.valueOf(rawKey);
+			Object value = current.get(rawKey);
+			if (listEntryIdentityKey(key) && value != null && !(value instanceof Map<?, ?>)
+					&& !(value instanceof List<?>) && proposed.containsKey(rawKey)
+					&& java.util.Objects.equals(value, proposed.get(rawKey))) return true;
+		}
+		return false;
+	}
+
+	private static boolean preservesSecretFields(Map<?, ?> proposed, Map<?, ?> current, String path) {
+		for (Object rawKey : current.keySet()) {
+			String key = String.valueOf(rawKey);
+			Object old = current.get(rawKey);
+			String childPath = path + key;
+			if (secret(childPath, key, old)) {
+				if (!proposed.containsKey(rawKey)) return false;
+				Object candidate = proposed.get(rawKey);
+				if (candidate == null || candidate instanceof Map<?, ?> || candidate instanceof List<?>) return false;
+			} else if ((old instanceof Map<?, ?> || old instanceof List<?>) && containsSecrets(old,
+					old instanceof Map<?, ?> ? childPath + "." : childPath)) {
+				if (!proposed.containsKey(rawKey)
+						|| !sameSecretSafeListOrder(proposed.get(rawKey), old,
+							old instanceof Map<?, ?> ? childPath + "." : childPath)) return false;
+			}
+		}
+		return true;
+	}
+
 	@SuppressWarnings("unchecked")
 	private static boolean hasNonSecretEdit(Object proposed, Object current, String path) {
 		if (secret(path, "", current)) return false;
 		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
+			String mapPath = path.endsWith(".") ? path : path + ".";
+			for (Object rawKey : currentMap.keySet()) {
+				String key = String.valueOf(rawKey);
+				Object old = currentMap.get(rawKey);
+				if (!proposedMap.containsKey(rawKey) && !secret(mapPath + key, key, old)) return true;
+			}
 			for (Object rawKey : proposedMap.keySet()) {
 				String key = String.valueOf(rawKey);
 				Object old = currentMap.get(rawKey);
-				if (!secret(path + "." + key, key, old)
-						&& hasNonSecretEdit(proposedMap.get(rawKey), old, path + "." + key)) return true;
+				if (!secret(mapPath + key, key, old)
+						&& hasNonSecretEdit(proposedMap.get(rawKey), old, mapPath + key)) return true;
 			}
 			return false;
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -1024,27 +1024,68 @@ final class ProxyConfigurationFileService {
 	}
 
 	private static List<String> changes(Map<String, Object> before, Map<String, Object> after) {
-		Map<String, String> left = flatten(before, "");
-		Map<String, String> right = flatten(after, "");
-		Set<String> keys = new java.util.TreeSet<>(); keys.addAll(left.keySet()); keys.addAll(right.keySet());
+		Map<StructuralPath, Object> left = flatten(before, List.of());
+		Map<StructuralPath, Object> right = flatten(after, List.of());
+		Set<StructuralPath> keys = new java.util.TreeSet<>(ProxyConfigurationFileService::comparePaths);
+		keys.addAll(left.keySet());
+		keys.addAll(right.keySet());
 		List<String> result = new ArrayList<>();
-		for (String key : keys) {
+		for (StructuralPath key : keys) {
 			if (java.util.Objects.equals(left.get(key), right.get(key))) continue;
-			result.add((left.containsKey(key) ? right.containsKey(key) ? "changed " : "removed " : "added ") + key);
+			result.add((left.containsKey(key) ? right.containsKey(key) ? "changed " : "removed " : "added ")
+					+ key.display());
 			if (result.size() == 20) break;
 		}
 		return List.copyOf(result);
 	}
 
 	@SuppressWarnings("unchecked")
-	private static Map<String, String> flatten(Map<String, Object> source, String prefix) {
-		Map<String, String> result = new LinkedHashMap<>();
-		source.entrySet().stream().sorted(Map.Entry.comparingByKey(Comparator.naturalOrder())).forEach(entry -> {
-			String path = prefix + entry.getKey();
-			if (entry.getValue() instanceof Map<?, ?> nested) result.putAll(flatten((Map<String, Object>) nested, path + "."));
-			else result.put(path, String.valueOf(entry.getValue()));
+	private static Map<StructuralPath, Object> flatten(Map<String, Object> source, List<String> prefix) {
+		Map<StructuralPath, Object> result = new LinkedHashMap<>();
+			source.entrySet().stream().sorted(Map.Entry.comparingByKey(Comparator.naturalOrder())).forEach(entry -> {
+			List<String> path = new ArrayList<>(prefix);
+			path.add(entry.getKey());
+			if (entry.getValue() instanceof Map<?, ?> nested) {
+				if (nested.isEmpty()) result.put(new StructuralPath(path), StructuralLeaf.EMPTY_MAPPING);
+				else result.putAll(flatten((Map<String, Object>) nested, path));
+			} else {
+				result.put(new StructuralPath(path), entry.getValue());
+			}
 		});
 		return result;
+	}
+
+	private enum StructuralLeaf {
+		EMPTY_MAPPING
+	}
+
+	private static int comparePaths(StructuralPath left, StructuralPath right) {
+		int common = Math.min(left.segments().size(), right.segments().size());
+		for (int index = 0; index < common; index++) {
+			int comparison = left.segments().get(index).compareTo(right.segments().get(index));
+			if (comparison != 0) return comparison;
+		}
+		return Integer.compare(left.segments().size(), right.segments().size());
+	}
+
+	private record StructuralPath(List<String> segments) {
+		private StructuralPath {
+			segments = List.copyOf(segments);
+		}
+
+		private String display() {
+			StringBuilder path = new StringBuilder();
+			for (String segment : segments) {
+				if (segment.matches("[A-Za-z_][A-Za-z0-9_-]*")) {
+					if (!path.isEmpty()) path.append('.');
+					path.append(segment);
+				} else {
+					path.append("[\"").append(segment.replace("\\", "\\\\").replace("\"", "\\\""))
+							.append("\"]");
+				}
+			}
+			return path.toString();
+		}
 	}
 
 	private static void move(Path source, Path destination) throws IOException {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -147,6 +147,8 @@ final class ProxyConfigurationFileService {
 							Files.copy(Channels.newInputStream(source), rollback, StandardCopyOption.REPLACE_EXISTING);
 						}
 						copyPermissions(backup, rollback);
+						if (!revision(readRaw()).equals(revision(preview.resolvedContent)))
+							throw new IOException("proxy configuration changed during rollback staging");
 						mover.move(rollback, target);
 					} finally { Files.deleteIfExists(rollback); }
 					rolledBack = true;
@@ -818,17 +820,22 @@ final class ProxyConfigurationFileService {
 		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
 			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
 			String mapPath = path.endsWith(".") ? path : path + ".";
+			boolean hasIdentity = false;
+			boolean sawSecret = false;
+			boolean allSecretsRedacted = true;
 			for (Object rawKey : proposedMap.keySet()) {
 				String key = String.valueOf(rawKey);
 				Object old = currentMap.get(rawKey);
 				Object candidate = proposedMap.get(rawKey);
 				if (secret(mapPath + key, key, old)) {
-					if (!REDACTED.equals(candidate)) return false;
+					sawSecret = true;
+					if (candidate instanceof Map<?, ?> || candidate instanceof List<?> || candidate == null) return false;
+					if (!REDACTED.equals(candidate)) allSecretsRedacted = false;
 				} else if (!sameSecretSafeListOrder(candidate, old, mapPath + key)) {
 					return false;
-				}
+				} else hasIdentity = true;
 			}
-			return true;
+			return hasIdentity || sawSecret && allSecretsRedacted;
 		}
 		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
 			if (proposedList.size() != currentList.size()) return false;

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -816,7 +816,12 @@ final class ProxyConfigurationFileService {
 				|| normalized.contains("apikey") || normalized.contains("authorization")
 				|| normalized.contains("webhookurl")) return true;
 		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "");
-		if (infrastructurePath(normalizedPath, "database") || infrastructurePath(normalizedPath, "globaldata")
+		if ((!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && rootDatabaseField(normalizedPath))
+				|| infrastructurePath(normalizedPath, "database")
+				|| infrastructurePath(normalizedPath, "mysql") || infrastructurePath(normalizedPath, "globaldata")
+				|| infrastructurePath(normalizedPath, "votecache")
+				|| infrastructurePath(normalizedPath, "nonvotedcache")
+				|| infrastructurePath(normalizedPath, "votelogging")
 				|| infrastructurePath(normalizedPath, "redis")
 				|| infrastructurePath(normalizedPath, "multiproxyredis")) {
 			return Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname",
@@ -842,6 +847,12 @@ final class ProxyConfigurationFileService {
 			return lowered.startsWith("jdbc:") || lowered.matches("^[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*");
 		}
 		return false;
+	}
+
+	private static boolean rootDatabaseField(String normalizedPath) {
+		return !normalizedPath.contains(".") && !normalizedPath.contains("[")
+				&& Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname",
+						"prefix", "dbindex").contains(normalizedPath);
 	}
 
 	private static boolean infrastructurePath(String normalizedPath, String section) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -312,7 +312,7 @@ final class ProxyConfigurationFileService {
 				String itemPath = path + "[" + index + "]";
 				result.add(secret(itemPath, "", item) ? REDACTED : maskStructure(item, itemPath));
 			}
-			return List.copyOf(result);
+			return Collections.unmodifiableList(result);
 		}
 		return value;
 	}
@@ -807,7 +807,7 @@ final class ProxyConfigurationFileService {
 				result.add(resolveList(list, oldValues, itemPath));
 			} else result.add(value);
 		}
-		return List.copyOf(result);
+		return Collections.unmodifiableList(result);
 	}
 
 	private static boolean secret(String path, String key, Object value) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -1076,7 +1076,7 @@ final class ProxyConfigurationFileService {
 	}
 
 	private static boolean secret(String path, String key, Object value) {
-		String normalized = key.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
+		String normalized = normalizeSecretName(key);
 		if (normalized.contains("password") || normalized.contains("passphrase") || normalized.contains("secret")
 				|| normalized.contains("token") || normalized.contains("credential")
 				|| normalized.contains("apikey") || normalized.contains("accesskey")
@@ -1116,6 +1116,12 @@ final class ProxyConfigurationFileService {
 			return lowered.startsWith("jdbc:") || lowered.matches("^[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*");
 		}
 		return false;
+	}
+
+	/** Normalizes the separators accepted in credential field names before classification. */
+	private static String normalizeSecretName(String value) {
+		return value.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replace(".", "")
+				.replaceAll("\\s+", "");
 	}
 
 	private static boolean rootDatabaseField(String normalizedPath) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -697,10 +697,8 @@ final class ProxyConfigurationFileService {
 
 	private static void restoreRedactedComments(Node proposed, Map<String, CommentLine> expected) {
 		Map<String, CommentReference> comments = commentReferences(proposed, "root");
-		List<String> expectedOwners = expected.keySet().stream().map(ProxyConfigurationFileService::commentOwner).toList();
-		List<String> proposedOwners = comments.entrySet().stream()
-				.filter(entry -> REDACTED_COMMENT.equals(entry.getValue().line().getValue()))
-				.map(entry -> commentOwner(entry.getKey())).toList();
+		Map<String, Integer> expectedOwners = expectedRedactedCommentCountsByOwner(expected);
+		Map<String, Integer> proposedOwners = redactedCommentCountsByOwner(comments);
 		if (!expectedOwners.equals(proposedOwners)) throw new IllegalArgumentException("redacted placeholder is invalid");
 		Map<String, List<CommentLine>> originals = new LinkedHashMap<>();
 		for (Map.Entry<String, CommentLine> entry : expected.entrySet()) {
@@ -718,6 +716,24 @@ final class ProxyConfigurationFileService {
 
 	private static String commentOwner(String slot) {
 		return slot.substring(0, slot.lastIndexOf('|'));
+	}
+
+	private static Map<String, Integer> redactedCommentCountsByOwner(
+			Map<String, ? extends CommentReference> comments) {
+		Map<String, Integer> result = new LinkedHashMap<>();
+		for (Map.Entry<String, ? extends CommentReference> entry : comments.entrySet()) {
+			if (!REDACTED_COMMENT.equals(entry.getValue().line().getValue())) continue;
+			result.merge(commentOwner(entry.getKey()), 1, Integer::sum);
+		}
+		return result;
+	}
+
+	private static Map<String, Integer> expectedRedactedCommentCountsByOwner(Map<String, CommentLine> comments) {
+		Map<String, Integer> result = new LinkedHashMap<>();
+		for (Map.Entry<String, CommentLine> entry : comments.entrySet()) {
+			result.merge(commentOwner(entry.getKey()), 1, Integer::sum);
+		}
+		return result;
 	}
 
 	private static Map<String, CommentReference> commentReferences(Node root, String path) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -439,9 +439,11 @@ final class ProxyConfigurationFileService {
 			for (int index = 0; index < proposed.size(); index++) {
 				Object old = current.get(index);
 				String itemPath = path + "[" + index + "]";
-				boolean retained = secret(itemPath, "", old)
-						? REDACTED.equals(proposed.get(index))
-						: retainsOrReplacesSecretValues(proposed.get(index), old, itemPath);
+				if (secret(itemPath, "", old)
+						&& current.subList(proposed.size(), current.size()).contains(proposed.get(index))) {
+					throw new IllegalArgumentException("redacted placeholder is invalid");
+				}
+				boolean retained = retainsOrReplacesSecretValues(proposed.get(index), old, itemPath);
 				if (secretBearingValue(old, itemPath) && !retained) {
 					throw new IllegalArgumentException("redacted placeholder is invalid");
 				}
@@ -991,9 +993,7 @@ final class ProxyConfigurationFileService {
 						&& !hasUniqueStableIdentity(proposedList, currentList, i)) return false;
 				if (proposedList.size() < currentList.size()
 						&& secretBearingValue(currentList.get(i), path + "[" + i + "]")
-						&& !(secret(path + "[" + i + "]", "", currentList.get(i))
-								? REDACTED.equals(proposedList.get(i))
-								: retainsOrReplacesSecretValues(proposedList.get(i), currentList.get(i), path + "[" + i + "]"))) return false;
+						&& !retainsOrReplacesSecretValues(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
 			}
 			if (proposedList.size() < currentList.size()) {
 				for (int i = proposedList.size(); i < currentList.size(); i++) {
@@ -1141,8 +1141,7 @@ final class ProxyConfigurationFileService {
 
 	/** Normalizes the separators accepted in credential field names before classification. */
 	private static String normalizeSecretName(String value) {
-		return value.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replace(".", "")
-				.replaceAll("\\s+", "");
+		return value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "");
 	}
 
 	private static boolean compoundInfrastructureField(String key) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -50,6 +52,9 @@ final class ProxyConfigurationFileService {
 	static final String REDACTED = "__VOTINGPLUGIN_CONTROL_REDACTED__";
 	static final int MAX_BYTES = 512 * 1024;
 	private static final String REDACTED_COMMENT = " " + REDACTED;
+	private static final Pattern LABELED_COMMENT_DETAIL = Pattern.compile("([A-Za-z0-9 _-]+)\\s*[:=]");
+	private static final Pattern BARE_NETWORK_ADDRESS = Pattern.compile(
+			"(?i)(?<![a-z0-9_-])(?:(?:\\d{1,3}\\.){3}\\d{1,3}|(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{2,63}|(?=[0-9a-f:]*:[0-9a-f:]*:)[0-9a-f:]{3,})(?![a-z0-9_:-])");
 	private final Path target;
 	private final MoveAction mover;
 	private final TempFileAction tempFiles;
@@ -687,10 +692,47 @@ final class ProxyConfigurationFileService {
 	private static boolean sensitiveComment(String comment, boolean sensitiveContext, Set<String> values) {
 		if (sensitiveContext) return true;
 		String lowered = comment.toLowerCase(Locale.ROOT);
-		if (lowered.matches("(?s).*\\b(password|secret|token|api[ _-]?key|authorization|jdbc|webhook)\\b.*")
-				|| lowered.matches("(?s).*[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*")) return true;
+		if (lowered.matches("(?s).*\\b(password|passphrase|secret|token|credentials?|api[ _-]?key|access[ _-]?key|private[ _-]?key|client[ _-]?secret|signing[ _-]?key|authorization|jdbc|webhook)\\b.*")
+				|| lowered.matches("(?s).*[a-z][a-z0-9+.-]*://[^/@\\s]+:[^/@\\s]+@.*")
+				|| labeledSensitiveDetail(comment)
+				|| BARE_NETWORK_ADDRESS.matcher(comment).find()
+				|| lowered.matches("(?s).*\\b(?:jdbc:[a-z][a-z0-9+.-]*:|[a-z][a-z0-9+.-]*://)[^\\s#]+.*")) return true;
 		for (String value : values) {
 			if (lowered.contains(value.toLowerCase(Locale.ROOT))) return true;
+		}
+		return false;
+	}
+
+	private static boolean labeledSensitiveDetail(String comment) {
+		Matcher details = LABELED_COMMENT_DETAIL.matcher(comment);
+		while (details.find()) {
+			if (!comment.substring(details.end()).trim().isEmpty() && sensitiveCommentLabel(details.group(1))) return true;
+		}
+		return false;
+	}
+
+	private static boolean sensitiveCommentLabel(String rawLabel) {
+		String label = rawLabel
+				.replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
+				.replaceAll("([a-z0-9])([A-Z])", "$1 $2")
+				.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", " ").trim();
+		if (label.isEmpty()) return false;
+		Set<String> sensitiveLabels = Set.of("host", "hostname", "endpoint", "address", "port", "server", "broker",
+				"database", "db", "schema", "socket", "proxy", "redis", "mysql", "mqtt", "bungee", "connection",
+				"uri", "url", "ip", "ipv4", "ipv6", "password", "passphrase", "secret", "token", "authorization", "apikey", "webhook",
+				"credential", "credentials", "accesskey", "privatekey", "clientsecret", "signingkey", "bearer");
+		for (String token : label.split(" +")) {
+			if (sensitiveLabels.contains(token)) return true;
+		}
+		String compact = label.replace(" ", "");
+		for (String fragment : Set.of("privatekey", "accesskey", "apikey", "clientsecret", "signingkey")) {
+			if (compact.contains(fragment)) return true;
+		}
+		for (String suffix : Set.of("host", "hostname", "endpoint", "address", "port", "server", "broker", "database",
+				"dbname", "schema", "socket", "proxy", "redis", "mysql", "mqtt", "bungee", "connection", "uri",
+				"url", "ipv4", "ipv6", "password", "passphrase", "secret", "token", "authorization", "apikey", "webhook",
+				"credential", "credentials", "accesskey", "privatekey", "clientsecret", "signingkey", "bearer")) {
+			if (compact.endsWith(suffix)) return true;
 		}
 		return false;
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -824,7 +824,7 @@ final class ProxyConfigurationFileService {
 				|| infrastructurePath(normalizedPath, "votelogging")
 				|| infrastructurePath(normalizedPath, "redis")
 				|| infrastructurePath(normalizedPath, "multiproxyredis")) {
-			return Set.of("host", "port", "database", "username", "password", "line", "driver", "poolname",
+			return Set.of("host", "port", "database", "name", "username", "password", "line", "driver", "poolname",
 					"prefix", "dbindex")
 					.contains(normalized);
 		}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -697,18 +697,27 @@ final class ProxyConfigurationFileService {
 
 	private static void restoreRedactedComments(Node proposed, Map<String, CommentLine> expected) {
 		Map<String, CommentReference> comments = commentReferences(proposed, "root");
+		List<String> expectedOwners = expected.keySet().stream().map(ProxyConfigurationFileService::commentOwner).toList();
+		List<String> proposedOwners = comments.entrySet().stream()
+				.filter(entry -> REDACTED_COMMENT.equals(entry.getValue().line().getValue()))
+				.map(entry -> commentOwner(entry.getKey())).toList();
+		if (!expectedOwners.equals(proposedOwners)) throw new IllegalArgumentException("redacted placeholder is invalid");
+		Map<String, List<CommentLine>> originals = new LinkedHashMap<>();
 		for (Map.Entry<String, CommentLine> entry : expected.entrySet()) {
-			CommentReference reference = comments.get(entry.getKey());
-			if (reference == null || !REDACTED_COMMENT.equals(reference.line().getValue())) {
-				throw new IllegalArgumentException("redacted placeholder is invalid");
-			}
-			reference.replace(entry.getValue());
+			originals.computeIfAbsent(commentOwner(entry.getKey()), ignored -> new ArrayList<>()).add(entry.getValue());
 		}
+		Map<String, Integer> indexes = new LinkedHashMap<>();
 		for (Map.Entry<String, CommentReference> entry : comments.entrySet()) {
-			if (REDACTED_COMMENT.equals(entry.getValue().line().getValue()) && !expected.containsKey(entry.getKey())) {
-				throw new IllegalArgumentException("redacted placeholder is invalid");
-			}
+			if (!REDACTED_COMMENT.equals(entry.getValue().line().getValue())) continue;
+			String owner = commentOwner(entry.getKey());
+			int index = indexes.getOrDefault(owner, 0);
+			entry.getValue().replace(originals.get(owner).get(index));
+			indexes.put(owner, index + 1);
 		}
+	}
+
+	private static String commentOwner(String slot) {
+		return slot.substring(0, slot.lastIndexOf('|'));
 	}
 
 	private static Map<String, CommentReference> commentReferences(Node root, String path) {
@@ -1101,10 +1110,15 @@ final class ProxyConfigurationFileService {
 				|| normalized.contains("token") || normalized.contains("credential")
 				|| normalized.contains("apikey") || normalized.contains("accesskey")
 				|| normalized.contains("privatekey") || normalized.contains("signingkey")
-				|| normalized.contains("authorization")
-				|| normalized.contains("webhookurl")) return true;
+				|| normalized.contains("authorization")) return true;
+		if (normalized.contains("webhook")) return !(value instanceof Map<?, ?>) && !(value instanceof List<?>);
 		if (!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && compoundInfrastructureField(key)) return true;
 		String normalizedPath = path.toLowerCase(Locale.ROOT).replace("_", "").replace("-", "").replaceAll("\\s+", "");
+		if (value instanceof String text && normalizedPath.contains("webhook")) {
+			String lowered = text.trim().toLowerCase(Locale.ROOT);
+			if (Set.of("url", "uri", "endpoint", "address", "callback").contains(normalized)
+					|| lowered.startsWith("http://") || lowered.startsWith("https://")) return true;
+		}
 		if ((!(value instanceof Map<?, ?>) && !(value instanceof List<?>) && rootDatabaseField(normalizedPath))
 				|| infrastructurePath(normalizedPath, "database")
 				|| infrastructurePath(normalizedPath, "mysql") || infrastructurePath(normalizedPath, "globaldata")

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -1104,7 +1104,7 @@ final class ProxyConfigurationFileService {
 				|| infrastructurePath(normalizedPath, "votelogging")
 				|| infrastructurePath(normalizedPath, "redis")
 				|| infrastructurePath(normalizedPath, "multiproxyredis")) {
-			return Set.of("host", "port", "database", "name", "username", "password", "line", "driver", "poolname",
+			return Set.of("host", "port", "database", "name", "user", "username", "password", "line", "driver", "poolname",
 					"prefix", "dbindex")
 					.contains(normalized);
 		}
@@ -1143,18 +1143,23 @@ final class ProxyConfigurationFileService {
 		if (words.isEmpty()) return false;
 		String[] tokens = words.split(" +");
 		String last = tokens[tokens.length - 1];
+		String compact = words.replace(" ", "");
+		if (compact.matches("^(database|db|mysql|redis|mqtt)(user|username)$")) return true;
 		if (tokens.length > 1 && Set.of("host", "endpoint", "address", "port", "broker", "database", "schema",
 				"socket", "uri", "url", "ipv4", "ipv6").contains(last)) return true;
 		if (tokens.length > 2 && "name".equals(last)
 				&& Set.of("host", "db").contains(tokens[tokens.length - 2])) return true;
-		String compact = words.replace(" ", "");
+		if (tokens.length > 1 && Set.of("user", "username").contains(last)
+				&& Set.of("database", "db", "mysql", "redis", "mqtt").contains(tokens[tokens.length - 2])) return true;
+		if (tokens.length > 2 && "name".equals(last) && "user".equals(tokens[tokens.length - 2])
+				&& Set.of("database", "db", "mysql", "redis", "mqtt").contains(tokens[tokens.length - 3])) return true;
 		return Set.of("dburl", "dbport", "dbhost", "dbname", "apiurl", "apiuri", "redisport", "redishost",
 				"mysqlport", "mysqlhost", "mqttport", "mqtthost").contains(compact);
 	}
 
 	private static boolean rootDatabaseField(String normalizedPath) {
 		return !normalizedPath.contains(".") && !normalizedPath.contains("[")
-				&& Set.of("host", "port", "database", "name", "username", "password", "line", "driver", "poolname",
+				&& Set.of("host", "port", "database", "name", "user", "username", "password", "line", "driver", "poolname",
 						"prefix", "dbindex").contains(normalizedPath);
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileService.java
@@ -783,6 +783,8 @@ final class ProxyConfigurationFileService {
 
 	@SuppressWarnings("unchecked")
 	private static List<Object> resolveList(List<?> proposed, List<?> current, String path) {
+		if (containsSecrets(current, path) && !sameSecretSafeListOrder(proposed, current, path))
+			throw new IllegalArgumentException("reordering lists containing redacted secrets is not supported");
 		List<Object> result = new ArrayList<>();
 		for (int index = 0; index < proposed.size(); index++) {
 			Object value = proposed.get(index);
@@ -808,6 +810,33 @@ final class ProxyConfigurationFileService {
 			} else result.add(value);
 		}
 		return Collections.unmodifiableList(result);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static boolean sameSecretSafeListOrder(Object proposed, Object current, String path) {
+		if (REDACTED.equals(proposed)) return true;
+		if (proposed instanceof Map<?, ?> proposedMap && current instanceof Map<?, ?> currentMap) {
+			if (!proposedMap.keySet().equals(currentMap.keySet())) return false;
+			String mapPath = path.endsWith(".") ? path : path + ".";
+			for (Object rawKey : proposedMap.keySet()) {
+				String key = String.valueOf(rawKey);
+				Object old = currentMap.get(rawKey);
+				Object candidate = proposedMap.get(rawKey);
+				if (secret(mapPath + key, key, old)) {
+					if (!REDACTED.equals(candidate)) return false;
+				} else if (!sameSecretSafeListOrder(candidate, old, mapPath + key)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if (proposed instanceof List<?> proposedList && current instanceof List<?> currentList) {
+			if (proposedList.size() != currentList.size()) return false;
+			for (int i = 0; i < proposedList.size(); i++)
+				if (!sameSecretSafeListOrder(proposedList.get(i), currentList.get(i), path + "[" + i + "]")) return false;
+			return true;
+		}
+		return java.util.Objects.equals(proposed, current);
 	}
 
 	private static boolean secret(String path, String key, Object value) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -25,7 +25,9 @@ import com.google.gson.JsonParser;
 /** Durable result journal for proxy-routing operations accepted by a specific Control node. */
 final class ProxyControlResultStore {
 	private static final int VERSION = 2;
-	private static final int MAX_BYTES = 256 * 1024;
+	/** Matches the bounded Control response envelope, including escaped managed-file content. */
+	private static final int MAX_BYTES = 4 * 1024 * 1024;
+	private static final int MAX_RESULT_BYTES = MAX_BYTES;
 	private static final int MAX_RESULTS = 128;
 	private static final String FILE_NAME = ".control-proxy-pending-results.json";
 
@@ -68,8 +70,10 @@ final class ProxyControlResultStore {
 				UUID operationId = UUID.fromString(string(item, "operationId"));
 				if (!item.has("committed") || !item.get("committed").isJsonPrimitive()
 						|| !item.has("claimRequired") || !item.get("claimRequired").isJsonPrimitive()) throw invalid();
+				JsonObject result = object(item, "result");
+				if (result.toString().getBytes(StandardCharsets.UTF_8).length > MAX_RESULT_BYTES) throw invalid();
 				StoredResult previous = results.put(operationId,
-						new StoredResult(object(item, "result").deepCopy(), item.get("committed").getAsBoolean(),
+						new StoredResult(result.deepCopy(), item.get("committed").getAsBoolean(),
 								item.get("claimRequired").getAsBoolean()));
 				if (previous != null) throw invalid();
 			}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -140,6 +140,7 @@ final class ProxyControlResultStore {
 				throw new IOException("Too many pending Control coordinator routes");
 			routes.put(identity, new RouteEntry(route, copiedResults, routeRequired));
 		}
+		if (totalResults(routes) > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
 
 		byte[] bytes = serialize(routes);
 		if (bytes.length > MAX_JOURNAL_BYTES) throw new IOException("Control proxy-result journal is too large");
@@ -216,7 +217,14 @@ final class ProxyControlResultStore {
 			if (routes.size() >= MAX_ROUTES
 					|| routes.put(route.identity(), new RouteEntry(route, results, routeRequired)) != null) throw invalid();
 		}
+		if (totalResults(routes) > MAX_RESULTS) throw invalid();
 		return new Journal(routes);
+	}
+
+	private static int totalResults(Map<String, RouteEntry> routes) {
+		long total = 0;
+		for (RouteEntry entry : routes.values()) total += entry.results().size();
+		return total > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) total;
 	}
 
 	private static Route parseRoute(JsonObject routeJson) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -11,8 +11,11 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -22,18 +25,144 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-/** Durable result journal for proxy-routing operations accepted by a specific Control node. */
+/**
+ * Durable result journal for proxy-routing operations accepted by Control nodes.
+ *
+ * <p>The journal is intentionally a single bounded file. A result is kept under
+ * the stable identity of the coordinator that accepted its operation, so changing
+ * plugin version, heartbeat, or HTTP timeouts cannot move it to another route.
+ * Saving one route merges it into the existing journal; it never replaces other
+ * coordinators' results.</p>
+ */
 final class ProxyControlResultStore {
-	private static final int VERSION = 2;
+	private static final int LEGACY_VERSION = 2;
+	private static final int VERSION = 3;
 	/** Matches the bounded Control response envelope, including escaped managed-file content. */
 	private static final int MAX_BYTES = 4 * 1024 * 1024;
 	private static final int MAX_RESULT_BYTES = MAX_BYTES;
+	/** Global bound across every coordinator route in this journal. */
 	private static final int MAX_RESULTS = 128;
 	private static final String FILE_NAME = ".control-proxy-pending-results.json";
 
 	private ProxyControlResultStore() { }
 
+	/**
+	 * Loads one route for legacy callers which only have a single connector. New
+	 * code should use {@link #loadForRoute(Path, Route)} so another coordinator's
+	 * results can never be imported accidentally.
+	 */
 	static State load(Path dataDirectory) throws IOException {
+		Journal journal = loadJournal(dataDirectory);
+		if (journal == null || journal.routes().isEmpty()) return null;
+		return state(journal.routes().values().iterator().next());
+	}
+
+	/** Loads only results belonging to the requested stable coordinator identity. */
+	static State loadForRoute(Path dataDirectory, Route route) throws IOException {
+		Objects.requireNonNull(route, "route");
+		Journal journal = loadJournal(dataDirectory);
+		if (journal == null) return null;
+		RouteEntry entry = journal.routes().get(route.identity());
+		return entry == null ? null : state(entry);
+	}
+
+	/**
+	 * Returns one route which still requires its originating coordinator. This is
+	 * only a compatibility fallback for startup while Control is disabled; enabled
+	 * connectors must always call {@link #loadForRoute(Path, Route)}.
+	 */
+	static State loadRequired(Path dataDirectory) throws IOException {
+		Journal journal = loadJournal(dataDirectory);
+		if (journal == null) return null;
+		for (RouteEntry entry : journal.routes().values()) {
+			if (entry.routeRequired()) return state(entry);
+		}
+		return null;
+	}
+
+	/**
+	 * Selects the next route a configured connector must drive. Required recovery
+	 * routes take precedence so configuration changes cannot strand their results;
+	 * once they drain, the connector restart advances to the next route and finally
+	 * returns to the configured coordinator.
+	 */
+	static State loadPreferred(Path dataDirectory, Route configuredRoute) throws IOException {
+		Objects.requireNonNull(configuredRoute, "configuredRoute");
+		Journal journal = loadJournal(dataDirectory);
+		if (journal == null) return null;
+		for (RouteEntry entry : journal.routes().values()) {
+			if (entry.routeRequired()) return state(entry);
+		}
+		RouteEntry configured = journal.routes().get(configuredRoute.identity());
+		return configured == null ? null : state(configured);
+	}
+
+	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results) throws IOException {
+		save(dataDirectory, route, results, true);
+	}
+
+	/**
+	 * Replaces only the requested route's results and atomically writes the merged
+	 * global journal. If the global result or byte bound would be exceeded, this
+	 * method fails before touching the existing file; unacknowledged results are
+	 * never evicted to make room.
+	 */
+	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results, boolean routeRequired)
+			throws IOException {
+		Objects.requireNonNull(dataDirectory, "dataDirectory");
+		Objects.requireNonNull(route, "route");
+		Objects.requireNonNull(results, "results");
+		if (results.size() > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
+
+		Path target = target(dataDirectory);
+		Journal journal = loadJournal(dataDirectory);
+		LinkedHashMap<String, RouteEntry> routes = journal == null
+				? new LinkedHashMap<>() : new LinkedHashMap<>(journal.routes());
+		String identity = route.identity();
+		if (results.isEmpty()) {
+			if (Files.isSymbolicLink(target)) throw new IOException("Control proxy-result journal is unsafe");
+			routes.remove(identity);
+			if (routes.isEmpty()) {
+				DurableFiles.deleteIfExists(target);
+				return;
+			}
+		} else {
+			LinkedHashMap<UUID, StoredResult> copiedResults = new LinkedHashMap<>();
+			results.forEach((operationId, result) -> {
+				if (operationId == null || result == null) throw invalid();
+				copiedResults.put(operationId, result);
+			});
+			// Keep the newest runtime metadata for the same stable coordinator. The
+			// identity itself deliberately excludes mutable timing/version fields.
+			routes.put(identity, new RouteEntry(route, copiedResults, routeRequired));
+		}
+
+		int resultCount = routes.values().stream().mapToInt(entry -> entry.results().size()).sum();
+		if (resultCount > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
+		byte[] bytes = serialize(routes);
+		if (bytes.length > MAX_BYTES) throw new IOException("Control proxy-result journal is too large");
+
+		Files.createDirectories(dataDirectory);
+		if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)
+				&& (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target))) {
+			throw new IOException("Control proxy-result journal is unsafe");
+		}
+		Path staging = Files.createTempFile(dataDirectory, ".control-proxy-results-", ".json");
+		try {
+			try (FileChannel channel = FileChannel.open(staging, StandardOpenOption.TRUNCATE_EXISTING,
+					StandardOpenOption.WRITE)) {
+				ByteBuffer buffer = ByteBuffer.wrap(bytes);
+				while (buffer.hasRemaining()) channel.write(buffer);
+				channel.force(true);
+			}
+			Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			DurableFiles.forceDirectory(dataDirectory);
+		} finally {
+			Files.deleteIfExists(staging);
+		}
+	}
+
+	private static Journal loadJournal(Path dataDirectory) throws IOException {
 		Path target = target(dataDirectory);
 		if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) return null;
 		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target)
@@ -54,56 +183,96 @@ final class ProxyControlResultStore {
 			JsonElement parsed = JsonParser.parseString(new String(bytes, StandardCharsets.UTF_8));
 			if (!parsed.isJsonObject()) throw invalid();
 			JsonObject root = parsed.getAsJsonObject();
-			if (integer(root, "version") != VERSION) throw invalid();
-			boolean routeRequired = !root.has("routeRequired") || bool(root, "routeRequired");
-			JsonObject routeJson = object(root, "route");
-			Route route = new Route(string(routeJson, "nodeId"), string(routeJson, "displayName"),
-					string(routeJson, "platform"), string(routeJson, "pluginVersion"),
-					URI.create(string(routeJson, "endpoint")), string(routeJson, "credentialFile"),
-					integer(routeJson, "heartbeatSeconds"), integer(routeJson, "connectTimeoutMillis"),
-					integer(routeJson, "requestTimeoutMillis"));
-			JsonArray listed = array(root, "results");
-			if (listed.size() == 0 || listed.size() > MAX_RESULTS) throw invalid();
-			Map<UUID, StoredResult> results = new LinkedHashMap<>();
-			for (JsonElement element : listed) {
-				if (!element.isJsonObject()) throw invalid();
-				JsonObject item = element.getAsJsonObject();
-				UUID operationId = UUID.fromString(string(item, "operationId"));
-				if (!item.has("committed") || !item.get("committed").isJsonPrimitive()
-						|| !item.has("claimRequired") || !item.get("claimRequired").isJsonPrimitive()) throw invalid();
-				JsonObject result = object(item, "result");
-				if (result.toString().getBytes(StandardCharsets.UTF_8).length > MAX_RESULT_BYTES) throw invalid();
-				StoredResult previous = results.put(operationId,
-						new StoredResult(result.deepCopy(), item.get("committed").getAsBoolean(),
-								item.get("claimRequired").getAsBoolean()));
-				if (previous != null) throw invalid();
-			}
-			return new State(route, Map.copyOf(results), routeRequired);
+			int version = integer(root, "version");
+			if (version == LEGACY_VERSION) return legacyJournal(root);
+			if (version == VERSION) return currentJournal(root);
+			throw invalid();
 		} catch (RuntimeException e) {
 			throw new IOException("Control proxy-result journal is malformed", e);
 		}
 	}
 
-	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results) throws IOException {
-		save(dataDirectory, route, results, true);
+	private static Journal legacyJournal(JsonObject root) {
+		Route route = parseRoute(object(root, "route"));
+		boolean routeRequired = !root.has("routeRequired") || bool(root, "routeRequired");
+		Map<UUID, StoredResult> results = parseResults(array(root, "results"));
+		LinkedHashMap<String, RouteEntry> routes = new LinkedHashMap<>();
+		routes.put(route.identity(), new RouteEntry(route, results, routeRequired));
+		return new Journal(routes);
 	}
 
-	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results, boolean routeRequired)
-			throws IOException {
-		Path target = target(dataDirectory);
-		if (results.isEmpty()) {
-			if (Files.isSymbolicLink(target)) throw new IOException("Control proxy-result journal is unsafe");
-			DurableFiles.deleteIfExists(target);
-			return;
+	private static Journal currentJournal(JsonObject root) {
+		JsonArray listedRoutes = array(root, "routes");
+		if (listedRoutes.size() == 0) throw invalid();
+		LinkedHashMap<String, RouteEntry> routes = new LinkedHashMap<>();
+		int resultCount = 0;
+		for (JsonElement element : listedRoutes) {
+			if (!element.isJsonObject()) throw invalid();
+			JsonObject listed = element.getAsJsonObject();
+			Route route = parseRoute(object(listed, "route"));
+			boolean routeRequired = bool(listed, "routeRequired");
+			Map<UUID, StoredResult> results = parseResults(array(listed, "results"));
+			if (routes.put(route.identity(), new RouteEntry(route, results, routeRequired)) != null) throw invalid();
+			resultCount += results.size();
+			if (resultCount > MAX_RESULTS) throw invalid();
 		}
-		if (results.size() > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
-		if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)
-				&& (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target))) {
-			throw new IOException("Control proxy-result journal is unsafe");
+		return new Journal(routes);
+	}
+
+	private static Route parseRoute(JsonObject routeJson) {
+		return new Route(string(routeJson, "nodeId"), string(routeJson, "displayName"),
+				string(routeJson, "platform"), string(routeJson, "pluginVersion"),
+				URI.create(string(routeJson, "endpoint")), string(routeJson, "credentialFile"),
+				integer(routeJson, "heartbeatSeconds"), integer(routeJson, "connectTimeoutMillis"),
+				integer(routeJson, "requestTimeoutMillis"));
+	}
+
+	private static Map<UUID, StoredResult> parseResults(JsonArray listed) {
+		if (listed.size() == 0 || listed.size() > MAX_RESULTS) throw invalid();
+		LinkedHashMap<UUID, StoredResult> results = new LinkedHashMap<>();
+		for (JsonElement element : listed) {
+			if (!element.isJsonObject()) throw invalid();
+			JsonObject item = element.getAsJsonObject();
+			UUID operationId = UUID.fromString(string(item, "operationId"));
+			boolean committed = bool(item, "committed");
+			boolean claimRequired = bool(item, "claimRequired");
+			JsonObject result = object(item, "result");
+			if (result.toString().getBytes(StandardCharsets.UTF_8).length > MAX_RESULT_BYTES) throw invalid();
+			StoredResult previous = results.put(operationId,
+					new StoredResult(result.deepCopy(), committed, claimRequired));
+			if (previous != null) throw invalid();
 		}
+		return Collections.unmodifiableMap(new LinkedHashMap<>(results));
+	}
+
+	private static byte[] serialize(Map<String, RouteEntry> routes) {
 		JsonObject root = new JsonObject();
 		root.addProperty("version", VERSION);
-		root.addProperty("routeRequired", routeRequired);
+		JsonArray listedRoutes = new JsonArray();
+		for (RouteEntry entry : routes.values()) {
+			JsonObject listed = new JsonObject();
+			listed.add("route", routeJson(entry.route()));
+			listed.addProperty("routeRequired", entry.routeRequired());
+			JsonArray listedResults = new JsonArray();
+			for (Map.Entry<UUID, StoredResult> resultEntry : entry.results().entrySet()) {
+				UUID operationId = resultEntry.getKey();
+				StoredResult result = resultEntry.getValue();
+				if (operationId == null || result == null) throw invalid();
+				JsonObject item = new JsonObject();
+				item.addProperty("operationId", operationId.toString());
+				item.add("result", result.result().deepCopy());
+				item.addProperty("committed", result.committed());
+				item.addProperty("claimRequired", result.claimRequired());
+				listedResults.add(item);
+			}
+			listed.add("results", listedResults);
+			listedRoutes.add(listed);
+		}
+		root.add("routes", listedRoutes);
+		return root.toString().getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static JsonObject routeJson(Route route) {
 		JsonObject routeJson = new JsonObject();
 		routeJson.addProperty("nodeId", route.nodeId());
 		routeJson.addProperty("displayName", route.displayName());
@@ -114,33 +283,11 @@ final class ProxyControlResultStore {
 		routeJson.addProperty("heartbeatSeconds", route.heartbeatSeconds());
 		routeJson.addProperty("connectTimeoutMillis", route.connectTimeoutMillis());
 		routeJson.addProperty("requestTimeoutMillis", route.requestTimeoutMillis());
-		root.add("route", routeJson);
-		JsonArray listed = new JsonArray();
-		results.forEach((operationId, result) -> {
-			JsonObject item = new JsonObject();
-			item.addProperty("operationId", operationId.toString());
-			item.add("result", result.result().deepCopy());
-			item.addProperty("committed", result.committed());
-			item.addProperty("claimRequired", result.claimRequired());
-			listed.add(item);
-		});
-		root.add("results", listed);
-		byte[] bytes = root.toString().getBytes(StandardCharsets.UTF_8);
-		if (bytes.length > MAX_BYTES) throw new IOException("Control proxy-result journal is too large");
-		Files.createDirectories(dataDirectory);
-		Path staging = Files.createTempFile(dataDirectory, ".control-proxy-results-", ".json");
-		try {
-			try (FileChannel channel = FileChannel.open(staging, StandardOpenOption.TRUNCATE_EXISTING,
-					StandardOpenOption.WRITE)) {
-				ByteBuffer buffer = ByteBuffer.wrap(bytes);
-				while (buffer.hasRemaining()) channel.write(buffer);
-				channel.force(true);
-			}
-			Files.move(staging, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-			DurableFiles.forceDirectory(dataDirectory);
-		} finally {
-			Files.deleteIfExists(staging);
-		}
+		return routeJson;
+	}
+
+	private static State state(RouteEntry entry) {
+		return new State(entry.route(), entry.results(), entry.routeRequired());
 	}
 
 	private static Path target(Path dataDirectory) {
@@ -158,14 +305,16 @@ final class ProxyControlResultStore {
 	}
 
 	private static String string(JsonObject object, String name) {
-		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
+		if (!object.has(name) || !object.get(name).isJsonPrimitive()
+				|| !object.getAsJsonPrimitive(name).isString()) throw invalid();
 		String value = object.get(name).getAsString();
 		if (value == null || value.isBlank() || value.length() > 2048) throw invalid();
 		return value;
 	}
 
 	private static int integer(JsonObject object, String name) {
-		if (!object.has(name) || !object.get(name).isJsonPrimitive()) throw invalid();
+		if (!object.has(name) || !object.get(name).isJsonPrimitive()
+				|| !object.getAsJsonPrimitive(name).isNumber()) throw invalid();
 		return object.get(name).getAsInt();
 	}
 
@@ -179,12 +328,43 @@ final class ProxyControlResultStore {
 		return new IllegalArgumentException("invalid proxy-result journal");
 	}
 
+	private static String stableEndpoint(URI endpoint) {
+		Objects.requireNonNull(endpoint, "endpoint");
+		String scheme = endpoint.getScheme().toLowerCase(Locale.ROOT);
+		String host = endpoint.getHost();
+		if (host == null) return endpoint.normalize().toString();
+		host = host.toLowerCase(Locale.ROOT);
+		if (host.startsWith("[") && host.endsWith("]")) host = host.substring(1, host.length() - 1);
+		if (host.indexOf(':') >= 0) host = "[" + host + "]";
+		int port = endpoint.getPort();
+		boolean defaultPort = ("http".equals(scheme) && port == 80) || ("https".equals(scheme) && port == 443);
+		StringBuilder identity = new StringBuilder(scheme).append("://").append(host);
+		if (port >= 0 && !defaultPort) identity.append(':').append(port);
+		String path = endpoint.getRawPath();
+		if (path != null && !path.isEmpty() && !"/".equals(path)) identity.append(path);
+		if (endpoint.getRawQuery() != null) identity.append('?').append(endpoint.getRawQuery());
+		if (endpoint.getRawFragment() != null) identity.append('#').append(endpoint.getRawFragment());
+		return identity.toString();
+	}
+
 	record Route(String nodeId, String displayName, String platform, String pluginVersion, URI endpoint,
-			String credentialFile, int heartbeatSeconds, int connectTimeoutMillis, int requestTimeoutMillis) { }
-	record StoredResult(JsonObject result, boolean committed, boolean claimRequired) {
-		StoredResult {
-			if (committed && claimRequired) throw new IllegalArgumentException("committed result cannot require a claim");
+			String credentialFile, int heartbeatSeconds, int connectTimeoutMillis, int requestTimeoutMillis) {
+		String identity() {
+			return nodeId.trim() + "\n" + stableEndpoint(endpoint) + "\n"
+					+ platform.trim().toUpperCase(Locale.ROOT);
 		}
 	}
+
+	record StoredResult(JsonObject result, boolean committed, boolean claimRequired) {
+		StoredResult {
+			if (result == null || (committed && claimRequired)) {
+				throw new IllegalArgumentException("invalid proxy-result state");
+			}
+		}
+	}
+
 	record State(Route route, Map<UUID, StoredResult> results, boolean routeRequired) { }
+
+	private record RouteEntry(Route route, Map<UUID, StoredResult> results, boolean routeRequired) { }
+	private record Journal(LinkedHashMap<String, RouteEntry> routes) { }
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -39,6 +39,8 @@ final class ProxyControlResultStore {
 	private static final int VERSION = 3;
 	/** Matches the bounded Control response envelope, including escaped managed-file content. */
 	private static final int MAX_BYTES = 4 * 1024 * 1024;
+	private static final int MAX_ROUTES = 16;
+	private static final int MAX_JOURNAL_BYTES = MAX_ROUTES * MAX_BYTES;
 	private static final int MAX_RESULT_BYTES = MAX_BYTES;
 	/** Global bound across every coordinator route in this journal. */
 	private static final int MAX_RESULTS = 128;
@@ -134,13 +136,13 @@ final class ProxyControlResultStore {
 			});
 			// Keep the newest runtime metadata for the same stable coordinator. The
 			// identity itself deliberately excludes mutable timing/version fields.
+			if (!routes.containsKey(identity) && routes.size() >= MAX_ROUTES)
+				throw new IOException("Too many pending Control coordinator routes");
 			routes.put(identity, new RouteEntry(route, copiedResults, routeRequired));
 		}
 
-		int resultCount = routes.values().stream().mapToInt(entry -> entry.results().size()).sum();
-		if (resultCount > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
 		byte[] bytes = serialize(routes);
-		if (bytes.length > MAX_BYTES) throw new IOException("Control proxy-result journal is too large");
+		if (bytes.length > MAX_JOURNAL_BYTES) throw new IOException("Control proxy-result journal is too large");
 
 		Files.createDirectories(dataDirectory);
 		if (Files.exists(target, LinkOption.NOFOLLOW_LINKS)
@@ -166,7 +168,7 @@ final class ProxyControlResultStore {
 		Path target = target(dataDirectory);
 		if (!Files.exists(target, LinkOption.NOFOLLOW_LINKS)) return null;
 		if (!Files.isRegularFile(target, LinkOption.NOFOLLOW_LINKS) || Files.isSymbolicLink(target)
-				|| Files.size(target) > MAX_BYTES) {
+				|| Files.size(target) > MAX_JOURNAL_BYTES) {
 			throw new IOException("Control proxy-result journal is unsafe or too large");
 		}
 		byte[] bytes;
@@ -205,16 +207,14 @@ final class ProxyControlResultStore {
 		JsonArray listedRoutes = array(root, "routes");
 		if (listedRoutes.size() == 0) throw invalid();
 		LinkedHashMap<String, RouteEntry> routes = new LinkedHashMap<>();
-		int resultCount = 0;
 		for (JsonElement element : listedRoutes) {
 			if (!element.isJsonObject()) throw invalid();
 			JsonObject listed = element.getAsJsonObject();
 			Route route = parseRoute(object(listed, "route"));
 			boolean routeRequired = bool(listed, "routeRequired");
 			Map<UUID, StoredResult> results = parseResults(array(listed, "results"));
-			if (routes.put(route.identity(), new RouteEntry(route, results, routeRequired)) != null) throw invalid();
-			resultCount += results.size();
-			if (resultCount > MAX_RESULTS) throw invalid();
+			if (routes.size() >= MAX_ROUTES
+					|| routes.put(route.identity(), new RouteEntry(route, results, routeRequired)) != null) throw invalid();
 		}
 		return new Journal(routes);
 	}
@@ -266,6 +266,7 @@ final class ProxyControlResultStore {
 				listedResults.add(item);
 			}
 			listed.add("results", listedResults);
+			if (listed.toString().getBytes(StandardCharsets.UTF_8).length > MAX_BYTES) throw invalid();
 			listedRoutes.add(listed);
 		}
 		root.add("routes", listedRoutes);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -42,7 +42,7 @@ final class ProxyControlResultStore {
 	private static final int MAX_ROUTES = 16;
 	private static final int MAX_JOURNAL_BYTES = MAX_ROUTES * MAX_BYTES;
 	private static final int MAX_RESULT_BYTES = MAX_BYTES;
-	/** Global bound across every coordinator route in this journal. */
+	/** Per-coordinator-route bound. Released routes must not consume another route's capacity. */
 	private static final int MAX_RESULTS = 128;
 	private static final String FILE_NAME = ".control-proxy-pending-results.json";
 
@@ -105,9 +105,9 @@ final class ProxyControlResultStore {
 
 	/**
 	 * Replaces only the requested route's results and atomically writes the merged
-	 * global journal. If the global result or byte bound would be exceeded, this
-	 * method fails before touching the existing file; unacknowledged results are
-	 * never evicted to make room.
+	 * global journal. If the per-route or global byte bound would be exceeded,
+	 * this method fails before touching the existing file; unacknowledged results
+	 * are never evicted to make room.
 	 */
 	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results, boolean routeRequired)
 			throws IOException {
@@ -140,8 +140,6 @@ final class ProxyControlResultStore {
 				throw new IOException("Too many pending Control coordinator routes");
 			routes.put(identity, new RouteEntry(route, copiedResults, routeRequired));
 		}
-		if (totalResults(routes) > MAX_RESULTS) throw new IOException("Too many pending Control proxy results");
-
 		byte[] bytes = serialize(routes);
 		if (bytes.length > MAX_JOURNAL_BYTES) throw new IOException("Control proxy-result journal is too large");
 
@@ -217,14 +215,7 @@ final class ProxyControlResultStore {
 			if (routes.size() >= MAX_ROUTES
 					|| routes.put(route.identity(), new RouteEntry(route, results, routeRequired)) != null) throw invalid();
 		}
-		if (totalResults(routes) > MAX_RESULTS) throw invalid();
 		return new Journal(routes);
-	}
-
-	private static int totalResults(Map<String, RouteEntry> routes) {
-		long total = 0;
-		for (RouteEntry entry : routes.values()) total += entry.results().size();
-		return total > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) total;
 	}
 
 	private static Route parseRoute(JsonObject routeJson) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStore.java
@@ -55,6 +55,7 @@ final class ProxyControlResultStore {
 			if (!parsed.isJsonObject()) throw invalid();
 			JsonObject root = parsed.getAsJsonObject();
 			if (integer(root, "version") != VERSION) throw invalid();
+			boolean routeRequired = !root.has("routeRequired") || bool(root, "routeRequired");
 			JsonObject routeJson = object(root, "route");
 			Route route = new Route(string(routeJson, "nodeId"), string(routeJson, "displayName"),
 					string(routeJson, "platform"), string(routeJson, "pluginVersion"),
@@ -77,13 +78,18 @@ final class ProxyControlResultStore {
 								item.get("claimRequired").getAsBoolean()));
 				if (previous != null) throw invalid();
 			}
-			return new State(route, Map.copyOf(results));
+			return new State(route, Map.copyOf(results), routeRequired);
 		} catch (RuntimeException e) {
 			throw new IOException("Control proxy-result journal is malformed", e);
 		}
 	}
 
 	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results) throws IOException {
+		save(dataDirectory, route, results, true);
+	}
+
+	static void save(Path dataDirectory, Route route, Map<UUID, StoredResult> results, boolean routeRequired)
+			throws IOException {
 		Path target = target(dataDirectory);
 		if (results.isEmpty()) {
 			if (Files.isSymbolicLink(target)) throw new IOException("Control proxy-result journal is unsafe");
@@ -97,6 +103,7 @@ final class ProxyControlResultStore {
 		}
 		JsonObject root = new JsonObject();
 		root.addProperty("version", VERSION);
+		root.addProperty("routeRequired", routeRequired);
 		JsonObject routeJson = new JsonObject();
 		routeJson.addProperty("nodeId", route.nodeId());
 		routeJson.addProperty("displayName", route.displayName());
@@ -162,6 +169,12 @@ final class ProxyControlResultStore {
 		return object.get(name).getAsInt();
 	}
 
+	private static boolean bool(JsonObject object, String name) {
+		if (!object.has(name) || !object.get(name).isJsonPrimitive()
+				|| !object.getAsJsonPrimitive(name).isBoolean()) throw invalid();
+		return object.get(name).getAsBoolean();
+	}
+
 	private static IllegalArgumentException invalid() {
 		return new IllegalArgumentException("invalid proxy-result journal");
 	}
@@ -173,5 +186,5 @@ final class ProxyControlResultStore {
 			if (committed && claimRequired) throw new IllegalArgumentException("committed result cannot require a claim");
 		}
 	}
-	record State(Route route, Map<UUID, StoredResult> results) { }
+	record State(Route route, Map<UUID, StoredResult> results, boolean routeRequired) { }
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/proxy/velocity/VelocityConfig.java
@@ -131,6 +131,7 @@ public class VelocityConfig extends VelocityYMLFile implements VotingPluginProxy
 				if (!(failure instanceof DurableFiles.PublishedException)) controlInstalledSnapshot = null;
 				throw failure;
 			}
+			loadControlConfiguration();
 		} finally {
 			Files.deleteIfExists(stage);
 			if (backupStage != null) Files.deleteIfExists(backupStage);

--- a/VotingPlugin/src/main/resources/bungeeconfig.yml
+++ b/VotingPlugin/src/main/resources/bungeeconfig.yml
@@ -246,7 +246,8 @@ BlockedServers:
 WhiteListedServers: []
 
 # What type of bungee setup
-# Requires restart and set on all servers
+# Control can coordinate this method across the reported network after a successful preflight.
+# The proxy runtime is replaced only after its durable result is acknowledged.
 # https://github.com/BenCodez/VotingPlugin/wiki/Bungeecoord-Setups
 # Available:
 # PLUGINMESSAGING (Recommended)

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -715,6 +715,45 @@ class BackendConfigurationServiceTest {
 				Map.of("method", "PLUGINMESSAGING")));
 	}
 
+	@Test void proxyMethodApplyUsesOnlyTheTargetedRuntimeAction() throws Exception {
+		Path settings = directory.resolve("BungeeSettings.yml");
+		Files.writeString(settings, "UseBungeecord: true\nServer: lobby\nBungeeMethod: PLUGINMESSAGING\n"
+				+ "PluginMessageChannel: vp:vp\nRedis:\n  Host: localhost\n  Port: 6379\n");
+		AtomicInteger fullReloads = new AtomicInteger();
+		AtomicInteger transportSwitches = new AtomicInteger();
+		BackendConfigurationService service = new BackendConfigurationService(directory, fullReloads::incrementAndGet);
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("proxy-method",
+				Map.of("method", "REDIS"));
+
+		service.applyQuickSetup("proxy-method", Map.of("method", "REDIS"), preview.revision(),
+				ignored -> transportSwitches.incrementAndGet());
+
+		assertEquals(0, fullReloads.get());
+		assertEquals(1, transportSwitches.get());
+		assertTrue(Files.readString(settings).contains("BungeeMethod: REDIS"));
+	}
+
+	@Test void targetedProxyMethodFailureRollsBackWithTheSameTargetedAction() throws Exception {
+		Path settings = directory.resolve("BungeeSettings.yml");
+		String original = "UseBungeecord: true\nServer: lobby\nBungeeMethod: PLUGINMESSAGING\n"
+				+ "PluginMessageChannel: vp:vp\nRedis:\n  Host: localhost\n  Port: 6379\n";
+		Files.writeString(settings, original);
+		AtomicInteger targeted = new AtomicInteger();
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.QuickPreview preview = service.previewQuickSetup("proxy-method",
+				Map.of("method", "REDIS"));
+
+		BackendConfigurationService.ApplyFailureException failure = assertThrows(
+				BackendConfigurationService.ApplyFailureException.class,
+				() -> service.applyQuickSetup("proxy-method", Map.of("method", "REDIS"), preview.revision(), ignored -> {
+					if (targeted.incrementAndGet() == 1) throw new IOException("transport activation failed");
+				}));
+
+		assertTrue(failure.rolledBack());
+		assertEquals(2, targeted.get());
+		assertEquals(original, Files.readString(settings));
+	}
+
 	@Test void voteSitesSyncAddsAndUpdatesDefinitionsWithoutTouchingRewardsOrTargetOnlySites() throws Exception {
 		Path voteSites = directory.resolve("VoteSites.yml");
 		Files.writeString(voteSites, "VoteSites:\n"

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendConfigurationServiceTest.java
@@ -131,6 +131,19 @@ class BackendConfigurationServiceTest {
 		assertTrue(read.content().contains("# rotate " + BackendConfigurationService.REDACTED + " soon"));
 	}
 
+	@Test void redactsUserAndUsernameLabelledConfigurationComments() throws Exception {
+		Path config = directory.resolve("Config.yml");
+		Files.writeString(config, "# User: database-admin\n# DatabaseUsername=database-owner\nFeature: false\n");
+
+		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
+				.read("Config.yml");
+
+		assertFalse(read.content().contains("database-admin"));
+		assertFalse(read.content().contains("database-owner"));
+		assertTrue(read.content().contains("User: " + BackendConfigurationService.REDACTED));
+		assertTrue(read.content().contains("DatabaseUsername=" + BackendConfigurationService.REDACTED));
+	}
+
 	@Test void redactsSecretsInCommentOnlyDocuments() throws Exception {
 		Files.writeString(directory.resolve("Config.yml"), "# Password: header-secret\n# owner footer\n");
 		BackendConfigurationService.Document read = new BackendConfigurationService(directory, () -> { })
@@ -260,6 +273,24 @@ class BackendConfigurationServiceTest {
 
 		assertTrue(read.content().contains(BackendConfigurationService.REDACTED));
 		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", "Other: true\n"));
+	}
+
+	@Test void comparesRedactedCommentOwnersRegardlessOfMappingOrder() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "Alpha:\n  Enabled: true # Password: alpha-secret\n"
+				+ "Beta:\n  Enabled: true # Token: beta-secret\n");
+		BackendConfigurationService service = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document read = service.read("Config.yml");
+
+		String proposal = "Beta:\n  Enabled: false # Token: " + BackendConfigurationService.REDACTED + "\n"
+				+ "Alpha:\n  Enabled: true # Password: " + BackendConfigurationService.REDACTED + "\n";
+		BackendConfigurationService.Preview preview = service.preview("Config.yml", proposal);
+		assertTrue(preview.resolvedContent().contains("Token: beta-secret"));
+		assertTrue(preview.resolvedContent().contains("Password: alpha-secret"));
+
+		String moved = "Beta:\n  Enabled: false # Token: " + BackendConfigurationService.REDACTED
+				+ "\n  Extra: true # Password: " + BackendConfigurationService.REDACTED + "\n"
+				+ "Alpha:\n  Enabled: true\n";
+		assertThrows(IllegalArgumentException.class, () -> service.preview("Config.yml", moved));
 	}
 
 	@Test void rejectsMaskedDocumentsThatExpandPastTheSizeLimit() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/BackendControlConnectorProtocolTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -15,12 +17,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.bencodez.votingplugin.control.BackendControlResultStore.StoredResult;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 class BackendControlConnectorProtocolTest {
+	@TempDir Path directory;
 	@Test void onlyTheLeaseExpiryConflictRequestsAResultReclaim() {
 		assertTrue(BackendControlConnector.taskLeaseExpired(new BackendControlConnector.Response(409,
 				"{\"error\":{\"code\":\"TASK_LEASE_EXPIRED\"}}")));
@@ -44,6 +48,26 @@ class BackendControlConnectorProtocolTest {
 		assertFalse(recovered.claimRequired());
 		assertFalse(recovered.restartConnector());
 		assertTrue("RECOVERY_ABORTED".equals(recovered.result().get("code").getAsString()));
+	}
+
+	@Test void installedFileIntentRecoveryRebuildsMaskedContent() throws Exception {
+		Files.writeString(directory.resolve("Config.yml"), "Database:\n  Password: keep-me\nDebug: true\n");
+		BackendConfigurationService configurations = new BackendConfigurationService(directory, () -> { });
+		BackendConfigurationService.Document installed = configurations.read("Config.yml");
+		JsonObject configuration = new JsonObject();
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", "Config.yml");
+		JsonObject intent = new JsonObject();
+		intent.addProperty("revision", installed.revision());
+		intent.add("configuration", configuration);
+		StoredResult recovered = BackendControlConnector.committedInstalledForAttempt(configurations,
+				new StoredResult(intent, false, false, false), "00000000-0000-0000-0000-000000000198");
+
+		assertTrue(recovered.committed());
+		assertEquals("00000000-0000-0000-0000-000000000198", recovered.result().get("attemptId").getAsString());
+		String content = recovered.result().getAsJsonObject("configuration").get("content").getAsString();
+		assertFalse(content.contains("keep-me"));
+		assertTrue(content.contains(BackendConfigurationService.REDACTED));
 	}
 
 	@Test void registrationRequiresFileControlButAllowsQuickSetupToRemainOptional() {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
@@ -18,6 +18,10 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
+import com.bencodez.advancedcore.api.user.UserStorage;
+import com.bencodez.simpleapi.sql.data.DataValue;
+import com.bencodez.simpleapi.sql.data.DataValueInt;
+import com.bencodez.simpleapi.sql.data.DataValueString;
 import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.user.VotingPluginUser;
 import com.bencodez.votingplugin.votelog.VoteLogMysqlTable;
@@ -230,6 +234,46 @@ class ControlInspectionServiceTest {
 		assertEquals("Zulu", result.getAsJsonArray("lastVotes").get(1).getAsJsonObject()
 				.get("siteKey").getAsString());
 		assertFalse(result.get("lastVotesTruncated").getAsBoolean());
+		assertFalse(result.get("storageRowAvailable").getAsBoolean());
+		assertTrue(result.getAsJsonArray("columns").isEmpty());
+	}
+
+	@Test void playerInspectionShowsExactAllowListedStorageValuesWithoutInternalPayloads() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		VotingPluginUser user = mock(VotingPluginUser.class, RETURNS_DEEP_STUBS);
+		when(plugin.getUserManager().userExist("ExactName")).thenReturn(true);
+		when(plugin.getVotingPluginUserManager().getVotingPluginUser("ExactName")).thenReturn(user);
+		when(plugin.getStorageType()).thenReturn(UserStorage.SQLITE);
+		when(user.getUUID()).thenReturn("3b0c76c1-b7ef-4a2c-a565-b7bc662531f9");
+		when(user.getPlayerName()).thenReturn("ExactName");
+		when(user.getOfflineVotes()).thenReturn(new ArrayList<>());
+		when(user.getLastVotes()).thenReturn(new HashMap<>());
+		HashMap<String, DataValue> stored = new HashMap<>();
+		stored.put("Points", new DataValueInt(42));
+		stored.put("VoteShopLimitKeys", new DataValueInt(3));
+		stored.put("TopVoterIgnore", new DataValueString("true"));
+		stored.put("VoteShopLimitInjected", new DataValueString("must not leave through a dynamic field"));
+		stored.put("DailyTotal", new DataValueString("must not leave through an integer field"));
+		stored.put("Reminded", new DataValueString("must not leave through a boolean field"));
+		stored.put("OfflineVotes", new DataValueString("private serialized vote payload"));
+		stored.put("FuturePluginSecret", new DataValueString("must not leave the backend"));
+		when(user.getUserData().getValues()).thenReturn(stored);
+		ControlInspectionService service = new ControlInspectionService(plugin);
+
+		JsonObject result = service.inspect(JsonParser.parseString(
+				"{\"kind\":\"player\",\"filters\":{\"name\":\"ExactName\"}}")
+				.getAsJsonObject()).getAsJsonObject("result");
+		assertTrue(result.get("storageRowAvailable").getAsBoolean());
+		assertEquals("SQLITE", result.get("storage").getAsString());
+		assertEquals(List.of("Points", "TopVoterIgnore", "VoteShopLimitKeys"), result.getAsJsonArray("columns").asList().stream()
+				.map(value -> value.getAsJsonObject().get("name").getAsString()).toList());
+		assertEquals(List.of("42", "true", "3"), result.getAsJsonArray("columns").asList().stream()
+				.map(value -> value.getAsJsonObject().get("value").getAsString()).toList());
+		assertFalse(result.toString().contains("private serialized vote payload"));
+		assertFalse(result.toString().contains("must not leave through a dynamic field"));
+		assertFalse(result.toString().contains("must not leave through an integer field"));
+		assertFalse(result.toString().contains("must not leave through a boolean field"));
+		assertFalse(result.toString().contains("must not leave the backend"));
 	}
 
 	@Test void voteSiteHealthIncludesPersistedDetectedInboxWithoutVoteLogging() {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
@@ -276,6 +276,63 @@ class ControlInspectionServiceTest {
 		assertFalse(result.toString().contains("must not leave the backend"));
 	}
 
+	@Test void playerInspectionBoundsAllowListedStorageColumnsAtTheSharedRowLimit() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		VotingPluginUser user = mock(VotingPluginUser.class, RETURNS_DEEP_STUBS);
+		when(plugin.getUserManager().userExist("ExactName")).thenReturn(true);
+		when(plugin.getVotingPluginUserManager().getVotingPluginUser("ExactName")).thenReturn(user);
+		when(plugin.getStorageType()).thenReturn(UserStorage.SQLITE);
+		when(user.getUUID()).thenReturn("3b0c76c1-b7ef-4a2c-a565-b7bc662531f9");
+		when(user.getPlayerName()).thenReturn("ExactName");
+		when(user.getOfflineVotes()).thenReturn(new ArrayList<>());
+		when(user.getLastVotes()).thenReturn(new HashMap<>());
+		HashMap<String, DataValue> stored = new HashMap<>();
+		for (int index = 0; index <= ControlInspectionService.MAX_ROWS; index++) {
+			stored.put(String.format("VoteShopLimit%03d", index), new DataValueInt(index));
+		}
+		when(user.getUserData().getValues()).thenReturn(stored);
+		ControlInspectionService service = new ControlInspectionService(plugin);
+
+		JsonObject result = service.inspect(JsonParser.parseString(
+				"{\"kind\":\"player\",\"filters\":{\"name\":\"ExactName\"}}")
+				.getAsJsonObject()).getAsJsonObject("result");
+
+		assertEquals(ControlInspectionService.MAX_ROWS, result.getAsJsonArray("columns").size());
+		assertEquals("VoteShopLimit000", result.getAsJsonArray("columns").get(0).getAsJsonObject()
+				.get("name").getAsString());
+		assertEquals("VoteShopLimit099", result.getAsJsonArray("columns").get(99).getAsJsonObject()
+				.get("name").getAsString());
+		assertTrue(result.get("columnsTruncated").getAsBoolean());
+	}
+
+	@Test void diagnosticsBoundsAndReportsTruncatedPluginInventory() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		org.bukkit.configuration.file.YamlConfiguration config = new org.bukkit.configuration.file.YamlConfiguration();
+		org.bukkit.configuration.file.YamlConfiguration voteSites = new org.bukkit.configuration.file.YamlConfiguration();
+		when(plugin.getConfigFile().getData()).thenReturn(config);
+		when(plugin.getConfigVoteSites().getData()).thenReturn(voteSites);
+		when(plugin.getVoteSiteManager().getVoteSites()).thenReturn(new ArrayList<>());
+		when(plugin.getVoteLogMysqlTable()).thenReturn(null);
+		org.bukkit.plugin.Plugin[] installed = new org.bukkit.plugin.Plugin[ControlInspectionService.MAX_ROWS + 1];
+		for (int index = 0; index < installed.length; index++) {
+			installed[index] = mock(org.bukkit.plugin.Plugin.class, RETURNS_DEEP_STUBS);
+			when(installed[index].getDescription().getName()).thenReturn(String.format("Plugin%03d", index));
+		}
+		when(installed[99].getDescription().getName()).thenReturn("plugina");
+		when(installed[100].getDescription().getName()).thenReturn("PluginA");
+		when(plugin.getServer().getPluginManager().getPlugins()).thenReturn(installed);
+		ControlInspectionService service = new ControlInspectionService(plugin);
+
+		JsonObject result = service.inspect(JsonParser.parseString(
+				"{\"kind\":\"diagnostics\",\"filters\":{}}")
+				.getAsJsonObject()).getAsJsonObject("result");
+
+		assertEquals(ControlInspectionService.MAX_ROWS, result.getAsJsonArray("detectedPlugins").size());
+		assertEquals("Plugin000", result.getAsJsonArray("detectedPlugins").get(0).getAsString());
+		assertEquals("PluginA", result.getAsJsonArray("detectedPlugins").get(99).getAsString());
+		assertTrue(result.get("detectedPluginsTruncated").getAsBoolean());
+	}
+
 	@Test void voteSiteHealthIncludesPersistedDetectedInboxWithoutVoteLogging() {
 		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
 		org.bukkit.configuration.file.YamlConfiguration voteSites = new org.bukkit.configuration.file.YamlConfiguration();

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
@@ -250,6 +250,8 @@ class ControlInspectionServiceTest {
 		when(user.getLastVotes()).thenReturn(new HashMap<>());
 		HashMap<String, DataValue> stored = new HashMap<>();
 		stored.put("Points", new DataValueInt(42));
+		stored.put("MonthTotal-JANUARY-2025", new DataValueInt(11));
+		stored.put("MonthTotal-DECEMBER-2026", new DataValueInt(12));
 		stored.put("VoteShopLimitKeys", new DataValueInt(3));
 		stored.put("TopVoterIgnore", new DataValueString("true"));
 		stored.put("VoteShopLimitInjected", new DataValueString("must not leave through a dynamic field"));
@@ -257,6 +259,12 @@ class ControlInspectionServiceTest {
 		stored.put("Reminded", new DataValueString("must not leave through a boolean field"));
 		stored.put("OfflineVotes", new DataValueString("private serialized vote payload"));
 		stored.put("FuturePluginSecret", new DataValueString("must not leave the backend"));
+		stored.put("MonthTotal_2025_1", new DataValueInt(91));
+		stored.put("MonthTotal-JANUARY-25", new DataValueInt(92));
+		stored.put("MonthTotal-JANUARY-2025-extra", new DataValueInt(93));
+		stored.put("MonthTotal-january-2025", new DataValueInt(94));
+		stored.put("MonthTotal-SMARCH-2025", new DataValueInt(95));
+		stored.put("MonthTotal-FEBRUARY-2025", new DataValueString("wrong type"));
 		when(user.getUserData().getValues()).thenReturn(stored);
 		ControlInspectionService service = new ControlInspectionService(plugin);
 
@@ -265,15 +273,52 @@ class ControlInspectionServiceTest {
 				.getAsJsonObject()).getAsJsonObject("result");
 		assertTrue(result.get("storageRowAvailable").getAsBoolean());
 		assertEquals("SQLITE", result.get("storage").getAsString());
-		assertEquals(List.of("Points", "TopVoterIgnore", "VoteShopLimitKeys"), result.getAsJsonArray("columns").asList().stream()
+		assertEquals(List.of("MonthTotal-DECEMBER-2026", "MonthTotal-JANUARY-2025", "Points", "TopVoterIgnore", "VoteShopLimitKeys"), result.getAsJsonArray("columns").asList().stream()
 				.map(value -> value.getAsJsonObject().get("name").getAsString()).toList());
-		assertEquals(List.of("42", "true", "3"), result.getAsJsonArray("columns").asList().stream()
+		assertEquals(List.of("12", "11", "42", "true", "3"), result.getAsJsonArray("columns").asList().stream()
 				.map(value -> value.getAsJsonObject().get("value").getAsString()).toList());
 		assertFalse(result.toString().contains("private serialized vote payload"));
 		assertFalse(result.toString().contains("must not leave through a dynamic field"));
 		assertFalse(result.toString().contains("must not leave through an integer field"));
 		assertFalse(result.toString().contains("must not leave through a boolean field"));
 		assertFalse(result.toString().contains("must not leave the backend"));
+		assertFalse(result.toString().contains("MonthTotal_2025_1"));
+		assertFalse(result.toString().contains("MonthTotal-JANUARY-25"));
+		assertFalse(result.toString().contains("MonthTotal-JANUARY-2025-extra"));
+		assertFalse(result.toString().contains("MonthTotal-january-2025"));
+		assertFalse(result.toString().contains("MonthTotal-SMARCH-2025"));
+		assertFalse(result.toString().contains("MonthTotal-FEBRUARY-2025"));
+	}
+
+	@Test void playerInspectionBoundsHistoricalMonthTotalsDeterministically() {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		VotingPluginUser user = mock(VotingPluginUser.class, RETURNS_DEEP_STUBS);
+		when(plugin.getUserManager().userExist("ExactName")).thenReturn(true);
+		when(plugin.getVotingPluginUserManager().getVotingPluginUser("ExactName")).thenReturn(user);
+		when(plugin.getStorageType()).thenReturn(UserStorage.SQLITE);
+		when(user.getUUID()).thenReturn("3b0c76c1-b7ef-4a2c-a565-b7bc662531f9");
+		when(user.getPlayerName()).thenReturn("ExactName");
+		when(user.getOfflineVotes()).thenReturn(new ArrayList<>());
+		when(user.getLastVotes()).thenReturn(new HashMap<>());
+		HashMap<String, DataValue> stored = new HashMap<>();
+		List<String> expected = new ArrayList<>();
+		for (int index = 0; index <= ControlInspectionService.MAX_ROWS; index++) {
+			String name = "MonthTotal-" + java.time.Month.of(index % 12 + 1).name() + "-" + (2000 + index / 12);
+			stored.put(name, new DataValueInt(index));
+			expected.add(name);
+		}
+		expected.sort(String.CASE_INSENSITIVE_ORDER.thenComparing(java.util.Comparator.naturalOrder()));
+		when(user.getUserData().getValues()).thenReturn(stored);
+		ControlInspectionService service = new ControlInspectionService(plugin);
+
+		JsonObject result = service.inspect(JsonParser.parseString(
+				"{\"kind\":\"player\",\"filters\":{\"name\":\"ExactName\"}}")
+				.getAsJsonObject()).getAsJsonObject("result");
+
+		assertEquals(expected.subList(0, ControlInspectionService.MAX_ROWS),
+				result.getAsJsonArray("columns").asList().stream()
+						.map(value -> value.getAsJsonObject().get("name").getAsString()).toList());
+		assertTrue(result.get("columnsTruncated").getAsBoolean());
 	}
 
 	@Test void playerInspectionBoundsAllowListedStorageColumnsAtTheSharedRowLimit() {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/control/ControlInspectionServiceTest.java
@@ -192,8 +192,16 @@ class ControlInspectionServiceTest {
 
 		assertEquals(List.of("Middle", "alpha", "Zulu"), result.getAsJsonArray("topServices").asList().stream()
 				.map(row -> row.getAsJsonObject().get("service").getAsString()).toList());
+		assertEquals(List.of(6L, 3L, 3L), result.getAsJsonArray("topServices").asList().stream()
+				.map(row -> row.getAsJsonObject().get("count").getAsLong()).toList());
+		assertEquals(List.of(6L, 3L, 3L), result.getAsJsonArray("topServices").asList().stream()
+				.map(row -> row.getAsJsonObject().get("votes").getAsLong()).toList());
 		assertEquals(List.of("hub", "Creative", "survival"), result.getAsJsonArray("topServers").asList().stream()
 				.map(row -> row.getAsJsonObject().get("server").getAsString()).toList());
+		assertEquals(List.of(8L, 2L, 2L), result.getAsJsonArray("topServers").asList().stream()
+				.map(row -> row.getAsJsonObject().get("count").getAsLong()).toList());
+		assertEquals(List.of(8L, 2L, 2L), result.getAsJsonArray("topServers").asList().stream()
+				.map(row -> row.getAsJsonObject().get("votes").getAsLong()).toList());
 	}
 
 	@Test void exactPlayerMissDoesNotLoadOrEnumerateUsers() {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -9,7 +9,13 @@ import com.bencodez.votingplugin.proxy.control.ControlConnector.Transport;
 import com.bencodez.votingplugin.proxy.control.ProxyControlResultStore.StoredResult;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -20,15 +26,25 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ControlConnectorTest {
+	@TempDir Path dataDirectory;
 	private ScheduledExecutorService scheduler;
 	private FakeTransport transport;
 	private List<String> logs;
+
+	@Test void responseBudgetCanCarryTheLargestEscapedManagedFileTask() {
+		assertTrue(ControlConnector.MAX_RESPONSE_BYTES >= ProxyConfigurationFileService.MAX_BYTES * 6);
+	}
 	private ControlConnector connector;
 
 	@BeforeEach void setUp() {
@@ -275,6 +291,135 @@ class ControlConnectorTest {
 		assertFalse(ControlConnector.requiresRuntimeReplacement(new StoredResult(result, true, false)));
 	}
 
+	@Test void proxyFileCapabilityAdvertisesAndDispatchesMaskedReadResults() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Database:\n  Password: local-secret\nProxy:\n  Enabled: true\n");
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove));
+		transport.acceptProxyFiles = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"READ\",\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"bungeeconfig.yml\"}}"));
+
+		connector.cycle();
+
+		JsonObject registration = JsonParser.parseString(transport.requests.get(0).body()).getAsJsonObject();
+		assertTrue(registration.getAsJsonArray("capabilities").asList().stream()
+				.anyMatch(value -> "config.proxy-files.v1".equals(value.getAsString())));
+		JsonObject result = submittedResult();
+		JsonObject configuration = result.getAsJsonObject("configuration");
+		assertEquals("file", configuration.get("domain").getAsString());
+		assertEquals("bungeeconfig.yml", configuration.get("fileName").getAsString());
+		assertTrue(configuration.get("content").getAsString().contains(ProxyConfigurationFileService.REDACTED));
+		assertFalse(transport.requests.stream().map(Request::body).anyMatch(body -> body.contains("local-secret")));
+	}
+
+	@Test void proxyFileRejectsUnmanagedNamesWithAStructuredSafeFailure() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Database:\n  Password: local-secret\n");
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove));
+		transport.acceptProxyFiles = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"READ\",\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"../../private/local-secret.yml\"}}"));
+
+		connector.cycle();
+
+		JsonObject result = submittedResult();
+		assertFalse(result.get("success").getAsBoolean());
+		assertEquals("VALIDATION_ERROR", result.get("code").getAsString());
+		assertEquals("proxy configuration file is not managed", result.get("message").getAsString());
+		assertFalse(result.toString().contains("local-secret"));
+		assertFalse(result.toString().contains("../"));
+	}
+
+	@Test void proxyFileWriteAheadIntentPersistsOnlyRecoveryMetadataBeforeTheFileIsPublished() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Database:\n  Password: local-secret\nProxy:\n  Enabled: true\n");
+		CountDownLatch firstMove = new CountDownLatch(1);
+		CountDownLatch releaseMove = new CountDownLatch(1);
+		AtomicBoolean blockFirstMove = new AtomicBoolean(true);
+		ProxyConfigurationFileService service = new ProxyConfigurationFileService(file, (source, target) -> {
+			if (blockFirstMove.compareAndSet(true, false)) {
+				firstMove.countDown();
+				try {
+					releaseMove.await();
+				} catch (InterruptedException failure) {
+					Thread.currentThread().interrupt();
+					throw new java.io.IOException(failure);
+				}
+			}
+			atomicMove(source, target);
+		});
+		String proposed = "Database:\n  Password: " + ProxyConfigurationFileService.REDACTED
+				+ "\nProxy:\n  Enabled: false\n";
+		String expectedRevision = ProxyConfigurationFileService.revision(Files.readString(file));
+		String expectedProposedRevision = ProxyConfigurationFileService.revision(service.preview(
+				ProxyConfigurationFileService.FILE_NAME, proposed).resolvedContent());
+		connector.close();
+		connector = fileConnector(service);
+		transport.acceptProxyFiles = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"APPLY\",\"expectedRevision\":\"" + expectedRevision + "\","
+						+ "\"configuration\":{\"domain\":\"file\",\"fileName\":\"bungeeconfig.yml\","
+						+ "\"content\":\"Database:\\n  Password: " + ProxyConfigurationFileService.REDACTED
+						+ "\\nProxy:\\n  Enabled: false\\n\"}}"));
+
+		CompletableFuture<Void> cycle = CompletableFuture.runAsync(connector::cycle);
+		assertTrue(firstMove.await(2, TimeUnit.SECONDS));
+		try {
+			String journal = Files.readString(dataDirectory.resolve(".control-proxy-pending-results.json"));
+			StoredResult intent = ProxyControlResultStore.load(dataDirectory).results().values().iterator().next();
+			JsonObject configuration = intent.result().getAsJsonObject("configuration");
+			assertFalse(intent.committed());
+			assertFalse(intent.result().get("reloaded").getAsBoolean());
+			assertTrue(intent.result().get("message").getAsString().contains("restart the proxy"));
+			assertEquals("file", configuration.get("domain").getAsString());
+			assertEquals("bungeeconfig.yml", configuration.get("fileName").getAsString());
+			assertEquals(expectedProposedRevision, intent.result().get("revision").getAsString());
+			assertFalse(configuration.has("content"));
+			assertFalse(journal.contains("local-secret"));
+			assertFalse(journal.contains("Enabled: false"));
+		} finally {
+			releaseMove.countDown();
+		}
+		cycle.get(2, TimeUnit.SECONDS);
+	}
+
+	@Test void failedProxyIntentPublicationRestoresTheInMemoryWriteAheadState() throws Exception {
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(dataDirectory.resolve(
+				ProxyConfigurationFileService.FILE_NAME), ControlConnectorTest::atomicMove));
+		Path journal = dataDirectory.resolve(".control-proxy-pending-results.json");
+		Path external = dataDirectory.resolve("external-journal.json");
+		Files.writeString(external, "{}");
+		try {
+			Files.createSymbolicLink(journal, external.getFileName());
+		} catch (UnsupportedOperationException unsupported) {
+			return;
+		}
+
+		Method fileIntent = taskResultClass().getDeclaredMethod("fileIntent", String.class, String.class, List.class);
+		fileIntent.setAccessible(true);
+		Object intent = fileIntent.invoke(null, ProxyConfigurationFileService.FILE_NAME, "anticipated-revision",
+				List.of("changed Proxy.Enabled"));
+		Method persistIntent = ControlConnector.class.getDeclaredMethod("persistIntent", UUID.class,
+				taskResultClass(), String.class);
+		persistIntent.setAccessible(true);
+
+		assertThrows(java.lang.reflect.InvocationTargetException.class, () -> persistIntent.invoke(connector,
+				UUID.fromString("00000000-0000-0000-0000-000000000099"), intent,
+				"00000000-0000-0000-0000-000000000199"));
+		assertEquals(0, completedTaskCount());
+	}
+
 	@Test void lostResultResponseIsResubmittedBeforeAnotherOperationClaim() {
 		connector.close();
 		ProxyRoutingConfiguration current = new ProxyRoutingConfiguration(false, List.of());
@@ -298,6 +443,36 @@ class ControlConnectorTest {
 
 		assertEquals(2, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
+	}
+
+	@Test void largeProxyFileReadSurvivesLostAcknowledgementAndConnectorRestart() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Large: '" + "a".repeat(300 * 1024) + "'\n");
+		ProxyConfigurationFileService service = new ProxyConfigurationFileService(file,
+				ControlConnectorTest::atomicMove);
+		connector.close();
+		connector = fileConnector(service);
+		transport.acceptProxyFiles = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"READ\",\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"bungeeconfig.yml\"}}"));
+		transport.resultSubmission = new CompletableFuture<>();
+
+		connector.cycle();
+		transport.resultSubmission.completeExceptionally(new java.io.IOException("acknowledgement lost"));
+		assertEquals(Status.UNAVAILABLE, connector.status());
+		assertTrue(Files.size(dataDirectory.resolve(".control-proxy-pending-results.json")) > 256 * 1024);
+
+		connector.close();
+		connector = fileConnector(service);
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(204, ""));
+		transport.resultSubmission = CompletableFuture.completedFuture(new Response(200, "{}"));
+		connector.cycle();
+
+		assertFalse(Files.exists(dataDirectory.resolve(".control-proxy-pending-results.json")));
+		assertEquals(2, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 	}
 
 	@Test void expiredResultLeaseIsReclaimedAndReboundBeforeResubmission() {
@@ -438,12 +613,59 @@ class ControlConnectorTest {
 				URI.create("http://127.0.0.1:8080"), 30, 3000, 5000);
 	}
 
+	private JsonObject submittedResult() {
+		return JsonParser.parseString(transport.requests.stream().filter(request -> request.path().endsWith("/result"))
+				.findFirst().orElseThrow().body()).getAsJsonObject();
+	}
+
+	private static void atomicMove(Path source, Path target) throws java.io.IOException {
+		Files.move(source, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	private static Class<?> taskResultClass() {
+		return java.util.Arrays.stream(ControlConnector.class.getDeclaredClasses())
+				.filter(type -> type.getSimpleName().equals("TaskResult")).findFirst().orElseThrow();
+	}
+
+	@SuppressWarnings("unchecked")
+	private int completedTaskCount() throws Exception {
+		Field completed = ControlConnector.class.getDeclaredField("completedTasks");
+		completed.setAccessible(true);
+		return ((Map<UUID, StoredResult>) completed.get(connector)).size();
+	}
+
+	@SuppressWarnings("unchecked")
+	private ControlConnector fileConnector(ProxyConfigurationFileService fileService) throws Exception {
+		Constructor<ControlConnector> constructor = ControlConnector.class.getDeclaredConstructor(Settings.class,
+				ScheduledExecutorService.class, Transport.class, Supplier.class, Consumer.class, UUID.class,
+				LongSupplier.class, ProxyRoutingConfigurationService.class, Path.class, ProxyControlResultStore.Route.class,
+				boolean.class, Runnable.class, Function.class, ProxyMethodConfigurationService.class, Runnable.class,
+				ProxyConfigurationFileService.class);
+		constructor.setAccessible(true);
+		ControlConnector created = constructor.newInstance(settings(), scheduler, transport,
+				(Supplier<List<ObservedBackend>>) List::of,
+				(Consumer<String>) logs::add, UUID.randomUUID(), (LongSupplier) () -> 0L, null, dataDirectory,
+				new ProxyControlResultStore.Route("proxy-a", "Proxy A", "VELOCITY", "7.1.2",
+						URI.create("http://127.0.0.1:8080"), "credential.txt", 30, 3000, 5000),
+				false, null,
+				(Function<String, CompletableFuture<com.bencodez.votingplugin.proxy.VotingPluginProxy.CommunicationTestResult>>) null,
+				null, null, fileService);
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(dataDirectory);
+		if (recovered != null) {
+			Field completed = ControlConnector.class.getDeclaredField("completedTasks");
+			completed.setAccessible(true);
+			((Map<UUID, StoredResult>) completed.get(created)).putAll(recovered.results());
+		}
+		return created;
+	}
+
 	private static final class FakeTransport implements Transport {
 		private final List<Request> requests = new ArrayList<>();
 		private Response nextPrimary;
 		private CompletableFuture<Response> stalled;
 		private RuntimeException synchronousFailure;
 		private boolean acceptConfiguration;
+		private boolean acceptProxyFiles;
 		private CompletableFuture<Response> operationClaim;
 		private CompletableFuture<Response> resultSubmission;
 		private CountDownLatch firstSendEntered;
@@ -488,7 +710,9 @@ class ControlConnectorTest {
 				}
 				if ("/api/v1/nodes/register".equals(request.path())) {
 					String capabilities = acceptConfiguration
-							? "[\"presence.snapshot\",\"config.proxy-routing.v1\"]" : "[\"presence.snapshot\"]";
+							? "[\"presence.snapshot\",\"config.proxy-routing.v1\"]"
+							: acceptProxyFiles ? "[\"presence.snapshot\",\"config.proxy-files.v1\"]"
+							: "[\"presence.snapshot\"]";
 					return CompletableFuture.completedFuture(new Response(201,
 							"{\"identity\":{\"protocolVersion\":1},\"node\":{\"acceptedCapabilities\":"
 									+ capabilities + "}}"));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -316,6 +316,29 @@ class ControlConnectorTest {
 		assertFalse(transport.requests.stream().map(Request::body).anyMatch(body -> body.contains("local-secret")));
 	}
 
+	@Test void proxyFileTaskIsRejectedWhenOnlyRoutingControlWasNegotiated() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Debug: false\n");
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, (source, target) -> {
+			throw new AssertionError("an unnegotiated proxy file task must not publish changes");
+		}));
+		transport.acceptConfiguration = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"APPLY\",\"expectedRevision\":\"ignored\","
+						+ "\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"bungeeconfig.yml\",\"content\":\"Debug: true\\n\"}}"));
+
+		connector.cycle();
+
+		JsonObject result = submittedResult();
+		assertFalse(result.get("success").getAsBoolean());
+		assertEquals("UNSUPPORTED", result.get("code").getAsString());
+		assertEquals("Debug: false\n", Files.readString(file));
+	}
+
 	@Test void proxyFileRejectsUnmanagedNamesWithAStructuredSafeFailure() throws Exception {
 		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
 		Files.writeString(file, "Database:\n  Password: local-secret\n");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class ControlConnectorTest {
 	@TempDir Path dataDirectory;
@@ -314,6 +315,45 @@ class ControlConnectorTest {
 		assertEquals("bungeeconfig.yml", configuration.get("fileName").getAsString());
 		assertTrue(configuration.get("content").getAsString().contains(ProxyConfigurationFileService.REDACTED));
 		assertFalse(transport.requests.stream().map(Request::body).anyMatch(body -> body.contains("local-secret")));
+	}
+
+	@Test void proxyFilePreviewRejectsARevisionThatChangesAfterCalculation() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Debug: false\n");
+		ProxyConfigurationFileService actual = new ProxyConfigurationFileService(file,
+				ControlConnectorTest::atomicMove);
+		ProxyConfigurationFileService service = mock(ProxyConfigurationFileService.class);
+		AtomicBoolean mutated = new AtomicBoolean();
+		when(service.preview(ProxyConfigurationFileService.FILE_NAME, "Debug: true\n")).thenAnswer(invocation -> {
+			ProxyConfigurationFileService.Preview preview = actual.preview(
+					invocation.getArgument(0), invocation.getArgument(1));
+			if (!mutated.compareAndSet(false, true)) return preview;
+			try {
+				Files.writeString(file, "Debug: changed-locally\n");
+			} catch (java.io.IOException failure) {
+				throw new AssertionError(failure);
+			}
+			return preview;
+		});
+		when(service.read(ProxyConfigurationFileService.FILE_NAME)).thenAnswer(invocation ->
+				actual.read(invocation.getArgument(0)));
+		connector.close();
+		connector = fileConnector(service);
+		transport.acceptProxyFiles = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000199\","
+						+ "\"type\":\"PREVIEW\",\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"bungeeconfig.yml\",\"content\":\"Debug: true\\n\"}}"));
+
+		connector.cycle();
+
+		JsonObject result = submittedResult();
+		assertTrue(mutated.get());
+		assertFalse(result.get("success").getAsBoolean());
+		assertEquals("STALE_REVISION", result.get("code").getAsString());
+		assertFalse(result.has("configuration"));
+		assertEquals("Debug: changed-locally\n", Files.readString(file));
 	}
 
 	@Test void proxyFileTaskIsRejectedWhenOnlyRoutingControlWasNegotiated() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -484,6 +484,26 @@ class ControlConnectorTest {
 		assertEquals(0, completedTaskCount());
 	}
 
+	@Test void proxyFileTaskResultsBoundChangeDescriptionsBeforeJournaling() throws Exception {
+		Method fileIntent = taskResultClass().getDeclaredMethod("fileIntent", String.class, String.class, List.class);
+		fileIntent.setAccessible(true);
+		Object result = fileIntent.invoke(null, ProxyConfigurationFileService.FILE_NAME, "anticipated-revision",
+				List.of("changed " + "x".repeat(1000)));
+		Method changes = taskResultClass().getDeclaredMethod("changes");
+		changes.setAccessible(true);
+
+		@SuppressWarnings("unchecked") List<String> bounded = (List<String>) changes.invoke(result);
+		assertEquals(1, bounded.size());
+		assertTrue(bounded.get(0).length() <= 240);
+		assertTrue(bounded.get(0).endsWith("..."));
+	}
+
+	@Test void resultChangeBoundsRetainExactlyTwentyRealChanges() {
+		List<String> changes = java.util.stream.IntStream.range(0, 20).mapToObj(index -> "changed Path" + index).toList();
+
+		assertEquals(changes, ControlConnector.boundedResultChanges(changes));
+	}
+
 	@Test void recoveredProxyFileIntentRebuildsMaskedContent() throws Exception {
 		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
 		Files.writeString(file, "Database:\n  Password: local-secret\nProxy:\n  Enabled: false\n");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -564,6 +564,15 @@ class ControlConnectorTest {
 		assertEquals(0, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
 		assertEquals(1, completedTaskCount());
+		AtomicBoolean replacement = new AtomicBoolean();
+		Field deferred = ControlConnector.class.getDeclaredField("deferredReplacement");
+		deferred.setAccessible(true);
+		deferred.set(connector, (Runnable) () -> replacement.set(true));
+		Method finishCycle = ControlConnector.class.getDeclaredMethod("finishCycle");
+		finishCycle.setAccessible(true);
+		finishCycle.invoke(connector);
+		assertTrue(replacement.get(), "a capability-blocked durable result must not prevent lifecycle replacement");
+		assertEquals(1, completedTaskCount(), "the blocked result must remain journaled for a later capable session");
 
 		Field accepted = ControlConnector.class.getDeclaredField("acceptedCapabilities");
 		accepted.setAccessible(true);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -19,6 +19,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -534,6 +535,43 @@ class ControlConnectorTest {
 
 		assertEquals(2, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
+	}
+
+	@Test void recoveredProxyFileResultWaitsForItsCapabilityWithoutBlockingClaims() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Proxy:\n  Enabled: false\n");
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove));
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+		result.addProperty("attemptId", "00000000-0000-0000-0000-000000000199");
+		JsonObject configuration = new JsonObject();
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", ProxyConfigurationFileService.FILE_NAME);
+		configuration.addProperty("content", "Proxy:\n  Enabled: false\n");
+		result.add("configuration", configuration);
+		Field completed = ControlConnector.class.getDeclaredField("completedTasks");
+		completed.setAccessible(true);
+		@SuppressWarnings("unchecked") Map<UUID, StoredResult> results =
+				(Map<UUID, StoredResult>) completed.get(connector);
+		results.put(UUID.fromString("00000000-0000-0000-0000-000000000099"),
+				new StoredResult(result, true, false));
+		transport.acceptConfiguration = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(204, ""));
+
+		connector.cycle();
+
+		assertEquals(0, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
+		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
+		assertEquals(1, completedTaskCount());
+
+		Field accepted = ControlConnector.class.getDeclaredField("acceptedCapabilities");
+		accepted.setAccessible(true);
+		accepted.set(connector, Set.of("presence.snapshot", "config.proxy-files.v1"));
+		transport.resultSubmission = CompletableFuture.completedFuture(new Response(200, "{}"));
+		connector.cycle();
+		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
+		assertEquals(0, completedTaskCount());
 	}
 
 	@Test void largeProxyFileReadSurvivesLostAcknowledgementAndConnectorRestart() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -942,15 +942,16 @@ class ControlConnectorTest {
 				boolean.class, Runnable.class, Function.class, ProxyMethodConfigurationService.class, Runnable.class,
 				ProxyConfigurationFileService.class);
 		constructor.setAccessible(true);
+		ProxyControlResultStore.Route connectorRoute = new ProxyControlResultStore.Route("proxy-a", "Proxy A",
+				"VELOCITY", "7.1.2", URI.create("http://127.0.0.1:8080"), "credential.txt", 30, 3000, 5000);
 		ControlConnector created = constructor.newInstance(settings(), scheduler, transport,
 				(Supplier<List<ObservedBackend>>) List::of,
 				(Consumer<String>) logs::add, UUID.randomUUID(), (LongSupplier) () -> 0L, null, dataDirectory,
-				new ProxyControlResultStore.Route("proxy-a", "Proxy A", "VELOCITY", "7.1.2",
-						URI.create("http://127.0.0.1:8080"), "credential.txt", 30, 3000, 5000),
+				connectorRoute,
 				recovering, recoveryComplete,
 				(Function<String, CompletableFuture<com.bencodez.votingplugin.proxy.VotingPluginProxy.CommunicationTestResult>>) null,
 				null, null, fileService);
-		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(dataDirectory);
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.loadForRoute(dataDirectory, connectorRoute);
 		if (recovered != null) {
 			Field completed = ControlConnector.class.getDeclaredField("completedTasks");
 			completed.setAccessible(true);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -483,6 +483,34 @@ class ControlConnectorTest {
 		assertEquals(0, completedTaskCount());
 	}
 
+	@Test void recoveredProxyFileIntentRebuildsMaskedContent() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Database:\n  Password: local-secret\nProxy:\n  Enabled: false\n");
+		ProxyConfigurationFileService service = new ProxyConfigurationFileService(file,
+				ControlConnectorTest::atomicMove);
+		connector.close();
+		connector = fileConnector(service);
+		ProxyConfigurationFileService.Document installed = service.read(ProxyConfigurationFileService.FILE_NAME);
+		Method fileIntent = taskResultClass().getDeclaredMethod("fileIntent", String.class, String.class, List.class);
+		fileIntent.setAccessible(true);
+		Object intent = fileIntent.invoke(null, ProxyConfigurationFileService.FILE_NAME, installed.revision(),
+				List.of("changed Proxy.Enabled"));
+		Method persistIntent = ControlConnector.class.getDeclaredMethod("persistIntent", UUID.class,
+				taskResultClass(), String.class);
+		persistIntent.setAccessible(true);
+		persistIntent.invoke(connector, UUID.fromString("00000000-0000-0000-0000-000000000099"), intent,
+				"00000000-0000-0000-0000-000000000199");
+		Method prepare = ControlConnector.class.getDeclaredMethod("prepareWriteAheadIntents");
+		prepare.setAccessible(true);
+		prepare.invoke(connector);
+
+		StoredResult recovered = ProxyControlResultStore.load(dataDirectory).results().values().iterator().next();
+		assertTrue(recovered.committed());
+		String content = recovered.result().getAsJsonObject("configuration").get("content").getAsString();
+		assertEquals(installed.content(), content);
+		assertFalse(content.contains("local-secret"));
+	}
+
 	@Test void lostResultResponseIsResubmittedBeforeAnotherOperationClaim() {
 		connector.close();
 		ProxyRoutingConfiguration current = new ProxyRoutingConfiguration(false, List.of());

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -557,7 +557,11 @@ class ControlConnectorTest {
 		results.put(UUID.fromString("00000000-0000-0000-0000-000000000099"),
 				new StoredResult(result, true, false));
 		transport.acceptConfiguration = true;
-		transport.operationClaim = CompletableFuture.completedFuture(new Response(204, ""));
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(200,
+				"{\"operationId\":\"00000000-0000-0000-0000-000000000099\","
+						+ "\"attemptId\":\"00000000-0000-0000-0000-000000000299\","
+						+ "\"type\":\"READ\",\"configuration\":{\"domain\":\"file\","
+						+ "\"fileName\":\"bungeeconfig.yml\"}}"));
 
 		connector.cycle();
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -512,6 +512,29 @@ class ControlConnectorTest {
 		assertFalse(content.contains("local-secret"));
 	}
 
+	@Test void malformedRecoveredProxyFileIntentIsAborted() throws Exception {
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(
+				dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME), ControlConnectorTest::atomicMove));
+		Method fileIntent = taskResultClass().getDeclaredMethod("fileIntent", String.class, String.class, List.class);
+		fileIntent.setAccessible(true);
+		Object intent = fileIntent.invoke(null, "not-managed.yml", "anticipated-revision", List.of("changed"));
+		Method persistIntent = ControlConnector.class.getDeclaredMethod("persistIntent", UUID.class,
+				taskResultClass(), String.class);
+		persistIntent.setAccessible(true);
+		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+		persistIntent.invoke(connector, operationId, intent, "00000000-0000-0000-0000-000000000199");
+
+		Method prepare = ControlConnector.class.getDeclaredMethod("prepareWriteAheadIntents");
+		prepare.setAccessible(true);
+		prepare.invoke(connector);
+
+		StoredResult recovered = ProxyControlResultStore.load(dataDirectory).results().get(operationId);
+		assertNotNull(recovered);
+		assertTrue(recovered.committed());
+		assertEquals("RECOVERY_ABORTED", recovered.result().get("code").getAsString());
+	}
+
 	@Test void lostResultResponseIsResubmittedBeforeAnotherOperationClaim() {
 		connector.close();
 		ProxyRoutingConfiguration current = new ProxyRoutingConfiguration(false, List.of());

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -316,6 +317,98 @@ class ControlConnectorTest {
 		assertEquals("bungeeconfig.yml", configuration.get("fileName").getAsString());
 		assertTrue(configuration.get("content").getAsString().contains(ProxyConfigurationFileService.REDACTED));
 		assertFalse(transport.requests.stream().map(Request::body).anyMatch(body -> body.contains("local-secret")));
+	}
+
+	@Test void recoveredCapabilityFilteredResultCompletesRecoveryAfterAnEmptyClaim() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Debug: false\n");
+		AtomicInteger recoveryCalls = new AtomicInteger();
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove), true,
+				recoveryCalls::incrementAndGet);
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+		result.addProperty("attemptId", "00000000-0000-0000-0000-000000000199");
+		JsonObject configuration = new JsonObject();
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", ProxyConfigurationFileService.FILE_NAME);
+		result.add("configuration", configuration);
+		Field completed = ControlConnector.class.getDeclaredField("completedTasks");
+		completed.setAccessible(true);
+		@SuppressWarnings("unchecked") Map<UUID, StoredResult> results =
+				(Map<UUID, StoredResult>) completed.get(connector);
+		results.put(UUID.fromString("00000000-0000-0000-0000-000000000099"),
+				new StoredResult(result, true, false));
+		transport.acceptConfiguration = true;
+		transport.operationClaim = CompletableFuture.completedFuture(new Response(204, ""));
+
+		connector.cycle();
+
+		assertEquals(1, recoveryCalls.get(), "a filtered recovered result must not pin the old connector route");
+		connector.cycle();
+		assertEquals(1, recoveryCalls.get(), "recovery completion must be idempotent");
+	}
+
+	@Test void recoveredCapabilityFilteredResultCompletesWithoutAnOperationLane() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Debug: false\n");
+		AtomicInteger recoveryCalls = new AtomicInteger();
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove), true,
+				recoveryCalls::incrementAndGet);
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+		result.addProperty("attemptId", "00000000-0000-0000-0000-000000000199");
+		JsonObject configuration = new JsonObject();
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", ProxyConfigurationFileService.FILE_NAME);
+		result.add("configuration", configuration);
+		Field completed = ControlConnector.class.getDeclaredField("completedTasks");
+		completed.setAccessible(true);
+		@SuppressWarnings("unchecked") Map<UUID, StoredResult> results =
+				(Map<UUID, StoredResult>) completed.get(connector);
+		results.put(UUID.fromString("00000000-0000-0000-0000-000000000099"),
+				new StoredResult(result, true, false));
+		// The server can keep this node registered for presence while refusing
+		// every operation capability, leaving no operation claim to return 204.
+		transport.acceptConfiguration = false;
+		transport.acceptProxyFiles = false;
+
+		connector.cycle();
+
+		assertEquals(1, recoveryCalls.get(),
+				"a filtered recovered result must complete after the successful no-operation handshake");
+		assertTrue(transport.requests.stream().noneMatch(request -> request.path().endsWith("/operations")));
+		ProxyControlResultStore.State retained = ProxyControlResultStore.load(dataDirectory);
+		assertNotNull(retained);
+		assertFalse(retained.routeRequired(), "the retained result must not pin the next connector to the old route");
+		connector.cycle();
+		assertEquals(1, recoveryCalls.get(), "recovery completion must be idempotent");
+	}
+
+	@Test void malformedProxyFileFieldsBecomeDurableValidationFailures() throws Exception {
+		Path file = dataDirectory.resolve(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "Debug: false\n");
+		connector.close();
+		connector = fileConnector(new ProxyConfigurationFileService(file, ControlConnectorTest::atomicMove));
+		transport.acceptProxyFiles = true;
+		String[] malformedTasks = {
+				"{\"domain\":\"file\",\"fileName\":\"bungeeconfig.yml\"}",
+				"{\"domain\":\"file\",\"fileName\":{},\"content\":\"Debug: true\\n\"}"
+		};
+		for (int index = 0; index < malformedTasks.length; index++) {
+			String operationId = String.format("00000000-0000-0000-0000-%012d", 99 + index);
+			String attemptId = String.format("00000000-0000-0000-0000-%012d", 199 + index);
+			String claim = "{\"operationId\":\"" + operationId + "\","
+					+ "\"attemptId\":\"" + attemptId + "\","
+					+ "\"type\":\"PREVIEW\",\"configuration\":" + malformedTasks[index] + "}";
+			transport.operationClaim = CompletableFuture.completedFuture(new Response(200, claim));
+			connector.cycle();
+			JsonObject result = submittedResult();
+			assertFalse(result.get("success").getAsBoolean());
+			assertEquals("VALIDATION_ERROR", result.get("code").getAsString());
+			assertEquals(Status.CONNECTED, connector.status());
+		}
 	}
 
 	@Test void proxyFilePreviewRejectsARevisionThatChangesAfterCalculation() throws Exception {
@@ -837,6 +930,12 @@ class ControlConnectorTest {
 
 	@SuppressWarnings("unchecked")
 	private ControlConnector fileConnector(ProxyConfigurationFileService fileService) throws Exception {
+		return fileConnector(fileService, false, null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private ControlConnector fileConnector(ProxyConfigurationFileService fileService, boolean recovering,
+			Runnable recoveryComplete) throws Exception {
 		Constructor<ControlConnector> constructor = ControlConnector.class.getDeclaredConstructor(Settings.class,
 				ScheduledExecutorService.class, Transport.class, Supplier.class, Consumer.class, UUID.class,
 				LongSupplier.class, ProxyRoutingConfigurationService.class, Path.class, ProxyControlResultStore.Route.class,
@@ -848,7 +947,7 @@ class ControlConnectorTest {
 				(Consumer<String>) logs::add, UUID.randomUUID(), (LongSupplier) () -> 0L, null, dataDirectory,
 				new ProxyControlResultStore.Route("proxy-a", "Proxy A", "VELOCITY", "7.1.2",
 						URI.create("http://127.0.0.1:8080"), "credential.txt", 30, 3000, 5000),
-				false, null,
+				recovering, recoveryComplete,
 				(Function<String, CompletableFuture<com.bencodez.votingplugin.proxy.VotingPluginProxy.CommunicationTestResult>>) null,
 				null, null, fileService);
 		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(dataDirectory);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -394,7 +394,9 @@ class ControlConnectorTest {
 		transport.acceptProxyFiles = true;
 		String[] malformedTasks = {
 				"{\"domain\":\"file\",\"fileName\":\"bungeeconfig.yml\"}",
-				"{\"domain\":\"file\",\"fileName\":{},\"content\":\"Debug: true\\n\"}"
+				"{\"domain\":\"file\",\"fileName\":{},\"content\":\"Debug: true\\n\"}",
+				"{\"domain\":\"file\",\"fileName\":\"bungeeconfig.yml\","
+						+ "\"content\":\"Debug: true\\n\",\"reload\":true}"
 		};
 		for (int index = 0; index < malformedTasks.length; index++) {
 			String operationId = String.format("00000000-0000-0000-0000-%012d", 99 + index);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ControlConnectorTest.java
@@ -581,6 +581,15 @@ class ControlConnectorTest {
 		connector.cycle();
 		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 		assertEquals(0, completedTaskCount());
+
+		results.put(UUID.fromString("00000000-0000-0000-0000-000000000099"),
+				new StoredResult(result, false, true));
+		accepted.set(connector, Set.of("presence.snapshot", "config.proxy-routing.v1"));
+		replacement.set(false);
+		deferred.set(connector, (Runnable) () -> replacement.set(true));
+		finishCycle.invoke(connector);
+		assertTrue(replacement.get(), "a capability-blocked lease-expired result must not prevent replacement");
+		assertEquals(1, completedTaskCount(), "the lease-expired result must remain available for a capable session");
 	}
 
 	@Test void largeProxyFileReadSurvivesLostAcknowledgementAndConnectorRestart() throws Exception {
@@ -669,7 +678,7 @@ class ControlConnectorTest {
 		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
 	}
 
-	@Test void abandonedWriteAheadIntentIsReportedAndReleasedWhenControlForgotTheOperation() {
+	@Test void abandonedWriteAheadIntentRetainsItsCapabilityUntilControlCanAcceptIt() throws Exception {
 		connector.close();
 		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000099");
 		ProxyRoutingConfiguration proposal = new ProxyRoutingConfiguration(true, List.of());
@@ -679,8 +688,9 @@ class ControlConnectorTest {
 		anticipated.addProperty("message", "Configuration applied");
 		anticipated.addProperty("revision", proposal.revision());
 		JsonObject configuration = new JsonObject();
-		configuration.addProperty("sendVotesToAllServers", true);
-		configuration.add("blockedServers", new com.google.gson.JsonArray());
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", ProxyConfigurationFileService.FILE_NAME);
+		configuration.addProperty("content", "Proxy:\n  Enabled: true\n");
 		anticipated.add("configuration", configuration);
 		anticipated.addProperty("attemptId", "00000000-0000-0000-0000-000000000199");
 		connector = new ControlConnector(settings(), scheduler, transport,
@@ -692,13 +702,19 @@ class ControlConnectorTest {
 				"{\"error\":{\"code\":\"OPERATION_NOT_FOUND\"}}"));
 
 		connector.cycle();
+		assertEquals(0, transport.requests.stream().filter(request -> request.path().endsWith("/result")).count());
+		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
+		Field accepted = ControlConnector.class.getDeclaredField("acceptedCapabilities");
+		accepted.setAccessible(true);
+		accepted.set(connector, Set.of("presence.snapshot", "config.proxy-files.v1"));
+		connector.cycle();
 		JsonObject submitted = JsonParser.parseString(transport.requests.stream()
 				.filter(request -> request.path().endsWith("/result")).findFirst().orElseThrow().body()).getAsJsonObject();
 		assertEquals("RECOVERY_ABORTED", submitted.get("code").getAsString());
 
 		transport.operationClaim = CompletableFuture.completedFuture(new Response(204, ""));
 		connector.cycle();
-		assertEquals(1, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
+		assertEquals(2, transport.requests.stream().filter(request -> request.path().endsWith("/operations")).count());
 		assertTrue(connector.reserveRuntimeReplacement());
 	}
 

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -143,6 +143,78 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresPrimarySocketsEndpointsAndComments() throws Exception {
+		Path file = write("""
+				BungeeServer:
+				  Host: proxy.internal # proxy.internal
+				  Port: 1297 # listener port 1297
+				SpigotServers:
+				  Host:
+				    Host: survival.internal # survival.internal
+				    Port: 1298 # backend port 1298
+				    Enabled: true
+				BungeeMethod: SOCKETS
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("proxy.internal"));
+		assertFalse(current.content().contains("survival.internal"));
+		assertFalse(current.content().contains("1297"));
+		assertFalse(current.content().contains("1298"));
+		assertTrue(current.content().contains("SpigotServers:\n  Host:"));
+		assertTrue(current.content().contains("Enabled: true"));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("Host: proxy.internal # proxy.internal"));
+		assertTrue(preview.resolvedContent().contains("Port: 1297 # listener port 1297"));
+		assertTrue(preview.resolvedContent().contains("Host: survival.internal # survival.internal"));
+		assertTrue(preview.resolvedContent().contains("Port: 1298 # backend port 1298"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		String applied = Files.readString(file);
+		assertTrue(applied.contains("Host: proxy.internal # proxy.internal"));
+		assertTrue(applied.contains("Host: survival.internal # survival.internal"));
+		assertTrue(applied.contains("Debug: true"));
+	}
+
+	@Test
+	void aliasValidationUsesYamlSyntaxInsteadOfScalarOrCommentText() throws Exception {
+		Path file = write("""
+				General:
+				  Broadcast: "Hello &aPlayer and *literal"
+				  Explanation: |
+				    Keep << text, &literal, and *literal unchanged.
+				  "<<": quoted-key
+				# use *name and &name in documentation
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertTrue(current.content().contains("Hello &aPlayer and *literal"));
+		assertTrue(current.content().contains("Keep << text, &literal, and *literal unchanged."));
+		assertTrue(current.content().contains("# use *name and &name in documentation"));
+		assertTrue(current.content().contains("'<<': quoted-key")
+				|| current.content().contains("\"<<\": quoted-key"));
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("Hello &aPlayer and *literal"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		assertTrue(Files.readString(file).contains("Debug: true"));
+
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Primary: &name value\nCopy: *name\n"));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Primary: &values\n  - one\nCopy: *values\n"));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Primary: &unused value\nDebug: false\n"));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"General:\n  <<: {Debug: true}\n"));
+	}
+
+	@Test
 	void masksAndRestoresMultiProxyRedisInfrastructure() throws Exception {
 		Path file = write("""
 				MultiProxyRedis:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -1,0 +1,348 @@
+package com.bencodez.votingplugin.proxy.control;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ProxyConfigurationFileServiceTest {
+	@TempDir Path directory;
+
+	@Test
+	void readMasksCredentialsJdbcDetailsAndControlPaths() throws Exception {
+		Path file = write("""
+				Database:
+				  Host: db.internal
+				  Port: 3306
+				  Database: voting
+				  Username: admin
+				  Password: secret
+				Redis:
+				  Host: redis.internal
+				  Password: redis-secret
+				MQTT:
+				  BrokerURL: tcp://user:pass@broker.internal:1883
+				Control:
+				  CredentialFile: control/credential.txt
+				  Hosted:
+				    JarFile: control/control.jar
+				    DataDirectory: control/data
+				BungeeMethod: PLUGINMESSAGING
+				""");
+
+		String content = service(file).read(ProxyConfigurationFileService.FILE_NAME).content();
+
+		assertFalse(content.contains("db.internal"));
+		assertFalse(content.contains("voting"));
+		assertFalse(content.contains("admin"));
+		assertFalse(content.contains("secret"));
+		assertFalse(content.contains("user:pass"));
+		assertFalse(content.contains("control/credential.txt"));
+		assertFalse(content.contains("control/control.jar"));
+		assertFalse(content.contains("control/data"));
+		assertTrue(content.contains("redis.internal"));
+		assertTrue(content.contains(ProxyConfigurationFileService.REDACTED));
+	}
+
+	@Test
+	void previewRestoresMaskedValuesAndAllowsSafeNestedAdditions() throws Exception {
+		Path file = write("""
+				Database:
+				  Host: db.internal
+				  Password: secret
+				BungeeMethod: PLUGINMESSAGING
+				""");
+		ProxyConfigurationFileService service = service(file);
+		String proposal = service.read(ProxyConfigurationFileService.FILE_NAME).content()
+				+ "NewSection:\n  Enabled: true\n";
+
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, proposal);
+
+		assertTrue(preview.resolvedContent().contains("db.internal"));
+		assertTrue(preview.resolvedContent().contains("secret"));
+		assertTrue(preview.resolvedContent().contains("NewSection"));
+		assertTrue(preview.changes().contains("added NewSection.Enabled"));
+	}
+
+	@Test
+	void roundTripsCommentsStylesAndNestedAdditionsWithoutLeakingSecrets() throws Exception {
+		Path file = write("""
+				# public header
+				General: # public inline
+				  # nested public comment
+				  Message: "hello" # still public
+				  Items:
+				    - first # sequence comment
+				    - |
+				      a block value
+				      remains styled
+				  Flow: {Enabled: true, Label: 'quoted'}
+				Database:
+				  Password: secret-value # password is secret-value
+				MQTT:
+				  BrokerURL: tcp://user:password@broker.internal:1883 # jdbc://user:password@host
+				Debug: 'false'
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document document = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertTrue(document.content().contains("# public header"));
+		assertTrue(document.content().contains("# nested public comment"));
+		assertTrue(document.content().contains("# sequence comment"));
+		assertTrue(document.content().contains("Message: \"hello\""));
+		assertTrue(document.content().contains("Flow: {"));
+		assertTrue(document.content().contains("Label: 'quoted'"));
+		assertTrue(document.content().contains("Debug: 'false'"));
+		assertFalse(document.content().contains("secret-value"));
+		assertFalse(document.content().contains("user:password"));
+		assertFalse(document.content().contains("jdbc://"));
+		assertTrue(document.content().contains("# " + ProxyConfigurationFileService.REDACTED));
+
+		String proposal = document.content() + "Added:\n  Value: true\n";
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("# public header"));
+		assertTrue(preview.resolvedContent().contains("# nested public comment"));
+		assertTrue(preview.resolvedContent().contains("# sequence comment"));
+		assertTrue(preview.resolvedContent().contains("Password: secret-value # password is secret-value"));
+		assertTrue(preview.resolvedContent().contains("BrokerURL: tcp://user:password@broker.internal:1883"));
+		assertTrue(preview.resolvedContent().contains("Added:\n  Value: true"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, document.revision());
+		String applied = Files.readString(file);
+		assertTrue(applied.contains("# public header"));
+		assertTrue(applied.contains("# nested public comment"));
+		assertTrue(applied.contains("# sequence comment"));
+		assertTrue(applied.contains("Password: secret-value # password is secret-value"));
+		assertTrue(applied.contains("Added:\n  Value: true"));
+	}
+
+	@Test
+	void masksShortAndBooleanLikeSecretsRepeatedInOtherwisePublicComments() throws Exception {
+		Path file = write("""
+				Database:
+				  Password: abcde
+				Redis:
+				  Password: false
+				MQTT:
+				  Password: on
+				Socket:
+				  Password: no
+				Other:
+				  Password: x
+				Debug: false # repeats abcde
+				Feature: true # false
+				Mode: safe # on
+				Fallback: safe # no
+				Marker: safe # x
+				""");
+
+		String content = service(file).read(ProxyConfigurationFileService.FILE_NAME).content();
+
+		assertFalse(content.contains("abcde"));
+		assertFalse(content.contains("# false"));
+		assertFalse(content.contains("# on"));
+		assertFalse(content.contains("# no"));
+		assertFalse(content.contains("# x"));
+		assertTrue(content.contains("# " + ProxyConfigurationFileService.REDACTED));
+	}
+
+	@Test
+	void previewAllowsAnExplicitReplacementForAnExistingSecret() throws Exception {
+		Path file = write("Database:\n  Password: old-secret\nDebug: false\n");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String proposal = current.content().replace("Password: " + ProxyConfigurationFileService.REDACTED,
+				"Password: new-secret");
+
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, proposal);
+
+		assertTrue(preview.resolvedContent().contains("Password: new-secret"));
+		assertFalse(preview.resolvedContent().contains("old-secret"));
+	}
+
+	@Test
+	void rejectsEditedDeletedOrMovedSecretValueAndCommentMarkers() throws Exception {
+		Path file = write("""
+				Database:
+				  Password: secret # a password comment
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+		String proposal = service.read(ProxyConfigurationFileService.FILE_NAME).content();
+
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				proposal.replace(ProxyConfigurationFileService.REDACTED, "changed")));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				proposal.replace("  Password: " + ProxyConfigurationFileService.REDACTED + " # "
+						+ ProxyConfigurationFileService.REDACTED + "\n", "")));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				proposal.replace("# " + ProxyConfigurationFileService.REDACTED, "# edited")));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, "Debug: false\n"));
+		String moved = proposal.replace("  Password: " + ProxyConfigurationFileService.REDACTED + " # "
+				+ ProxyConfigurationFileService.REDACTED + "\n", "")
+					+ "OtherPassword: " + ProxyConfigurationFileService.REDACTED + " # "
+					+ ProxyConfigurationFileService.REDACTED + "\n";
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, moved));
+	}
+
+	@Test
+	void applyPublishesConfigurationAndPreservesTargetPermissions() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		try {
+			Files.setPosixFilePermissions(file, java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"));
+		} catch (UnsupportedOperationException ignored) { }
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		ProxyConfigurationFileService.ApplyResult applied = service.apply(ProxyConfigurationFileService.FILE_NAME,
+				current.content().replace("false", "true"), current.revision());
+
+		assertTrue(Files.readString(file).contains("Debug: true"));
+		assertFalse(applied.rolledBack());
+		assertTrue(Files.isRegularFile(directory.resolve("bungeeconfig.yml.control-backup")));
+		try {
+			assertEquals("rw-------", java.nio.file.attribute.PosixFilePermissions.toString(
+					Files.getPosixFilePermissions(file)));
+		} catch (UnsupportedOperationException ignored) { }
+	}
+
+	@Test
+	void publicationFailureLeavesOriginalReadableAndRetryable() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		String original = Files.readString(file);
+		AtomicInteger moves = new AtomicInteger();
+		ProxyConfigurationFileService failing = new ProxyConfigurationFileService(file, (source, destination) -> {
+			if (moves.incrementAndGet() == 2) throw new IOException("forced publication failure " + destination);
+			atomicMove(source, destination);
+		});
+		ProxyConfigurationFileService.Document current = failing.read(ProxyConfigurationFileService.FILE_NAME);
+
+		assertThrows(ProxyConfigurationFileService.ApplyFailureException.class,
+				() -> failing.apply(ProxyConfigurationFileService.FILE_NAME,
+						current.content().replace("false", "true"), current.revision()));
+		assertEquals(original, Files.readString(file));
+		try (java.util.stream.Stream<Path> files = Files.list(directory)) {
+			assertFalse(files.anyMatch(path -> path.getFileName().toString().startsWith(".control-proxy-")));
+		}
+
+		ProxyConfigurationFileService retry = service(file);
+		ProxyConfigurationFileService.ApplyResult applied = retry.apply(ProxyConfigurationFileService.FILE_NAME,
+				retry.read(ProxyConfigurationFileService.FILE_NAME).content().replace("false", "true"),
+				retry.read(ProxyConfigurationFileService.FILE_NAME).revision());
+		assertTrue(Files.readString(file).contains("Debug: true"));
+		assertFalse(applied.rolledBack());
+	}
+
+	@Test
+	void publishedDurabilityFailureRollsBackOriginal() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		try {
+			Files.setPosixFilePermissions(file, java.nio.file.attribute.PosixFilePermissions.fromString("rw-r-----"));
+		} catch (UnsupportedOperationException ignored) { }
+		String original = Files.readString(file);
+		AtomicInteger moves = new AtomicInteger();
+		ProxyConfigurationFileService failing = new ProxyConfigurationFileService(file, (source, destination) -> {
+			atomicMove(source, destination);
+			if (moves.incrementAndGet() == 2) {
+				throw new com.bencodez.votingplugin.util.DurableFiles.PublishedException(
+						new IOException("forced directory sync failure"));
+			}
+		});
+		ProxyConfigurationFileService.Document current = failing.read(ProxyConfigurationFileService.FILE_NAME);
+
+		ProxyConfigurationFileService.ApplyFailureException failure = assertThrows(
+				ProxyConfigurationFileService.ApplyFailureException.class,
+				() -> failing.apply(ProxyConfigurationFileService.FILE_NAME,
+						current.content().replace("false", "true"), current.revision()));
+
+		assertTrue(failure.rolledBack());
+		assertEquals(original, Files.readString(file));
+		try {
+			assertEquals("rw-r-----", java.nio.file.attribute.PosixFilePermissions.toString(
+					Files.getPosixFilePermissions(file)));
+		} catch (UnsupportedOperationException ignored) { }
+	}
+
+	@Test
+	void cleansTheFirstTemporaryFileWhenBackupStagingCannotBeCreated() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		AtomicInteger calls = new AtomicInteger();
+		ProxyConfigurationFileService service = new ProxyConfigurationFileService(file,
+				ProxyConfigurationFileServiceTest::atomicMove, (parent, prefix, suffix) -> {
+					if (calls.incrementAndGet() == 2) throw new IOException("forced backup-stage failure");
+					return Files.createTempFile(parent, prefix, suffix);
+				});
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		assertThrows(ProxyConfigurationFileService.ApplyFailureException.class,
+				() -> service.apply(ProxyConfigurationFileService.FILE_NAME,
+						current.content().replace("false", "true"), current.revision()));
+		assertEquals("BungeeMethod: PLUGINMESSAGING\nDebug: false\n", Files.readString(file));
+		try (java.util.stream.Stream<Path> files = Files.list(directory)) {
+			assertFalse(files.anyMatch(path -> path.getFileName().toString().startsWith(".control-proxy-")));
+		}
+	}
+
+	@Test
+	void rejectsDuplicateKeysAliasesInvalidPlaceholderAndStaleRevision() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, "Debug: true\nDebug: false\n"));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, "Base: &base {Debug: true}\nCopy: *base\n"));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+						"Debug: " + ProxyConfigurationFileService.REDACTED + "\n"));
+		Files.writeString(file, "BungeeMethod: REDIS\nDebug: false\n");
+		assertThrows(ProxyConfigurationFileService.StaleRevisionException.class,
+				() -> service.apply(ProxyConfigurationFileService.FILE_NAME, current.content(), current.revision()));
+	}
+
+	@Test
+	void rejectsSymlinkTargetsAndInvalidUtf8() throws Exception {
+		Path real = directory.resolve("real.yml");
+		Files.writeString(real, "Debug: false\n");
+		Path linked = directory.resolve("bungeeconfig.yml");
+		try {
+			Files.createSymbolicLink(linked, real.getFileName());
+		} catch (UnsupportedOperationException | IOException unsupported) {
+			return;
+		}
+		assertThrows(IOException.class,
+				() -> service(linked).read(ProxyConfigurationFileService.FILE_NAME));
+		Files.delete(linked);
+		Files.write(linked, new byte[] {(byte) 0xc3, (byte) 0x28});
+		assertThrows(IOException.class,
+				() -> service(linked).read(ProxyConfigurationFileService.FILE_NAME));
+	}
+
+	private Path write(String content) throws IOException {
+		Path file = directory.resolve("bungeeconfig.yml");
+		Files.writeString(file, content, StandardCharsets.UTF_8);
+		return file;
+	}
+
+	private static ProxyConfigurationFileService service(Path file) {
+		return new ProxyConfigurationFileService(file, ProxyConfigurationFileServiceTest::atomicMove);
+	}
+
+	private static void atomicMove(Path source, Path destination) throws IOException {
+		Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -31,12 +31,26 @@ class ProxyConfigurationFileServiceTest {
 				  Host: redis.internal
 				  Password: redis-secret
 				MQTT:
-				  BrokerURL: tcp://user:pass@broker.internal:1883
+				  ClientID: private-client
+				  BrokerURL: ssl://broker.internal:8883
+				  Username: mqtt-user
+				  Password: mqtt-password
+				  Prefix: private-prefix
 				Control:
+				  Endpoint: http://control.internal:8080
 				  CredentialFile: control/credential.txt
 				  Hosted:
 				    JarFile: control/control.jar
 				    DataDirectory: control/data
+				    Host: control-host.internal
+				    Port: 8081
+				MultiProxySocketHost:
+				  Host: socket.internal
+				  Port: 1234
+				MultiProxyServers:
+				  second:
+				    Host: second.internal
+				    Port: 1235
 				BungeeMethod: PLUGINMESSAGING
 				""");
 
@@ -46,7 +60,15 @@ class ProxyConfigurationFileServiceTest {
 		assertFalse(content.contains("voting"));
 		assertFalse(content.contains("admin"));
 		assertFalse(content.contains("secret"));
-		assertFalse(content.contains("user:pass"));
+		assertFalse(content.contains("private-client"));
+		assertFalse(content.contains("broker.internal"));
+		assertFalse(content.contains("mqtt-user"));
+		assertFalse(content.contains("mqtt-password"));
+		assertFalse(content.contains("private-prefix"));
+		assertFalse(content.contains("control.internal"));
+		assertFalse(content.contains("control-host.internal"));
+		assertFalse(content.contains("socket.internal"));
+		assertFalse(content.contains("second.internal"));
 		assertFalse(content.contains("control/credential.txt"));
 		assertFalse(content.contains("control/control.jar"));
 		assertFalse(content.contains("control/data"));
@@ -67,6 +89,15 @@ class ProxyConfigurationFileServiceTest {
 				      Port: 6379
 				      Password: nested-password
 				      SSL: true
+				  - MQTT:
+				      BrokerURL: ssl://sequence-broker.internal:8883 # sequence-broker.internal
+				      Username: sequence-mqtt-user
+				      Prefix: sequence-prefix
+				  - Control:
+				      Endpoint: http://sequence-control.internal:8080 # sequence-control.internal
+				      Hosted:
+				        Host: sequence-control-host.internal
+				        Port: 8081
 				Endpoints:
 				  - jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password
 				Debug: false
@@ -77,6 +108,11 @@ class ProxyConfigurationFileServiceTest {
 		assertFalse(current.content().contains("sequence-secret"));
 		assertFalse(current.content().contains("redis.internal"));
 		assertFalse(current.content().contains("nested-password"));
+		assertFalse(current.content().contains("sequence-broker.internal"));
+		assertFalse(current.content().contains("sequence-mqtt-user"));
+		assertFalse(current.content().contains("sequence-prefix"));
+		assertFalse(current.content().contains("sequence-control.internal"));
+		assertFalse(current.content().contains("sequence-control-host.internal"));
 		assertFalse(current.content().contains("sequence-user"));
 		assertFalse(current.content().contains("sequence-password"));
 		assertTrue(current.content().contains("SSL: true"));
@@ -87,6 +123,12 @@ class ProxyConfigurationFileServiceTest {
 		assertTrue(preview.resolvedContent().contains("Authorization: sequence-secret # sequence-secret"));
 		assertTrue(preview.resolvedContent().contains("Host: redis.internal # redis.internal"));
 		assertTrue(preview.resolvedContent().contains("Password: nested-password"));
+		assertTrue(preview.resolvedContent().contains("BrokerURL: ssl://sequence-broker.internal:8883 # sequence-broker.internal"));
+		assertTrue(preview.resolvedContent().contains("Username: sequence-mqtt-user"));
+		assertTrue(preview.resolvedContent().contains("Prefix: sequence-prefix"));
+		assertTrue(preview.resolvedContent().contains("Endpoint: http://sequence-control.internal:8080 # sequence-control.internal"));
+		assertTrue(preview.resolvedContent().contains("Host: sequence-control-host.internal"));
+		assertTrue(preview.resolvedContent().contains("Port: 8081"));
 		assertTrue(preview.resolvedContent().contains("jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password"));
 		assertTrue(preview.resolvedContent().contains("SSL: true"));
 		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
@@ -94,6 +136,8 @@ class ProxyConfigurationFileServiceTest {
 		assertTrue(applied.contains("Authorization: sequence-secret # sequence-secret"));
 		assertTrue(applied.contains("Host: redis.internal # redis.internal"));
 		assertTrue(applied.contains("Password: nested-password"));
+		assertTrue(applied.contains("BrokerURL: ssl://sequence-broker.internal:8883 # sequence-broker.internal"));
+		assertTrue(applied.contains("Endpoint: http://sequence-control.internal:8080 # sequence-control.internal"));
 		assertTrue(applied.contains("jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password"));
 		assertTrue(applied.contains("Debug: true"));
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -50,8 +50,109 @@ class ProxyConfigurationFileServiceTest {
 		assertFalse(content.contains("control/credential.txt"));
 		assertFalse(content.contains("control/control.jar"));
 		assertFalse(content.contains("control/data"));
-		assertTrue(content.contains("redis.internal"));
+		assertFalse(content.contains("redis.internal"));
+		assertFalse(content.contains("redis-secret"));
 		assertTrue(content.contains(ProxyConfigurationFileService.REDACTED));
+	}
+
+	@Test
+	void masksAndRestoresSecretsNestedInSequences() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: primary
+				    Authorization: sequence-secret # sequence-secret
+				    Enabled: true
+				  - Redis:
+				      Host: redis.internal # redis.internal
+				      Port: 6379
+				      Password: nested-password
+				      SSL: true
+				Endpoints:
+				  - jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("sequence-secret"));
+		assertFalse(current.content().contains("redis.internal"));
+		assertFalse(current.content().contains("nested-password"));
+		assertFalse(current.content().contains("sequence-user"));
+		assertFalse(current.content().contains("sequence-password"));
+		assertTrue(current.content().contains("SSL: true"));
+		assertTrue(current.content().contains(ProxyConfigurationFileService.REDACTED));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("Authorization: sequence-secret # sequence-secret"));
+		assertTrue(preview.resolvedContent().contains("Host: redis.internal # redis.internal"));
+		assertTrue(preview.resolvedContent().contains("Password: nested-password"));
+		assertTrue(preview.resolvedContent().contains("jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password"));
+		assertTrue(preview.resolvedContent().contains("SSL: true"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		String applied = Files.readString(file);
+		assertTrue(applied.contains("Authorization: sequence-secret # sequence-secret"));
+		assertTrue(applied.contains("Host: redis.internal # redis.internal"));
+		assertTrue(applied.contains("Password: nested-password"));
+		assertTrue(applied.contains("jdbc:mysql://sequence-user:sequence-password@db.internal/votes # sequence-password"));
+		assertTrue(applied.contains("Debug: true"));
+	}
+
+	@Test
+	void masksAndRestoresMultiProxyRedisInfrastructure() throws Exception {
+		Path file = write("""
+				MultiProxyRedis:
+				  Host: multi-redis.internal # multi-redis.internal
+				  Port: 6380
+				  Username: multi-user
+				  Password: multi-password
+				  Db-Index: 2
+				  SSL: true
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("multi-redis.internal"));
+		assertFalse(current.content().contains("6380"));
+		assertFalse(current.content().contains("multi-user"));
+		assertFalse(current.content().contains("multi-password"));
+		assertFalse(current.content().contains("Db-Index: 2"));
+		assertTrue(current.content().contains("SSL: true"));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("Host: multi-redis.internal # multi-redis.internal"));
+		assertTrue(preview.resolvedContent().contains("Port: 6380"));
+		assertTrue(preview.resolvedContent().contains("Username: multi-user"));
+		assertTrue(preview.resolvedContent().contains("Password: multi-password"));
+		assertTrue(preview.resolvedContent().contains("Db-Index: 2"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		assertTrue(Files.readString(file).contains("Host: multi-redis.internal # multi-redis.internal"));
+	}
+
+	@Test
+	void rejectsRemovedReorderedOrIntroducedSequenceSecretMarkers() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: primary
+				    Authorization: sequence-secret
+				  - Name: secondary
+				    Enabled: true
+				""");
+		ProxyConfigurationFileService service = service(file);
+		String proposal = service.read(ProxyConfigurationFileService.FILE_NAME).content();
+		String removed = "Hooks:\n  - Name: primary\n  - Name: secondary\n    Enabled: true\n";
+		String reordered = "Hooks:\n  - Name: secondary\n    Enabled: true\n  - Name: primary\n"
+				+ "    Authorization: " + ProxyConfigurationFileService.REDACTED + "\n";
+
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, removed));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, reordered));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+						proposal + "Unexpected:\n  - " + ProxyConfigurationFileService.REDACTED + "\n"));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -143,6 +143,20 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void preservesNullEntriesInSequencesAcrossReadPreviewAndApply() throws Exception {
+		Path file = write("Servers: [null, active]\nEmptyEntries:\n  -\nDebug: false\n");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+
+		assertTrue(preview.resolvedContent().contains("null"));
+		assertTrue(Files.readString(file).contains("Debug: true"));
+	}
+
+	@Test
 	void masksAndRestoresPrimarySocketsEndpointsAndComments() throws Exception {
 		Path file = write("""
 				BungeeServer:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -84,6 +84,11 @@ class ProxyConfigurationFileServiceTest {
 				Access.Key: access-key-secret
 				Client.Secret: client-secret
 				Pass.Phrase: pass-phrase-secret
+				Database.User: service_account
+				DatabaseUsername: database_operator
+				DatabaseUserName: database_named_operator
+				Database.UserName: database_dotted_operator
+				MySQLUserName: mysql_named_operator
 				Debug: false
 				""");
 		ProxyConfigurationFileService service = service(file);
@@ -93,6 +98,11 @@ class ProxyConfigurationFileServiceTest {
 		assertFalse(current.content().contains("access-key-secret"));
 		assertFalse(current.content().contains("client-secret"));
 		assertFalse(current.content().contains("pass-phrase-secret"));
+		assertFalse(current.content().contains("service_account"));
+		assertFalse(current.content().contains("database_operator"));
+		assertFalse(current.content().contains("database_named_operator"));
+		assertFalse(current.content().contains("database_dotted_operator"));
+		assertFalse(current.content().contains("mysql_named_operator"));
 
 		String proposal = current.content().replace("Debug: false", "Debug: true");
 		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
@@ -100,6 +110,11 @@ class ProxyConfigurationFileServiceTest {
 		assertTrue(preview.resolvedContent().contains("Access.Key: access-key-secret"));
 		assertTrue(preview.resolvedContent().contains("Client.Secret: client-secret"));
 		assertTrue(preview.resolvedContent().contains("Pass.Phrase: pass-phrase-secret"));
+		assertTrue(preview.resolvedContent().contains("Database.User: service_account"));
+		assertTrue(preview.resolvedContent().contains("DatabaseUsername: database_operator"));
+		assertTrue(preview.resolvedContent().contains("DatabaseUserName: database_named_operator"));
+		assertTrue(preview.resolvedContent().contains("Database.UserName: database_dotted_operator"));
+		assertTrue(preview.resolvedContent().contains("MySQLUserName: mysql_named_operator"));
 
 		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
 		assertTrue(Files.readString(file).contains("Debug: true"));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -672,6 +672,68 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksDelimiterFreeSingleLabelInfrastructureHostsInComments() throws Exception {
+		Path file = write("""
+				# alternate Redis host redis-primary
+				# failover endpoint control
+				# database host db-production
+				# broker localhost:1883
+				# port 25565
+				# Control URL control-proxy
+				Feature: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("redis-primary"));
+		assertFalse(current.content().contains("control"));
+		assertFalse(current.content().contains("db-production"));
+		assertFalse(current.content().contains("localhost"));
+		assertFalse(current.content().contains("25565"));
+		assertFalse(current.content().contains("control-proxy"));
+		assertTrue(current.content().contains(ProxyConfigurationFileService.REDACTED));
+
+		String proposal = current.content().replace("Feature: false", "Feature: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("alternate Redis host redis-primary"));
+		assertTrue(preview.resolvedContent().contains("failover endpoint control"));
+		assertTrue(preview.resolvedContent().contains("database host db-production"));
+		assertTrue(preview.resolvedContent().contains("broker localhost:1883"));
+		assertTrue(preview.resolvedContent().contains("port 25565"));
+		assertTrue(preview.resolvedContent().contains("Control URL control-proxy"));
+	}
+
+	@Test
+	void allowsSafeEndAppendsToSecretBearingLists() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: primary
+				    Password: primary-secret
+				  - Name: secondary
+				    Password: secondary-secret
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		String proposal = current.content().replace("Debug: false",
+				"- Name: tertiary\n  Password: tertiary-secret\nDebug: false");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+
+		assertTrue(preview.resolvedContent().contains("Name: primary"));
+		assertTrue(preview.resolvedContent().contains("Password: primary-secret"));
+		assertTrue(preview.resolvedContent().contains("Name: secondary"));
+		assertTrue(preview.resolvedContent().contains("Password: secondary-secret"));
+		assertTrue(preview.resolvedContent().contains("Name: tertiary"));
+		assertTrue(preview.resolvedContent().contains("Password: tertiary-secret"));
+
+		String markerAppend = current.content().replace("Debug: false",
+				"- Name: tertiary\n  Password: " + ProxyConfigurationFileService.REDACTED + "\nDebug: false");
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, markerAppend));
+	}
+
+	@Test
 	void masksShortAndBooleanLikeSecretsRepeatedInOtherwisePublicComments() throws Exception {
 		Path file = write("""
 				Database:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -78,6 +78,34 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresDottedCredentialFieldNames() throws Exception {
+		Path file = write("""
+				API.Key: api-key-secret
+				Access.Key: access-key-secret
+				Client.Secret: client-secret
+				Pass.Phrase: pass-phrase-secret
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("api-key-secret"));
+		assertFalse(current.content().contains("access-key-secret"));
+		assertFalse(current.content().contains("client-secret"));
+		assertFalse(current.content().contains("pass-phrase-secret"));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("API.Key: api-key-secret"));
+		assertTrue(preview.resolvedContent().contains("Access.Key: access-key-secret"));
+		assertTrue(preview.resolvedContent().contains("Client.Secret: client-secret"));
+		assertTrue(preview.resolvedContent().contains("Pass.Phrase: pass-phrase-secret"));
+
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		assertTrue(Files.readString(file).contains("Debug: true"));
+	}
+
+	@Test
 	void masksAndRestoresCompoundCredentialFields() throws Exception {
 		Path file = write("""
 				AuthToken: auth-token-value

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -78,6 +78,49 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresEverySupportedDatabaseLayout() throws Exception {
+		Path file = write("""
+				Host: root.internal
+				Port: 3306
+				Database: rootdb
+				Username: rootuser
+				MySQL:
+				  Host: mysql.internal
+				  Username: mysqluser
+				VoteCache:
+				  Host: vote-cache.internal
+				  Username: cacheuser
+				NonVotedCache:
+				  Host: non-voted.internal
+				  Database: nonvoted
+				VoteLogging:
+				  Host: vote-log.internal
+				  Line: '&useSSL=true'
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("root.internal"));
+		assertFalse(current.content().contains("mysql.internal"));
+		assertFalse(current.content().contains("vote-cache.internal"));
+		assertFalse(current.content().contains("non-voted.internal"));
+		assertFalse(current.content().contains("vote-log.internal"));
+		assertFalse(current.content().contains("cacheuser"));
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+
+		assertTrue(preview.resolvedContent().contains("vote-cache.internal"));
+		String applied = Files.readString(file);
+		assertTrue(applied.contains("root.internal"));
+		assertTrue(applied.contains("mysql.internal"));
+		assertTrue(applied.contains("non-voted.internal"));
+		assertTrue(applied.contains("vote-log.internal"));
+		assertTrue(applied.contains("Debug: true"));
+	}
+
+	@Test
 	void masksAndRestoresSecretsNestedInSequences() throws Exception {
 		Path file = write("""
 				Hooks:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -502,6 +502,124 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksInfrastructureLabelsAndOrdinaryConnectionUrlsInComments() throws Exception {
+		Path file = write("""
+				# failover host: replica.internal
+				# ProxyHost: proxy.internal
+				# ControlEndpoint: https://control-alt.internal
+				# RedisHost: cache-alt.internal
+				# PrimaryRedisHost: redis-primary.internal
+				# FailoverDatabaseHost: db-failover.internal
+				# MultiProxyRedisHost: redis-multiproxy.internal
+				# MultiProxySocketHost: socket-multiproxy.internal
+				# BungeeServerHost: bungee.internal
+				# SpigotServersHost: spigot.internal
+				# CustomHostName: custom-db.internal
+				# FailoverDbName: votes_failover
+				# DBHost: db-acronym.internal
+				# DBPORT: 3306
+				# REDISPORT: 6379
+				# MySQLHost: mysql-acronym.internal
+				# DBURL: cluster.internal:5432
+				# APIURL: control-api.internal
+				# AuthToken: bearer-value
+				FeatureTwo: false # ApiToken: alternate-bearer
+				# Credential: secret-value
+				# AccessKey: access-value
+				# PrivateKey: private-value
+				# SSHPrivateKeyData: private-key-data
+				# AWSAccessKeyId: aws-access-id
+				# ApiKeyId: api-key-id
+				# IP: 10.0.0.8
+				# IPv4: 10.0.0.9
+				# IPv6: fd00::10
+				# connect through 10.0.0.10
+				# fail over to bare-db.internal
+				# Note: failover host: nested-label.internal
+				# management endpoint = https://control.internal:8443
+				# cache connection: redis://cache.internal:6379
+				Feature: false # database host: primary.internal
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("replica.internal"));
+		assertFalse(current.content().contains("proxy.internal"));
+		assertFalse(current.content().contains("control-alt.internal"));
+		assertFalse(current.content().contains("cache-alt.internal"));
+		assertFalse(current.content().contains("redis-primary.internal"));
+		assertFalse(current.content().contains("db-failover.internal"));
+		assertFalse(current.content().contains("redis-multiproxy.internal"));
+		assertFalse(current.content().contains("socket-multiproxy.internal"));
+		assertFalse(current.content().contains("bungee.internal"));
+		assertFalse(current.content().contains("spigot.internal"));
+		assertFalse(current.content().contains("custom-db.internal"));
+		assertFalse(current.content().contains("votes_failover"));
+		assertFalse(current.content().contains("db-acronym.internal"));
+		assertFalse(current.content().contains("3306"));
+		assertFalse(current.content().contains("6379"));
+		assertFalse(current.content().contains("mysql-acronym.internal"));
+		assertFalse(current.content().contains("cluster.internal"));
+		assertFalse(current.content().contains("control-api.internal"));
+		assertFalse(current.content().contains("bearer-value"));
+		assertFalse(current.content().contains("alternate-bearer"));
+		assertFalse(current.content().contains("secret-value"));
+		assertFalse(current.content().contains("access-value"));
+		assertFalse(current.content().contains("private-value"));
+		assertFalse(current.content().contains("private-key-data"));
+		assertFalse(current.content().contains("aws-access-id"));
+		assertFalse(current.content().contains("api-key-id"));
+		assertFalse(current.content().contains("10.0.0.8"));
+		assertFalse(current.content().contains("10.0.0.9"));
+		assertFalse(current.content().contains("fd00::10"));
+		assertFalse(current.content().contains("10.0.0.10"));
+		assertFalse(current.content().contains("bare-db.internal"));
+		assertFalse(current.content().contains("nested-label.internal"));
+		assertFalse(current.content().contains("control.internal"));
+		assertFalse(current.content().contains("cache.internal"));
+		assertFalse(current.content().contains("primary.internal"));
+		assertTrue(current.content().contains(ProxyConfigurationFileService.REDACTED));
+
+		String proposal = current.content().replace("Feature: false", "Feature: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("replica.internal"));
+		assertTrue(preview.resolvedContent().contains("ProxyHost: proxy.internal"));
+		assertTrue(preview.resolvedContent().contains("ControlEndpoint: https://control-alt.internal"));
+		assertTrue(preview.resolvedContent().contains("RedisHost: cache-alt.internal"));
+		assertTrue(preview.resolvedContent().contains("PrimaryRedisHost: redis-primary.internal"));
+		assertTrue(preview.resolvedContent().contains("FailoverDatabaseHost: db-failover.internal"));
+		assertTrue(preview.resolvedContent().contains("MultiProxyRedisHost: redis-multiproxy.internal"));
+		assertTrue(preview.resolvedContent().contains("MultiProxySocketHost: socket-multiproxy.internal"));
+		assertTrue(preview.resolvedContent().contains("BungeeServerHost: bungee.internal"));
+		assertTrue(preview.resolvedContent().contains("SpigotServersHost: spigot.internal"));
+		assertTrue(preview.resolvedContent().contains("CustomHostName: custom-db.internal"));
+		assertTrue(preview.resolvedContent().contains("FailoverDbName: votes_failover"));
+		assertTrue(preview.resolvedContent().contains("DBHost: db-acronym.internal"));
+		assertTrue(preview.resolvedContent().contains("DBPORT: 3306"));
+		assertTrue(preview.resolvedContent().contains("REDISPORT: 6379"));
+		assertTrue(preview.resolvedContent().contains("MySQLHost: mysql-acronym.internal"));
+		assertTrue(preview.resolvedContent().contains("DBURL: cluster.internal:5432"));
+		assertTrue(preview.resolvedContent().contains("APIURL: control-api.internal"));
+		assertTrue(preview.resolvedContent().contains("AuthToken: bearer-value"));
+		assertTrue(preview.resolvedContent().contains("ApiToken: alternate-bearer"));
+		assertTrue(preview.resolvedContent().contains("Credential: secret-value"));
+		assertTrue(preview.resolvedContent().contains("AccessKey: access-value"));
+		assertTrue(preview.resolvedContent().contains("PrivateKey: private-value"));
+		assertTrue(preview.resolvedContent().contains("SSHPrivateKeyData: private-key-data"));
+		assertTrue(preview.resolvedContent().contains("AWSAccessKeyId: aws-access-id"));
+		assertTrue(preview.resolvedContent().contains("ApiKeyId: api-key-id"));
+		assertTrue(preview.resolvedContent().contains("IP: 10.0.0.8"));
+		assertTrue(preview.resolvedContent().contains("IPv4: 10.0.0.9"));
+		assertTrue(preview.resolvedContent().contains("IPv6: fd00::10"));
+		assertTrue(preview.resolvedContent().contains("connect through 10.0.0.10"));
+		assertTrue(preview.resolvedContent().contains("fail over to bare-db.internal"));
+		assertTrue(preview.resolvedContent().contains("Note: failover host: nested-label.internal"));
+		assertTrue(preview.resolvedContent().contains("https://control.internal:8443"));
+		assertTrue(preview.resolvedContent().contains("redis://cache.internal:6379"));
+		assertTrue(preview.resolvedContent().contains("primary.internal"));
+	}
+
+	@Test
 	void masksShortAndBooleanLikeSecretsRepeatedInOtherwisePublicComments() throws Exception {
 		Path file = write("""
 				Database:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -474,6 +474,34 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void previewAllowsAnExplicitReplacementForASecretSequenceItem() throws Exception {
+		Path file = write("Endpoints:\n  - jdbc:mysql://old-user:old-password@db.invalid/votes\n");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String proposal = current.content().replace(ProxyConfigurationFileService.REDACTED,
+				"jdbc:mysql://new-user:new-password@db.invalid/votes");
+
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, proposal);
+
+		assertTrue(preview.resolvedContent().contains("jdbc:mysql://new-user:new-password@db.invalid/votes"));
+	}
+
+	@Test
+	void restoresCommentsForDottedAndNestedKeysWithoutLocationCollisions() throws Exception {
+		Path file = write("\"Database.Password\": first-secret # first secret comment\n"
+				+ "Database:\n  Password: second-secret # second secret comment\n");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, current.content());
+
+		assertTrue(preview.resolvedContent().contains("first-secret # first secret comment"));
+		assertTrue(preview.resolvedContent().contains("second-secret # second secret comment"));
+	}
+
+	@Test
 	void rejectsEditedDeletedOrMovedSecretValueAndCommentMarkers() throws Exception {
 		Path file = write("""
 				Database:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -83,6 +83,7 @@ class ProxyConfigurationFileServiceTest {
 				Host: root.internal
 				Port: 3306
 				Database: rootdb
+				Name: legacy_table
 				Username: rootuser
 				MySQL:
 				  Host: mysql.internal
@@ -102,6 +103,7 @@ class ProxyConfigurationFileServiceTest {
 
 		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
 		assertFalse(current.content().contains("root.internal"));
+		assertFalse(current.content().contains("legacy_table"));
 		assertFalse(current.content().contains("mysql.internal"));
 		assertFalse(current.content().contains("vote-cache.internal"));
 		assertFalse(current.content().contains("non-voted.internal"));
@@ -114,6 +116,7 @@ class ProxyConfigurationFileServiceTest {
 		assertTrue(preview.resolvedContent().contains("vote-cache.internal"));
 		String applied = Files.readString(file);
 		assertTrue(applied.contains("root.internal"));
+		assertTrue(applied.contains("legacy_table"));
 		assertTrue(applied.contains("mysql.internal"));
 		assertTrue(applied.contains("non-voted.internal"));
 		assertTrue(applied.contains("vote-log.internal"));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -106,6 +106,35 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresCompoundInfrastructureScalarNames() throws Exception {
+		Path file = write("""
+				ControlEndpoint: https://control.internal
+				RedisHost: cache.internal
+				BungeeMethod: PLUGINMESSAGING
+				DedicatedVotingProxy: true
+				ProxyServerName: public-name
+				MultiProxySupport: true
+				HttpTransport: enabled
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("control.internal"));
+		assertFalse(current.content().contains("cache.internal"));
+		assertTrue(current.content().contains("BungeeMethod: PLUGINMESSAGING"));
+		assertTrue(current.content().contains("DedicatedVotingProxy: true"));
+		assertTrue(current.content().contains("ProxyServerName: public-name"));
+		assertTrue(current.content().contains("MultiProxySupport: true"));
+		assertTrue(current.content().contains("HttpTransport: enabled"));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("ControlEndpoint: https://control.internal"));
+		assertTrue(preview.resolvedContent().contains("RedisHost: cache.internal"));
+	}
+
+	@Test
 	void masksAndRestoresCompoundCredentialFields() throws Exception {
 		Path file = write("""
 				AuthToken: auth-token-value
@@ -962,6 +991,30 @@ class ProxyConfigurationFileServiceTest {
 			assertEquals("rw-------", java.nio.file.attribute.PosixFilePermissions.toString(
 					Files.getPosixFilePermissions(file)));
 		} catch (UnsupportedOperationException ignored) { }
+	}
+
+	@Test
+	void preparedApplyBindsResolutionAndPublicationToOneRevisionCheckedSnapshot() throws Exception {
+		String original = "Password: secret-b\nDebug: false\n";
+		Path file = write(original);
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+
+		Files.writeString(file, "Password: secret-a\nDebug: false\n");
+		assertThrows(ProxyConfigurationFileService.StaleRevisionException.class,
+				() -> service.prepareApply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision()));
+
+		Files.writeString(file, original);
+		ProxyConfigurationFileService.PreparedApply prepared = service.prepareApply(
+				ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		assertTrue(prepared.preview().resolvedContent().contains("Password: secret-b"));
+		ProxyConfigurationFileService.ApplyResult applied = service.apply(prepared);
+
+		assertTrue(Files.readString(file).contains("Password: secret-b"));
+		assertTrue(Files.readString(file).contains("Debug: true"));
+		assertEquals(ProxyConfigurationFileService.revision(prepared.preview().resolvedContent()),
+				applied.document().revision());
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -125,6 +125,8 @@ class ProxyConfigurationFileServiceTest {
 		Path file = write("""
 				ControlEndpoint: https://control.internal
 				RedisHost: cache.internal
+				DatabaseServer: database.internal
+				RedisServer: redis.internal
 				BungeeMethod: PLUGINMESSAGING
 				DedicatedVotingProxy: true
 				ProxyServerName: public-name
@@ -137,6 +139,8 @@ class ProxyConfigurationFileServiceTest {
 		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
 		assertFalse(current.content().contains("control.internal"));
 		assertFalse(current.content().contains("cache.internal"));
+		assertFalse(current.content().contains("database.internal"));
+		assertFalse(current.content().contains("redis.internal"));
 		assertTrue(current.content().contains("BungeeMethod: PLUGINMESSAGING"));
 		assertTrue(current.content().contains("DedicatedVotingProxy: true"));
 		assertTrue(current.content().contains("ProxyServerName: public-name"));
@@ -147,6 +151,8 @@ class ProxyConfigurationFileServiceTest {
 		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
 		assertTrue(preview.resolvedContent().contains("ControlEndpoint: https://control.internal"));
 		assertTrue(preview.resolvedContent().contains("RedisHost: cache.internal"));
+		assertTrue(preview.resolvedContent().contains("DatabaseServer: database.internal"));
+		assertTrue(preview.resolvedContent().contains("RedisServer: redis.internal"));
 	}
 
 	@Test
@@ -564,6 +570,12 @@ class ProxyConfigurationFileServiceTest {
 		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
 		String safeSuffixRemoval = "Hooks:\n  - Name: primary\n    Password: "
 				+ ProxyConfigurationFileService.REDACTED + "\nDebug: false\n";
+		String rotationWithSafeSuffixRemoval = "Hooks:\n  - Name: primary\n    Password: rotated-secret\nDebug: false\n";
+
+		ProxyConfigurationFileService.Preview rotated = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, rotationWithSafeSuffixRemoval);
+		assertTrue(rotated.resolvedContent().contains("Password: rotated-secret"));
+		assertFalse(rotated.resolvedContent().contains("removable-tail"));
 
 		ProxyConfigurationFileService.Preview preview = service.preview(
 				ProxyConfigurationFileService.FILE_NAME, safeSuffixRemoval);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -200,6 +200,10 @@ class ProxyConfigurationFileServiceTest {
 		String unchangedOrder = current.content().replace("Debug: false", "Debug: true");
 		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, unchangedOrder).resolvedContent()
 				.contains("Password: alpha-secret"));
+		String rotatedSecret = current.content().replace("Password: " + ProxyConfigurationFileService.REDACTED,
+				"Password: rotated-secret");
+		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, rotatedSecret).resolvedContent()
+				.contains("Password: rotated-secret"));
 		String reordered = current.content().replace("Name: alpha", "Name: __swapped__")
 				.replace("Name: beta", "Name: alpha").replace("Name: __swapped__", "Name: beta");
 		assertThrows(IllegalArgumentException.class,
@@ -572,6 +576,32 @@ class ProxyConfigurationFileServiceTest {
 			assertEquals("rw-r-----", java.nio.file.attribute.PosixFilePermissions.toString(
 					Files.getPosixFilePermissions(file)));
 		} catch (UnsupportedOperationException ignored) { }
+	}
+
+	@Test
+	void doesNotRollbackOverAnAdministratorEditDuringRollbackStaging() throws Exception {
+		Path file = write("BungeeMethod: PLUGINMESSAGING\nDebug: false\n");
+		AtomicInteger moves = new AtomicInteger(), tempFiles = new AtomicInteger();
+		ProxyConfigurationFileService service = new ProxyConfigurationFileService(file, (source, destination) -> {
+			atomicMove(source, destination);
+			if (moves.incrementAndGet() == 2)
+				throw new com.bencodez.votingplugin.util.DurableFiles.PublishedException(
+						new IOException("forced publication failure"));
+		}, (parent, prefix, suffix) -> {
+			Path temporary = Files.createTempFile(parent, prefix, suffix);
+			if (tempFiles.incrementAndGet() == 3)
+				Files.writeString(file, "BungeeMethod: ADMIN_EDIT\nDebug: true\n");
+			return temporary;
+		});
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		ProxyConfigurationFileService.ApplyFailureException failure = assertThrows(
+				ProxyConfigurationFileService.ApplyFailureException.class,
+				() -> service.apply(ProxyConfigurationFileService.FILE_NAME,
+						current.content().replace("false", "true"), current.revision()));
+
+		assertFalse(failure.rolledBack());
+		assertEquals("BungeeMethod: ADMIN_EDIT\nDebug: true\n", Files.readString(file));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -333,17 +333,20 @@ class ProxyConfigurationFileServiceTest {
 		Path file = write("""
 				Database:
 				  Host: db.internal
+				  Name: votes_table
 				  Password: secret
 				BungeeMethod: PLUGINMESSAGING
 				""");
 		ProxyConfigurationFileService service = service(file);
 		String proposal = service.read(ProxyConfigurationFileService.FILE_NAME).content()
 				+ "NewSection:\n  Enabled: true\n";
+		assertFalse(proposal.contains("votes_table"));
 
 		ProxyConfigurationFileService.Preview preview = service.preview(
 				ProxyConfigurationFileService.FILE_NAME, proposal);
 
 		assertTrue(preview.resolvedContent().contains("db.internal"));
+		assertTrue(preview.resolvedContent().contains("votes_table"));
 		assertTrue(preview.resolvedContent().contains("secret"));
 		assertTrue(preview.resolvedContent().contains("NewSection"));
 		assertTrue(preview.changes().contains("added NewSection.Enabled"));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -194,8 +194,10 @@ class ProxyConfigurationFileServiceTest {
 				Hooks:
 				  - Name: alpha
 				    Password: alpha-secret
+				    Enabled: true
 				  - Name: beta
 				    Password: beta-secret
+				    Enabled: true
 				Debug: false
 				""");
 		ProxyConfigurationFileService service = service(file);
@@ -207,10 +209,34 @@ class ProxyConfigurationFileServiceTest {
 				"Password: rotated-secret");
 		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, rotatedSecret).resolvedContent()
 				.contains("Password: rotated-secret"));
+		String publicEdit = current.content().replaceFirst("Enabled: true", "Enabled: false");
+		String publicEditResolved = service.preview(ProxyConfigurationFileService.FILE_NAME, publicEdit).resolvedContent();
+		assertTrue(publicEditResolved.contains("Enabled: false"));
+		assertTrue(publicEditResolved.contains("Password: alpha-secret"));
 		String reordered = current.content().replace("Name: alpha", "Name: __swapped__")
 				.replace("Name: beta", "Name: alpha").replace("Name: __swapped__", "Name: beta");
 		assertThrows(IllegalArgumentException.class,
 				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, reordered));
+	}
+
+	@Test
+	void rejectsPublicEditsWhenSecretBearingEntriesHaveDuplicateIdentities() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: duplicate
+				    Password: first-secret
+				    Enabled: true
+				  - Name: duplicate
+				    Password: second-secret
+				    Enabled: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+		String current = service.read(ProxyConfigurationFileService.FILE_NAME).content();
+		String swappedPublicValues = current.replace("Enabled: true", "Enabled: __swapped__")
+				.replace("Enabled: false", "Enabled: true").replace("Enabled: __swapped__", "Enabled: false");
+
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, swappedPublicValues));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -78,6 +78,26 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksHostedControlDownloadUrlAndRestoresItForEdits() throws Exception {
+		String downloadUrl = "https://control.internal/download/token-value";
+		Path file = write("""
+				Control:
+				  Hosted:
+				    DownloadUrl: %s
+				Debug: false
+				""".formatted(downloadUrl));
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains(downloadUrl));
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains(downloadUrl));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, proposal, current.revision());
+		assertTrue(Files.readString(file).contains(downloadUrl));
+	}
+
+	@Test
 	void masksAndRestoresEverySupportedDatabaseLayout() throws Exception {
 		Path file = write("""
 				Host: root.internal

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -78,6 +78,58 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresCompoundCredentialFields() throws Exception {
+		Path file = write("""
+				AuthToken: auth-token-value
+				AccessToken: access-token-value
+				Credential: credential-value
+				PrivateKey: plain-private-material
+				Private Key: spaced-private-key-value
+				Access Key: spaced-access-key-value
+				API Key: spaced-api-key-value
+				KeyPassphrase: passphrase-value
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("auth-token-value"));
+		assertFalse(current.content().contains("access-token-value"));
+		assertFalse(current.content().contains("credential-value"));
+		assertFalse(current.content().contains("plain-private-material"));
+		assertFalse(current.content().contains("spaced-private-key-value"));
+		assertFalse(current.content().contains("spaced-access-key-value"));
+		assertFalse(current.content().contains("spaced-api-key-value"));
+		assertFalse(current.content().contains("passphrase-value"));
+
+		String proposal = current.content().replace("Debug: false", "Debug: true");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+		assertTrue(preview.resolvedContent().contains("AuthToken: auth-token-value"));
+		assertTrue(preview.resolvedContent().contains("AccessToken: access-token-value"));
+		assertTrue(preview.resolvedContent().contains("Credential: credential-value"));
+		assertTrue(preview.resolvedContent().contains("PrivateKey: plain-private-material"));
+		assertTrue(preview.resolvedContent().contains("Private Key: spaced-private-key-value"));
+		assertTrue(preview.resolvedContent().contains("Access Key: spaced-access-key-value"));
+		assertTrue(preview.resolvedContent().contains("API Key: spaced-api-key-value"));
+		assertTrue(preview.resolvedContent().contains("KeyPassphrase: passphrase-value"));
+	}
+
+	@Test
+	void previewAgainstSnapshotDoesNotResolveMarkersFromALaterFileVersion() throws Exception {
+		String revisionA = "AuthToken: secret-a\nDebug: false\n";
+		Path file = write(revisionA);
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		Files.writeString(file, "AuthToken: secret-b\nDebug: false\n");
+
+		ProxyConfigurationFileService.Preview preview = service.previewAgainstSnapshot(
+				current.content().replace("Debug: false", "Debug: true"), revisionA);
+
+		assertTrue(preview.resolvedContent().contains("AuthToken: secret-a"));
+		assertFalse(preview.resolvedContent().contains("secret-b"));
+	}
+
+	@Test
 	void masksHostedControlDownloadUrlAndRestoresItForEdits() throws Exception {
 		String downloadUrl = "https://control.internal/download/token-value";
 		Path file = write("""

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -555,6 +555,44 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void changeDescriptionsDistinguishDottedKeysFromNestedPaths() throws Exception {
+		Path file = write("\"a.b.x\": dotted\na:\n  b:\n    x: nested\n");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		String proposal = current.content().replace("dotted", "changed-dotted").replace("x: nested", "x: changed-nested");
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME, proposal);
+
+		assertEquals(java.util.List.of("changed a.b.x", "changed [\"a.b.x\"]"), preview.changes());
+	}
+
+	@Test
+	void changeDescriptionsPreserveYamlValueTypes() throws Exception {
+		Path file = write("Enabled: \"true\"\nPort: \"1\"\n");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Enabled: true\nPort: 1\n");
+
+		assertEquals(java.util.List.of("changed Enabled", "changed Port"), preview.changes());
+	}
+
+	@Test
+	void changeDescriptionsReportEmptyMappingAdditionsAndRemovals() throws Exception {
+		Path file = write("Enabled: true\nSection: {}\n");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Preview removal = service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Enabled: true\n");
+		assertEquals(java.util.List.of("removed Section"), removal.changes());
+
+		Files.writeString(file, "Enabled: true\n");
+		ProxyConfigurationFileService.Preview addition = service.preview(ProxyConfigurationFileService.FILE_NAME,
+				"Enabled: true\nSection: {}\n");
+		assertEquals(java.util.List.of("added Section"), addition.changes());
+	}
+
+	@Test
 	void rejectsEditedDeletedOrMovedSecretValueAndCommentMarkers() throws Exception {
 		Path file = write("""
 				Database:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -994,6 +994,26 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void comparesRedactedCommentOwnersRegardlessOfMappingOrder() throws Exception {
+		Path file = write("Alpha:\n  Enabled: true # Password: alpha-secret\n"
+				+ "Beta:\n  Enabled: true # Token: beta-secret\n");
+		ProxyConfigurationFileService service = service(file);
+
+		String reordered = "Beta:\n  Enabled: false # " + ProxyConfigurationFileService.REDACTED + "\n"
+				+ "Alpha:\n  Enabled: true # " + ProxyConfigurationFileService.REDACTED + "\n";
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, reordered);
+		assertTrue(preview.resolvedContent().contains("Token: beta-secret"));
+		assertTrue(preview.resolvedContent().contains("Password: alpha-secret"));
+
+		String moved = "Beta:\n  Enabled: false # " + ProxyConfigurationFileService.REDACTED
+				+ "\n  Extra: true # " + ProxyConfigurationFileService.REDACTED + "\n"
+				+ "Alpha:\n  Enabled: true\n";
+		assertThrows(IllegalArgumentException.class, () -> service.preview(
+				ProxyConfigurationFileService.FILE_NAME, moved));
+	}
+
+	@Test
 	void changeDescriptionsDistinguishDottedKeysFromNestedPaths() throws Exception {
 		Path file = write("\"a.b.x\": dotted\na:\n  b:\n    x: nested\n");
 		ProxyConfigurationFileService service = service(file);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -220,6 +220,27 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void allowsAddingOrRemovingNonSecretFieldsFromIdentifiedSecretEntries() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: primary
+				    Password: primary-secret
+				    Enabled: true
+				""");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+
+		String added = current.content().replace("Password: " + ProxyConfigurationFileService.REDACTED + "\n",
+				"Password: " + ProxyConfigurationFileService.REDACTED + "\n  Description: primary\n");
+		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, added).resolvedContent()
+				.contains("Description: primary"));
+
+		String removed = current.content().replaceFirst("  Enabled: true\\n", "");
+		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, removed).resolvedContent()
+				.contains("Password: primary-secret"));
+	}
+
+	@Test
 	void rejectsPublicEditsWhenSecretBearingEntriesHaveDuplicateIdentities() throws Exception {
 		Path file = write("""
 				Hooks:
@@ -237,6 +258,9 @@ class ProxyConfigurationFileServiceTest {
 
 		assertThrows(IllegalArgumentException.class,
 				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, swappedPublicValues));
+		String removedPublicField = current.replaceFirst("  Enabled: true\\n", "");
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, removedPublicField));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -479,6 +479,50 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void allowsOnlySafeSuffixRemovalFromSecretBearingLists() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: primary
+				    Password: primary-secret
+				  - Name: removable-tail
+				    Enabled: true
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String safeSuffixRemoval = "Hooks:\n  - Name: primary\n    Password: "
+				+ ProxyConfigurationFileService.REDACTED + "\nDebug: false\n";
+
+		ProxyConfigurationFileService.Preview preview = service.preview(
+				ProxyConfigurationFileService.FILE_NAME, safeSuffixRemoval);
+		assertTrue(preview.resolvedContent().contains("Password: primary-secret"));
+		assertFalse(preview.resolvedContent().contains("removable-tail"));
+		service.apply(ProxyConfigurationFileService.FILE_NAME, safeSuffixRemoval, current.revision());
+		assertFalse(Files.readString(file).contains("removable-tail"));
+
+		Path secretTail = write("""
+				Hooks:
+				  - Name: public
+				    Enabled: true
+				  - Name: protected-tail
+				    Password: protected-secret
+				Debug: false
+				""");
+		ProxyConfigurationFileService protectedTailService = service(secretTail);
+		assertThrows(IllegalArgumentException.class, () -> protectedTailService.preview(
+				ProxyConfigurationFileService.FILE_NAME, "Hooks:\n  - Name: public\n    Enabled: true\nDebug: false\n"));
+
+		Path shiftedSecret = write("""
+				Endpoints:
+				  - jdbc:mysql://old-user:old-password@db.invalid/votes
+				  - public-endpoint
+				""");
+		ProxyConfigurationFileService shiftedSecretService = service(shiftedSecret);
+		assertThrows(IllegalArgumentException.class, () -> shiftedSecretService.preview(
+				ProxyConfigurationFileService.FILE_NAME, "Endpoints:\n  - public-endpoint\n"));
+	}
+
+	@Test
 	void previewRestoresMaskedValuesAndAllowsSafeNestedAdditions() throws Exception {
 		Path file = write("""
 				Database:

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -963,6 +963,37 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksBareAndNestedWebhookFields() throws Exception {
+		Path file = write("Webhook: https://hooks.example.invalid/services/private-token\n"
+				+ "Notifications:\n  Webhook: https://notify.example.invalid/private-token\n"
+				+ "Webhooks:\n  Primary:\n    URL: https://primary.example.invalid/private-token\n"
+				+ "  Secondary:\n    URI: https://secondary.example.invalid/private-token\n"
+				+ "Debug: false\n");
+
+		String content = service(file).read(ProxyConfigurationFileService.FILE_NAME).content();
+
+		assertFalse(content.contains("hooks.example.invalid"));
+		assertFalse(content.contains("notify.example.invalid"));
+		assertFalse(content.contains("primary.example.invalid"));
+		assertFalse(content.contains("secondary.example.invalid"));
+		assertEquals(4, content.lines().filter(line -> line.contains(ProxyConfigurationFileService.REDACTED)).count());
+	}
+
+	@Test
+	void permitsPublicCommentInsertionAroundRedactedCommentButRequiresSameMarkerOwners() throws Exception {
+		Path file = write("Database:\n  # Password: secret\n  Password: secret\nDebug: false\n");
+		ProxyConfigurationFileService service = service(file);
+		String current = service.read(ProxyConfigurationFileService.FILE_NAME).content();
+		String withPublicComment = current.replace("# " + ProxyConfigurationFileService.REDACTED,
+				"# public documentation\n  # " + ProxyConfigurationFileService.REDACTED);
+
+		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, withPublicComment).resolvedContent()
+				.contains("Password: secret"));
+		assertThrows(IllegalArgumentException.class, () -> service.preview(ProxyConfigurationFileService.FILE_NAME,
+				withPublicComment.replace("# " + ProxyConfigurationFileService.REDACTED, "# removed")));
+	}
+
+	@Test
 	void changeDescriptionsDistinguishDottedKeysFromNestedPaths() throws Exception {
 		Path file = write("\"a.b.x\": dotted\na:\n  b:\n    x: nested\n");
 		ProxyConfigurationFileService service = service(file);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -121,6 +121,28 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksAndRestoresPunctuationDelimitedCredentialFieldNames() throws Exception {
+		Path file = write("""
+				API/Key: api-slash-secret
+				Private/Key: private-slash-secret
+				Auth|Token: token-punctuation-secret
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("api-slash-secret"));
+		assertFalse(current.content().contains("private-slash-secret"));
+		assertFalse(current.content().contains("token-punctuation-secret"));
+
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME,
+				current.content().replace("Debug: false", "Debug: true"));
+		assertTrue(preview.resolvedContent().contains("API/Key: api-slash-secret"));
+		assertTrue(preview.resolvedContent().contains("Private/Key: private-slash-secret"));
+		assertTrue(preview.resolvedContent().contains("Auth|Token: token-punctuation-secret"));
+	}
+
+	@Test
 	void masksAndRestoresCompoundInfrastructureScalarNames() throws Exception {
 		Path file = write("""
 				ControlEndpoint: https://control.internal
@@ -604,6 +626,12 @@ class ProxyConfigurationFileServiceTest {
 		ProxyConfigurationFileService shiftedSecretService = service(shiftedSecret);
 		assertThrows(IllegalArgumentException.class, () -> shiftedSecretService.preview(
 				ProxyConfigurationFileService.FILE_NAME, "Endpoints:\n  - public-endpoint\n"));
+
+		ProxyConfigurationFileService.Preview scalarRotation = shiftedSecretService.preview(
+				ProxyConfigurationFileService.FILE_NAME,
+				"Endpoints:\n  - jdbc:mysql://new-user:new-password@db.invalid/votes\n");
+		assertTrue(scalarRotation.resolvedContent().contains("jdbc:mysql://new-user:new-password@db.invalid/votes"));
+		assertFalse(scalarRotation.resolvedContent().contains("public-endpoint"));
 	}
 
 	@Test

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -186,6 +186,27 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void rejectsReorderingSecretBearingSequenceEntriesButAllowsInPlaceEdits() throws Exception {
+		Path file = write("""
+				Hooks:
+				  - Name: alpha
+				    Password: alpha-secret
+				  - Name: beta
+				    Password: beta-secret
+				Debug: false
+				""");
+		ProxyConfigurationFileService service = service(file);
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		String unchangedOrder = current.content().replace("Debug: false", "Debug: true");
+		assertTrue(service.preview(ProxyConfigurationFileService.FILE_NAME, unchangedOrder).resolvedContent()
+				.contains("Password: alpha-secret"));
+		String reordered = current.content().replace("Name: alpha", "Name: __swapped__")
+				.replace("Name: beta", "Name: alpha").replace("Name: __swapped__", "Name: beta");
+		assertThrows(IllegalArgumentException.class,
+				() -> service.preview(ProxyConfigurationFileService.FILE_NAME, reordered));
+	}
+
+	@Test
 	void preservesNullEntriesInSequencesAcrossReadPreviewAndApply() throws Exception {
 		Path file = write("Servers: [null, active]\nEmptyEntries:\n  -\nDebug: false\n");
 		ProxyConfigurationFileService service = service(file);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyConfigurationFileServiceTest.java
@@ -178,6 +178,43 @@ class ProxyConfigurationFileServiceTest {
 	}
 
 	@Test
+	void masksInfrastructureConnectionListsButKeepsLogicalServerSettings() throws Exception {
+		Path file = write("Redis:\n"
+				+ "  Hosts:\n"
+				+ "    - cache-a.internal\n"
+				+ "    - cache-b.internal\n"
+				+ "  Users:\n"
+				+ "    - redis-service\n"
+				+ "Database:\n"
+				+ "  Hosts: [db-a.internal, db-b.internal]\n"
+				+ "  Users: [database-service]\n"
+				+ "PrimaryServer: false\n"
+				+ "FallBackServer: true\n"
+				+ "Debug: false\n");
+		ProxyConfigurationFileService service = service(file);
+
+		ProxyConfigurationFileService.Document current = service.read(ProxyConfigurationFileService.FILE_NAME);
+		assertFalse(current.content().contains("cache-a.internal"));
+		assertFalse(current.content().contains("cache-b.internal"));
+		assertFalse(current.content().contains("redis-service"));
+		assertFalse(current.content().contains("db-a.internal"));
+		assertFalse(current.content().contains("db-b.internal"));
+		assertFalse(current.content().contains("database-service"));
+		assertTrue(current.content().contains("PrimaryServer: false"));
+		assertTrue(current.content().contains("FallBackServer: true"));
+
+		ProxyConfigurationFileService.Preview preview = service.preview(ProxyConfigurationFileService.FILE_NAME,
+				current.content().replace("Debug: false", "Debug: true"));
+		assertTrue(preview.resolvedContent().contains("cache-a.internal"));
+		assertTrue(preview.resolvedContent().contains("cache-b.internal"));
+		assertTrue(preview.resolvedContent().contains("redis-service"));
+		assertTrue(preview.resolvedContent().contains("db-a.internal"));
+		assertTrue(preview.resolvedContent().contains("database-service"));
+		assertTrue(preview.resolvedContent().contains("PrimaryServer: false"));
+		assertTrue(preview.resolvedContent().contains("FallBackServer: true"));
+	}
+
+	@Test
 	void masksAndRestoresCompoundCredentialFields() throws Exception {
 		Path file = write("""
 				AuthToken: auth-token-value

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -56,6 +56,27 @@ class ProxyControlResultStoreTest {
 		assertFalse(recovered.claimRequired());
 	}
 
+	@Test void managedFileReadLargerThanLegacyJournalLimitSurvivesRestart() throws Exception {
+		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+		Route route = new Route("proxy-old", "Proxy Old", "VELOCITY", "7.1.2",
+				URI.create("https://control.example:8443"), "old-credential.txt", 30, 3000, 5000);
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+		JsonObject configuration = new JsonObject();
+		configuration.addProperty("domain", "file");
+		configuration.addProperty("fileName", ProxyConfigurationFileService.FILE_NAME);
+		configuration.addProperty("content", "a".repeat(300 * 1024));
+		result.add("configuration", configuration);
+
+		ProxyControlResultStore.save(directory, route,
+				Map.of(operationId, new StoredResult(result, true, false)));
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(directory);
+
+		assertEquals(300 * 1024, recovered.results().get(operationId).result()
+				.getAsJsonObject("configuration").get("content").getAsString().length());
+		assertTrue(Files.size(directory.resolve(".control-proxy-pending-results.json")) > 256 * 1024);
+	}
+
 	@Test void symbolicProxyResultJournalIsRejected() throws Exception {
 		Path external = directory.resolve("external.json");
 		Files.writeString(external, "{}");

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -131,7 +131,7 @@ class ProxyControlResultStoreTest {
 		assertEquals(configured, ProxyControlResultStore.loadPreferred(directory, configured).route());
 	}
 
-	@Test void globalResultLimitRejectsNewRouteWithoutEvictingExistingResults() throws Exception {
+	@Test void releasedRouteResultLimitDoesNotStarveAnotherRoute() throws Exception {
 		Route original = route("bounded-original");
 		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
 		for (int index = 0; index < 128; index++) {
@@ -140,14 +140,14 @@ class ProxyControlResultStoreTest {
 		}
 		ProxyControlResultStore.save(directory, original, existing);
 		Route additional = route("bounded-additional");
-		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
-				Map.of(UUID.fromString("00000000-0000-0000-0000-000000000102"),
-						new StoredResult(result(true), true, false))));
+		UUID additionalId = UUID.fromString("00000000-0000-0000-0000-000000000102");
+		ProxyControlResultStore.save(directory, additional,
+				Map.of(additionalId, new StoredResult(result(true), true, false)));
 		assertEquals(128, ProxyControlResultStore.loadForRoute(directory, original).results().size());
-		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+		assertTrue(ProxyControlResultStore.loadForRoute(directory, additional).results().containsKey(additionalId));
 	}
 
-	@Test void byteLimitRejectsNewRouteWithoutEvictingExistingResults() throws Exception {
+	@Test void releasedRouteByteLimitDoesNotStarveAnotherRoute() throws Exception {
 		Route original = route("bytes-original");
 		JsonObject large = result(true);
 		large.addProperty("payload", "x".repeat(3_950_000));
@@ -158,11 +158,11 @@ class ProxyControlResultStoreTest {
 		Route additional = route("bytes-additional");
 		JsonObject extra = result(true);
 		extra.addProperty("payload", "y".repeat(300_000));
-		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
-				Map.of(UUID.fromString("00000000-0000-0000-0000-000000000104"),
-						new StoredResult(extra, true, false))));
+		UUID additionalOperation = UUID.fromString("00000000-0000-0000-0000-000000000104");
+		ProxyControlResultStore.save(directory, additional,
+				Map.of(additionalOperation, new StoredResult(extra, true, false)));
 		assertTrue(ProxyControlResultStore.loadForRoute(directory, original).results().containsKey(originalOperation));
-		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+		assertTrue(ProxyControlResultStore.loadForRoute(directory, additional).results().containsKey(additionalOperation));
 	}
 
 	@Test void legacyV2JournalLoadsByStableIdentityAndMigratesOnNextSave() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -2,6 +2,8 @@ package com.bencodez.votingplugin.proxy.control;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,6 +58,145 @@ class ProxyControlResultStoreTest {
 
 		assertFalse(recovered.routeRequired());
 		assertTrue(recovered.results().containsKey(operationId));
+	}
+
+	@Test void releasedResultsStayBoundWhenTheConfiguredRouteChanges() throws Exception {
+		UUID oldOperation = UUID.fromString("00000000-0000-0000-0000-000000000099");
+		UUID newOperation = UUID.fromString("00000000-0000-0000-0000-000000000100");
+		Route oldRoute = new Route("proxy-old", "Proxy Old", "VELOCITY", "7.1.2",
+				URI.create("https://old-control.example:8443"), "old-credential.txt", 30, 3000, 5000);
+		Route newRoute = new Route("proxy-new", "Proxy New", "VELOCITY", "7.1.2",
+				URI.create("https://new-control.example:8443"), "new-credential.txt", 30, 3000, 5000);
+		JsonObject oldResult = new JsonObject();
+		oldResult.addProperty("success", true);
+		JsonObject newResult = new JsonObject();
+		newResult.addProperty("success", true);
+
+		ProxyControlResultStore.save(directory, oldRoute,
+				Map.of(oldOperation, new StoredResult(oldResult, true, false)), false);
+		ProxyControlResultStore.save(directory, newRoute,
+				Map.of(newOperation, new StoredResult(newResult, true, false)));
+
+		assertEquals(oldRoute, ProxyControlResultStore.loadForRoute(directory, oldRoute).route(),
+				"the released old route must remain durably bound");
+		assertNull(ProxyControlResultStore.loadForRoute(directory, new Route("other", "Other", "VELOCITY", "7.1.2",
+				URI.create("https://other-control.example:8443"), "other-credential.txt", 30, 3000, 5000)));
+		ProxyControlResultStore.State current = ProxyControlResultStore.loadForRoute(directory, newRoute);
+		assertNotNull(current);
+		assertEquals(newRoute, current.route());
+		assertTrue(current.results().containsKey(newOperation));
+
+		ProxyControlResultStore.save(directory, newRoute, Map.of());
+		assertNull(ProxyControlResultStore.loadForRoute(directory, newRoute));
+		assertTrue(ProxyControlResultStore.loadForRoute(directory, oldRoute).results().containsKey(oldOperation),
+				"acknowledging the new route must not remove the old route result");
+	}
+
+	@Test void stableRouteIdentityIgnoresVersionTimingAndCredentialRotation() throws Exception {
+		Route original = new Route("proxy-stable", "Old display name", "VELOCITY", "7.1.2",
+				URI.create("https://CONTROL.example:443"), "credential.txt", 30, 3000, 5000);
+		Route updated = new Route("proxy-stable", "New display name", "VELOCITY", "7.2.0",
+				URI.create("https://control.example"), "rotated-credential.txt", 120, 10000, 15000);
+		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000101");
+
+		ProxyControlResultStore.save(directory, original,
+				Map.of(operationId, new StoredResult(result(true), true, false)));
+		ProxyControlResultStore.save(directory, updated,
+				Map.of(operationId, new StoredResult(result(true), true, false)));
+
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.loadForRoute(directory, updated);
+		assertNotNull(recovered);
+		assertEquals(updated, recovered.route(), "metadata may refresh without changing route identity");
+		assertEquals(1, recovered.results().size(), "runtime and credential changes must not split the coordinator");
+		assertEquals(3, com.google.gson.JsonParser.parseString(
+				Files.readString(directory.resolve(".control-proxy-pending-results.json")))
+				.getAsJsonObject().get("version").getAsInt());
+	}
+
+	@Test void requiredOriginRoutesAreSelectedBeforeCurrentConfiguration() throws Exception {
+		Route first = route("required-first");
+		Route second = route("required-second");
+		Route configured = route("configured");
+		ProxyControlResultStore.save(directory, first,
+				Map.of(UUID.randomUUID(), new StoredResult(result(true), true, false)), true);
+		ProxyControlResultStore.save(directory, second,
+				Map.of(UUID.randomUUID(), new StoredResult(result(true), true, false)), true);
+		ProxyControlResultStore.save(directory, configured,
+				Map.of(UUID.randomUUID(), new StoredResult(result(true), true, false)), false);
+
+		assertEquals(first, ProxyControlResultStore.loadPreferred(directory, configured).route());
+		ProxyControlResultStore.save(directory, first, Map.of());
+		assertEquals(second, ProxyControlResultStore.loadPreferred(directory, configured).route());
+		ProxyControlResultStore.save(directory, second, Map.of());
+		assertEquals(configured, ProxyControlResultStore.loadPreferred(directory, configured).route());
+	}
+
+	@Test void globalResultLimitRejectsNewRouteWithoutEvictingExistingResults() throws Exception {
+		Route original = route("bounded-original");
+		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
+		for (int index = 0; index < 128; index++) {
+			existing.put(UUID.nameUUIDFromBytes(("operation-" + index).getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+					new StoredResult(result(true), true, false));
+		}
+		ProxyControlResultStore.save(directory, original, existing);
+		Route additional = route("bounded-additional");
+		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
+				Map.of(UUID.fromString("00000000-0000-0000-0000-000000000102"),
+						new StoredResult(result(true), true, false))));
+		assertEquals(128, ProxyControlResultStore.loadForRoute(directory, original).results().size());
+		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+	}
+
+	@Test void byteLimitRejectsNewRouteWithoutEvictingExistingResults() throws Exception {
+		Route original = route("bytes-original");
+		JsonObject large = result(true);
+		large.addProperty("payload", "x".repeat(3_950_000));
+		UUID originalOperation = UUID.fromString("00000000-0000-0000-0000-000000000103");
+		ProxyControlResultStore.save(directory, original,
+				Map.of(originalOperation, new StoredResult(large, true, false)));
+
+		Route additional = route("bytes-additional");
+		JsonObject extra = result(true);
+		extra.addProperty("payload", "y".repeat(300_000));
+		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
+				Map.of(UUID.fromString("00000000-0000-0000-0000-000000000104"),
+						new StoredResult(extra, true, false))));
+		assertTrue(ProxyControlResultStore.loadForRoute(directory, original).results().containsKey(originalOperation));
+		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+	}
+
+	@Test void legacyV2JournalLoadsByStableIdentityAndMigratesOnNextSave() throws Exception {
+		Route legacy = route("legacy");
+		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000105");
+		String legacyJson = "{\"version\":2,\"routeRequired\":true,\"route\":{"
+				+ "\"nodeId\":\"legacy\",\"displayName\":\"Proxy legacy\",\"platform\":\"VELOCITY\","
+				+ "\"pluginVersion\":\"7.1.2\",\"endpoint\":\"https://legacy.control.example:8443\","
+				+ "\"credentialFile\":\"legacy-credential.txt\",\"heartbeatSeconds\":30,"
+				+ "\"connectTimeoutMillis\":3000,\"requestTimeoutMillis\":5000},\"results\":[{"
+				+ "\"operationId\":\"" + operationId + "\",\"result\":{\"success\":true},"
+				+ "\"committed\":true,\"claimRequired\":false}]}";
+		Files.writeString(directory.resolve(".control-proxy-pending-results.json"), legacyJson);
+
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.loadForRoute(directory, legacy);
+		assertNotNull(recovered);
+		assertTrue(recovered.results().containsKey(operationId));
+		ProxyControlResultStore.save(directory, legacy, recovered.results(), recovered.routeRequired());
+		JsonObject migrated = com.google.gson.JsonParser.parseString(
+				Files.readString(directory.resolve(".control-proxy-pending-results.json"))).getAsJsonObject();
+		assertEquals(3, migrated.get("version").getAsInt());
+		assertEquals(1, migrated.getAsJsonArray("routes").size());
+	}
+
+	private static JsonObject result(boolean success) {
+		JsonObject result = new JsonObject();
+		result.addProperty("success", success);
+		return result;
+	}
+
+	private static Route route(String nodeId) {
+		return new Route(nodeId, "Proxy " + nodeId, "VELOCITY", "7.1.2",
+				URI.create("https://" + nodeId + ".control.example:8443"), nodeId + "-credential.txt",
+				30, 3000, 5000);
 	}
 
 	@Test void writeAheadIntentRetainsItsUncommittedStateAcrossRestart() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.io.TempDir;
 import com.bencodez.votingplugin.proxy.control.ProxyControlResultStore.Route;
 import com.bencodez.votingplugin.proxy.control.ProxyControlResultStore.StoredResult;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 class ProxyControlResultStoreTest {
 	@TempDir Path directory;
@@ -131,7 +132,7 @@ class ProxyControlResultStoreTest {
 		assertEquals(configured, ProxyControlResultStore.loadPreferred(directory, configured).route());
 	}
 
-	@Test void releasedRouteResultLimitDoesNotStarveAnotherRoute() throws Exception {
+	@Test void globalResultLimitRejectsAnAdditionalRouteWithoutReplacingTheJournal() throws Exception {
 		Route original = route("bounded-original");
 		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
 		for (int index = 0; index < 128; index++) {
@@ -141,10 +142,29 @@ class ProxyControlResultStoreTest {
 		ProxyControlResultStore.save(directory, original, existing);
 		Route additional = route("bounded-additional");
 		UUID additionalId = UUID.fromString("00000000-0000-0000-0000-000000000102");
-		ProxyControlResultStore.save(directory, additional,
-				Map.of(additionalId, new StoredResult(result(true), true, false)));
+		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
+				Map.of(additionalId, new StoredResult(result(true), true, false))));
 		assertEquals(128, ProxyControlResultStore.loadForRoute(directory, original).results().size());
-		assertTrue(ProxyControlResultStore.loadForRoute(directory, additional).results().containsKey(additionalId));
+		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+	}
+
+	@Test void currentJournalRejectsAggregateResultsAboveTheGlobalLimit() throws Exception {
+		Route original = route("aggregate-load-original");
+		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
+		for (int index = 0; index < 65; index++) {
+			existing.put(UUID.nameUUIDFromBytes(("aggregate-operation-" + index)
+					.getBytes(java.nio.charset.StandardCharsets.UTF_8)), new StoredResult(result(true), true, false));
+		}
+		ProxyControlResultStore.save(directory, original, existing);
+		Path journal = directory.resolve(".control-proxy-pending-results.json");
+		JsonObject root = JsonParser.parseString(Files.readString(journal)).getAsJsonObject();
+		JsonObject duplicate = root.getAsJsonArray("routes").get(0).getAsJsonObject().deepCopy();
+		duplicate.getAsJsonObject("route").addProperty("nodeId", "aggregate-load-copy");
+		duplicate.getAsJsonObject("route").addProperty("endpoint", "https://aggregate-copy.example:8443");
+		root.getAsJsonArray("routes").add(duplicate);
+		Files.writeString(journal, root.toString());
+
+		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.load(directory));
 	}
 
 	@Test void releasedRouteByteLimitDoesNotStarveAnotherRoute() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -132,23 +132,23 @@ class ProxyControlResultStoreTest {
 		assertEquals(configured, ProxyControlResultStore.loadPreferred(directory, configured).route());
 	}
 
-	@Test void globalResultLimitRejectsAnAdditionalRouteWithoutReplacingTheJournal() throws Exception {
+	@Test void releasedRouteResultsDoNotConsumeAnotherRoutesCapacity() throws Exception {
 		Route original = route("bounded-original");
 		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
 		for (int index = 0; index < 128; index++) {
 			existing.put(UUID.nameUUIDFromBytes(("operation-" + index).getBytes(java.nio.charset.StandardCharsets.UTF_8)),
 					new StoredResult(result(true), true, false));
 		}
-		ProxyControlResultStore.save(directory, original, existing);
+		ProxyControlResultStore.save(directory, original, existing, false);
 		Route additional = route("bounded-additional");
 		UUID additionalId = UUID.fromString("00000000-0000-0000-0000-000000000102");
-		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.save(directory, additional,
-				Map.of(additionalId, new StoredResult(result(true), true, false))));
+		ProxyControlResultStore.save(directory, additional,
+				Map.of(additionalId, new StoredResult(result(true), true, false)), false);
 		assertEquals(128, ProxyControlResultStore.loadForRoute(directory, original).results().size());
-		assertNull(ProxyControlResultStore.loadForRoute(directory, additional));
+		assertTrue(ProxyControlResultStore.loadForRoute(directory, additional).results().containsKey(additionalId));
 	}
 
-	@Test void currentJournalRejectsAggregateResultsAboveTheGlobalLimit() throws Exception {
+	@Test void currentJournalAcceptsAggregateResultsWithinEachRouteLimit() throws Exception {
 		Route original = route("aggregate-load-original");
 		Map<UUID, StoredResult> existing = new LinkedHashMap<>();
 		for (int index = 0; index < 65; index++) {
@@ -164,7 +164,10 @@ class ProxyControlResultStoreTest {
 		root.getAsJsonArray("routes").add(duplicate);
 		Files.writeString(journal, root.toString());
 
-		assertThrows(java.io.IOException.class, () -> ProxyControlResultStore.load(directory));
+		assertEquals(65, ProxyControlResultStore.loadForRoute(directory, original).results().size());
+		Route copied = new Route("aggregate-load-copy", "Proxy aggregate-load-original", "VELOCITY", "7.1.2",
+				URI.create("https://aggregate-copy.example:8443"), "aggregate-load-original-credential.txt", 30, 3000, 5000);
+		assertEquals(65, ProxyControlResultStore.loadForRoute(directory, copied).results().size());
 	}
 
 	@Test void releasedRouteByteLimitDoesNotStarveAnotherRoute() throws Exception {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/proxy/control/ProxyControlResultStoreTest.java
@@ -36,10 +36,26 @@ class ProxyControlResultStoreTest {
 		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(directory);
 
 		assertEquals(route, recovered.route());
+		assertTrue(recovered.routeRequired());
 		assertEquals("applied-revision", recovered.results().get(operationId).result().get("revision").getAsString());
 		assertTrue(recovered.results().get(operationId).committed());
 		ProxyControlResultStore.save(directory, route, Map.of());
 		assertFalse(Files.exists(directory.resolve(".control-proxy-pending-results.json")));
+	}
+
+	@Test void completedRecoveryRetainsResultsWithoutPinningTheOldRoute() throws Exception {
+		UUID operationId = UUID.fromString("00000000-0000-0000-0000-000000000099");
+		Route route = new Route("proxy-old", "Proxy Old", "VELOCITY", "7.1.2",
+				URI.create("https://control.example:8443"), "old-credential.txt", 30, 3000, 5000);
+		JsonObject result = new JsonObject();
+		result.addProperty("success", true);
+
+		ProxyControlResultStore.save(directory, route,
+				Map.of(operationId, new StoredResult(result, true, false)), false);
+		ProxyControlResultStore.State recovered = ProxyControlResultStore.load(directory);
+
+		assertFalse(recovered.routeRequired());
+		assertTrue(recovered.results().containsKey(operationId));
 	}
 
 	@Test void writeAheadIntentRetainsItsUncommittedStateAcrossRestart() throws Exception {

--- a/docs/control-agent-contract.md
+++ b/docs/control-agent-contract.md
@@ -90,7 +90,7 @@ JSON object whose `schemaVersion` is the JSON integer `1` (not a string), `kind`
 `generatedAt` parses as an ISO-8601 instant, and `result` is a JSON object. Failures omit `data` and use
 `VALIDATION_ERROR`, `UNAVAILABLE`, `RESULT_TOO_LARGE`, or `INSPECTION_FAILED`.
 
-Data is limited to 512 KiB. General rows are limited to 100, top lists to 20, diagnostics to 128 detected plugin names,
+Data is limited to 512 KiB. General rows and diagnostics plugin inventories are limited to 100, top lists to 20,
 and lookback windows to 365 days. Summary top lists order vote counts descending, then names case-insensitively and by
 exact spelling; the database applies the same name tie-break before its limit. The connector performs inspections on a
 dedicated single-thread daemon executor, separate from presence and configuration work and never on the Bukkit primary
@@ -119,7 +119,7 @@ encoded `proposal` may be larger, with a 64 KiB hard limit.
 | `vote-trace` | required canonical 36-character UUID `voteId`; optional string `days`/`limit` | Chronological VoteLog events sharing one correlation ID |
 | `vote-site-resolution` | required valid `serviceSite` (1–64 characters); optional string boolean `includeDisabled` | Dry-runs existing resolution and reports whether auto-create would be attempted; never calls the creating resolver |
 | `reward-simulation` | required `proposal`, a JSON object encoded as one filter string | Validates and normalizes typed actions, reports the plan, and never invokes `RewardBuilder` |
-| `diagnostics` | none | Bounded redacted environment/configuration status, configured/readable VoteLog state, and detected plugin names |
+| `diagnostics` | none | Bounded redacted environment/configuration status, configured/readable VoteLog state, and up to 100 detected plugin names with an explicit truncation indicator |
 
 Valid VoteLog `event` values are `VOTE_RECEIVED`, `VOTEMILESTONE`, `VOTE_STREAK_REWARD`, `TOP_VOTER_REWARD`, and
 `VOTESHOP_PURCHASE`. Search values are exact, not substrings. VoteLog summary/search/trace return `UNAVAILABLE` when the
@@ -229,7 +229,7 @@ unloaded site keys are not returned. They are not log enumeration or an end-to-e
 ## Data and security invariants
 
 - Inspection results may contain only the typed fields documented above. Never echo a credential, password, token,
-  database/Redis/MQTT host, webhook URL, raw configuration, or raw server log.
+  database or transport host, Control endpoint, webhook URL, raw configuration, or raw server log.
 - Unexpected managed configuration read, preview, apply, and reload exceptions retain their action-specific result code but
   return fixed external text; their detailed cause is logged only on the backend and is never copied into a Control result.
 - An unexpected handler exception returns only generic `INSPECTION_FAILED` text. The backend log may identify its exception

--- a/docs/control-agent-contract.md
+++ b/docs/control-agent-contract.md
@@ -114,7 +114,7 @@ encoded `proposal` may be larger, with a 64 KiB hard limit.
 | `overview` | none | Versions, configuration health, bounded data-storage mode, proxy mode, vote-site counts, and configured/readable VoteLog state |
 | `vote-site-health` | string `days` (1–365, default 30) | Configured site status, bounded aggregate last-vote/count data, unmatched logged services, and persisted unconfigured service observations |
 | `player` | exactly one of `name` (1–16 characters) or `uuid` (canonical 36-character UUID) | Exact existing-player lookup; totals, points, streaks, up to 100 per-site last-vote rows, and pending vote count saturated at 100,000; never lists players |
-| `vote-log-summary` | string `days` (1–365, default 30) | Vote totals, immediate/cached split, unique voters, top services, and top servers |
+| `vote-log-summary` | string `days` (1–365, default 30) | Vote totals, immediate/cached split, unique voters, and bounded top-service (`service`, canonical `count`) and top-server (`server`, canonical `count`) rows; schema-v1 nodes also emit the equal legacy `votes` alias for staggered dashboard upgrades |
 | `vote-log-search` | at most one of exact `player` (1–16 characters), `service` (1–64), or `server` (1–64); optional `event` and string `days`/`limit` | Bounded recent event rows; `limit` is 1–100 and defaults to 25 |
 | `vote-trace` | required canonical 36-character UUID `voteId`; optional string `days`/`limit` | Chronological VoteLog events sharing one correlation ID |
 | `vote-site-resolution` | required valid `serviceSite` (1–64 characters); optional string boolean `includeDisabled` | Dry-runs existing resolution and reports whether auto-create would be attempted; never calls the creating resolver |

--- a/docs/control-agent-contract.md
+++ b/docs/control-agent-contract.md
@@ -10,6 +10,67 @@ has two separate lanes:
 Do not translate an inspection request into a configuration operation. Do not add raw SQL, arbitrary commands, player
 enumeration, database browsing, filesystem paths, or generic key/value reads to either contract.
 
+## Proxy file contract (`config.proxy-files.v1`)
+
+This is a proxy-only capability, advertised by an enrolled BungeeCord or Velocity node. It is separate from
+`config.proxy-routing.v1`, `config.proxy-method.v1`, and the backend `config.files.v1` capability. The only managed file
+is the proxy's top-level `bungeeconfig.yml` in the VotingPlugin data folder. `fileName` must be exactly
+`bungeeconfig.yml`; paths, subdirectories, and other filenames are rejected. The file and proposed UTF-8 content are
+bounded at 512 KiB. YAML must be a mapping, use string keys and supported scalar/map/list values, and may not contain
+aliases/merge keys, duplicate keys, invalid UTF-8, NULs, or nesting deeper than 50.
+
+The operation is carried in the normal authenticated node operation queue. Control claims an operation with
+`POST /api/v1/nodes/{nodeId}/operations` and `{"sessionId":"<connector-session-uuid>"}`. A claimed task has
+`operationId`, `attemptId`, `type`, and, for APPLY, `expectedRevision`, plus this configuration object:
+
+```json
+{
+  "domain": "file",
+  "fileName": "bungeeconfig.yml",
+  "content": "...masked YAML..."
+}
+```
+
+`content` is omitted for READ. The node submits the result through the normal operation-result endpoint; a result has
+`success`, `code`, `message`, `revision` (on success), `configuration` (on success), `changes`, `reloaded`, and
+`rolledBack`, and includes the claimed `attemptId`. A successful configuration object contains `domain`, `fileName`,
+and masked `content`. `changes` is a deterministic, lexicographically ordered list of at most 20 flattened YAML paths,
+using `added`, `changed`, or `removed` prefixes. The complete operation-result request and connector HTTP response retain
+the shared 4 MiB protocol bound; the stricter 512 KiB limit applies to the managed YAML content itself.
+
+The node posts that result to `POST /api/v1/nodes/{nodeId}/operations/{operationId}/result` with the same
+`sessionId`; there is no second proxy-file-specific envelope. `attemptId` is retained in the result so Control can
+match the leased attempt. Control's HTTP success response acknowledges receipt; a `409` `TASK_LEASE_EXPIRED` leaves
+the result journaled for recovery/retry, while `404` `OPERATION_NOT_FOUND` is treated as an acknowledgement because
+the Control-side operation is already gone. Malformed or non-success transport responses affect only this connector
+queue and are retried with its normal bounded backoff.
+
+READ returns the current masked document and its SHA-256 revision. PREVIEW parses and validates the proposal, resolves
+unchanged redacted secret markers against the local document, returns the current revision and changes, and does not
+write. APPLY requires the exact revision returned by the preview (and checks it again around staging/installation),
+writes through a staged file and atomic activation, and retains `bungeeconfig.yml.control-backup`. A stale or changed
+revision returns `success:false`, `code:"STALE_REVISION"`, with no configuration payload. Invalid file names, YAML,
+content, or redaction use `VALIDATION_ERROR`; unavailable/read or save failures use the fixed `APPLY_FAILED` result;
+an installation failure returns `APPLY_FAILED` and reports whether rollback succeeded in `rolledBack`.
+
+Proxy-file APPLY does not reload the proxy in this connector (`reloaded:false`); the success message instructs an
+operator to restart the proxy for general settings to take effect. It is not the `proxy-method` runtime-replacement
+operation. A failed installation attempts to restore the backup atomically. The result is journaled by operation ID
+until Control acknowledges it, so a leased retry does not apply the change twice; on node recovery an unfinished APPLY
+is either recognized as already installed by revision or reported as `RECOVERY_ABORTED`.
+
+Control must authenticate as the enrolled node and must include `config.proxy-files.v1` in `acceptedCapabilities`
+before assigning these tasks. If the capability was not negotiated, the node returns `UNSUPPORTED` without reading or
+writing the file. Proxy and backend nodes may be enrolled against the same Control instance, but each node has its own
+identity, credential/session, operation lease, revision, and result journal: a backend capability does not authorize a
+proxy-file task, and one peer's approval or revision cannot be used for another peer. Control should therefore present
+this editor only for a capable proxy node and require its normal authenticated admin preview/approval flow.
+
+All reads mask secrets. The mask covers password/secret/token/API-key/authorization/webhook URL fields and selected
+database, Redis, MQTT, proxy-host, and Control infrastructure fields; JDBC-style and credential-bearing URLs are also
+masked. A submitted redaction marker preserves the local secret; replacement secrets may be submitted in an authenticated
+operation but are never returned or journaled.
+
 ## Easy automatic vote-site toggle
 
 The `auto-create-vote-sites` quick-setup preset owns exactly one setting:
@@ -225,6 +286,41 @@ An exact player result includes at most 100 `lastVotes` rows with `siteKey`, `di
 `lastVotesTruncated`. These are stored last-vote values for sites that currently resolve as enabled; disabled, invalid, or
 unloaded site keys are not returned. They are not log enumeration or an end-to-end delivery history.
 `pendingOfflineVotes` is a bounded count saturated at 100,000 rather than a detailed queue view.
+
+### Exact-player storage fields (schema version 1)
+
+The `player` result additionally contains `storageRowAvailable`, `storage`, `columns`, and `columnsTruncated`.
+`storageRowAvailable` is true only when the exact loaded player has user data and a configured storage type that can be
+read. When false, `columns` is an empty array, `columnsTruncated` is false, and `storage` is omitted. `storage` is the
+storage enum name (for example `SQLITE`), not a connection or table description.
+
+Each `columns` entry is exactly `{ "name": <string>, "type": <string>, "value": <string> }`. `value` is a bounded
+string rendering: integer values are decimal text, booleans are `true`/`false` text, and string values are returned as
+text (a null string renders as empty text). `type` is exactly the underlying stored `DataValue.getType().name()`;
+the allow-list accepts only the corresponding string, boolean, or integer value type described below. Only these fields
+are eligible:
+
+- Static string names (must have a string value): `UUID`, `PlayerName`, `LastOnline`, `DayVoteStreakLastUpdate`,
+  `VoteRemindersLast`.
+- Static boolean names (native boolean, or a string exactly matching `true`/`false`, case-insensitively): `TopVoterIgnore`,
+  `Reminded`, `DisableBroadcast`.
+- Static integer names (integer value): `VotePartyVotes`, `MonthTotal`, `AllTimeTotal`, `DailyTotal`, `WeeklyTotal`,
+  `Points`, `DayVoteStreak`, `BestDayVoteStreak`, `WeekVoteStreak`, `BestWeekVoteStreak`, `MonthVoteStreak`,
+  `BestMonthVoteStreak`, `HighestDailyTotal`, `HighestMonthlyTotal`, `HighestWeeklyTotal`, `LastMonthTotal`,
+  `LastWeeklyTotal`, `LastDailyTotal`.
+- Dynamic integer names: `MonthTotal-<MONTH>-<YYYY>` where `<MONTH>` is an uppercase English month name and `<YYYY>` is
+  exactly four digits; and `VoteShopLimit<suffix>` where `<suffix>` is 1–64 characters from `[A-Za-z0-9_-]`.
+- Four runtime-derived exact names: the configured cooldown flag (`CoolDownCheck` or `CoolDownCheck_<server-storage-name>`,
+  boolean), cooldown-site list (`CoolDownCheck_Sites` or `CoolDownCheck_<server-storage-name>_Sites`, string),
+  all-sites day (`AllSitesLast` or `AllSitesLast_<server-storage-name>`, integer), and almost-all-sites day
+  (`AlmostAllSitesLast` or `AlmostAllSitesLast_<server-storage-name>`, integer). The runtime names are compared exactly;
+  they are not wildcards.
+
+Other stored keys—including serialized offline/reward payloads, plugin-specific keys, malformed dynamic spellings, and
+allow-listed names with the wrong value type—are omitted. Entries are sorted by `name` case-insensitively, then by exact
+spelling, and at most 100 eligible entries are returned. A 101st eligible entry or a value larger than 16 KiB sets
+`columnsTruncated:true`; oversized values themselves are omitted. The complete result is bounded at 512 KiB. No
+credential, secret, raw payload, SQL metadata, or arbitrary storage key is exposed.
 
 ## Data and security invariants
 

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -231,6 +231,20 @@ Control configuration snapshots store the redacted managed-file content returned
 Restore resolves unchanged markers against each target's current secrets during preview/apply. Protect Control's data
 directory anyway because snapshots contain complete managed configuration structure and operational values.
 
+Proxy nodes separately advertise `config.proxy-files.v1` when their proxy-file adapter is available. This capability is
+restricted to exactly the proxy's top-level `bungeeconfig.yml` (no paths or alternate filenames) and to a 512 KiB
+UTF-8/YAML content bound inside the shared 4 MiB operation-response envelope. Control uses the normal authenticated
+operation queue. READ returns masked content and its SHA-256 revision; PREVIEW validates a proposal and reports
+deterministic changes without writing; APPLY requires the
+preview's exact revision and rejects a changed file with `STALE_REVISION`. APPLY stages and atomically installs the file,
+retains `bungeeconfig.yml.control-backup`, and reports `reloaded:false`: a successful edit requires a proxy restart to
+activate general settings. Redaction markers preserve local secrets, and replacement secrets are never returned or
+journaled. Results include the normal success/code/message/revision/configuration/changes/reloaded/rolledBack fields,
+remain durable by operation ID until acknowledged, and survive leased retries/recovery. Control must show this editor
+only to an authenticated, capable proxy node; backend `config.files.v1` enrollment, approval, and revisions are not
+interchangeable with a proxy peer. See [the Control agent contract](control-agent-contract.md#proxy-file-contract-configproxy-filesv1)
+for the exact task/result envelope and error behavior.
+
 Quick setups cover standalone backend mode, proxy-connected backend mode with an explicit server identity, adding/updating
 a vote site, an easy per-site or every-site command/message reward, six common operational toggles, a dedicated
 `auto-create-vote-sites` switch that changes only `Config.yml` → `AutoCreateVoteSites`, a non-secret `vote-logging` setup,
@@ -261,6 +275,12 @@ from current readability. Results are capped at 512 KiB, general rows at 100, de
 lookbacks at 365 days. It does not expose SQL, arbitrary user enumeration, raw configuration/logs,
 commands, reward execution, or writes. The exact schemas and safety invariants are documented in
 [the Control agent contract](control-agent-contract.md).
+
+Exact-player results may include the schema-v1 storage fields `storageRowAvailable`, `storage`, `columns`, and
+`columnsTruncated`. Storage output is read-only and allow-listed, with at most 100 deterministically ordered column
+entries and per-value/content bounds; unavailable storage returns an empty column list and no storage name. It excludes
+serialized payloads, credentials, secrets, and arbitrary keys. See [the exact-player storage schema](control-agent-contract.md#exact-player-storage-fields-schema-version-1)
+for the static/dynamic names and value-type rules.
 
 Inspection filters are string values on the wire and are parsed by the selected kind's strict schema. The connector runs
 the handlers, including bounded VoteLog/player storage reads, on the dedicated inspection daemon rather than Bukkit's

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -143,10 +143,11 @@ Proxy discovery-connector timing bounds are intentional:
 
 - heartbeat: 10–300 seconds;
 - connect/request timeout: 500–30,000 milliseconds;
-- response body: at most 64 KiB;
+- response body: at most 4 MiB, including bounded managed-file/configuration operation results;
 - backend snapshot: at most 4096 entries.
 
-Do not raise these by patching around validation; correct the topology or connectivity problem instead.
+Do not raise these by patching around validation; correct the topology or connectivity problem instead. The larger
+response envelope remains bounded and exists so the proxy connector can receive managed-file operations.
 
 ### Bukkit full-configuration enrollment
 

--- a/docs/control-connector.md
+++ b/docs/control-connector.md
@@ -166,9 +166,8 @@ Control:
     RequestTimeoutMillis: 10000
 ```
 
-The Bukkit connector uses the same 10–300-second heartbeat and 500–30,000-millisecond timeout ranges, but its bounded
-response-body limit is 4 MiB so it can receive managed-file/configuration tasks. Do not apply the proxy connector's 64 KiB
-discovery-response bound to this lane.
+The Bukkit connector uses the same 10–300-second heartbeat and 500–30,000-millisecond timeout ranges, with the same
+bounded 4 MiB response envelope as the proxy connector for managed-file/configuration tasks.
 
 Use an address the backend itself can reach, normally the proxy VM/private IP. Proxy-mediated enrollment deliberately
 rejects `localhost`, `127.0.0.0/8`, and IPv6 loopback because those addresses resolve to the backend rather than the proxy
@@ -272,7 +271,7 @@ The WebUI settings catalog is a static versioned reference, not an arbitrary key
 The inspection lane provides typed overview, vote-site health (including persisted unconfigured-service observations),
 exact-player data with bounded per-site last votes, VoteLog summary/search/correlation trace, side-effect-free vote-site
 resolution, reward-proposal simulation, and redacted diagnostics. Overview/diagnostics distinguish VoteLog configuration
-from current readability. Results are capped at 512 KiB, general rows at 100, detected diagnostic plugin names at 128, and
+from current readability. Results are capped at 512 KiB, general rows at 100, detected diagnostic plugin names at 100, and
 lookbacks at 365 days. It does not expose SQL, arbitrary user enumeration, raw configuration/logs,
 commands, reward execution, or writes. The exact schemas and safety invariants are documented in
 [the Control agent contract](control-agent-contract.md).


### PR DESCRIPTION
## Summary

- add a bounded, revisioned, secret-masked `bungeeconfig.yml` Control capability for proxy nodes
- preserve durable write-ahead result recovery, permissions, atomic publication, rollback, and explicit restart-required semantics
- reload only the backend proxy handler for coordinated proxy-method changes while retaining acknowledged proxy runtime replacement
- expose bounded allow-listed stored player fields through exact-player inspection
- add regression coverage for role/capability boundaries, masking, large durable results, lost acknowledgements, and rollback

Paired Control UI/API PR will target `BenCodez/VotingPlugin-Control` from the same branch name.

## Local verification

- `mvn -B -s /root/dev/.maven-votingplugin-settings.xml -f VotingPlugin/pom.xml clean verify` — 520 tests passed
- `git diff --check` — passed

## Compatibility and safety

- Control remains optional and outside vote-processing/startup paths
- the new capability is negotiated independently as `config.proxy-files.v1`
- only the fixed proxy `bungeeconfig.yml` path is accepted
- general proxy-file saves do not hot-reload the proxy; they report restart required
- no credential values are returned to Control