### PR TITLE
Add placeholder for configured vote streak amounts

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
@@ -424,6 +424,16 @@ public class PlaceHolders {
 			}
 		}.withDescription("Current month votestreak").updateDataKey("MonthVoteStreak"));
 
+		placeholders.add(new PlaceHolder<VotingPluginUser>("VoteStreakAmount_") {
+
+			@Override
+			public String placeholderRequest(VotingPluginUser user, String identifier) {
+				String target = identifier.substring("VoteStreakAmount_".length());
+				int amount = plugin.getVoteStreakHandler().getVoteStreakAmount(user, target);
+				return amount >= 0 ? Integer.toString(amount) : "invalid";
+			}
+		}.withDescription("Current amount for a VoteStreak ID or progress group").useStartsWith());
+
 		placeholders.add(new PlaceHolder<VotingPluginUser>("BestDailyVoteStreak") {
 
 			@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -572,6 +572,32 @@ public class VoteStreakHandler {
 	}
 
 	/**
+	 * Gets the current amount for a configured vote streak or progress group.
+	 * Milestone IDs belonging to a progress group return that group's shared
+	 * amount.
+	 *
+	 * @param user   voting plugin user
+	 * @param target standalone streak ID, milestone ID, or progress group ID
+	 * @return current streak amount, or -1 when the user or target is invalid
+	 */
+	public int getVoteStreakAmount(VotingPluginUser user, String target) {
+		if (user == null || target == null || target.trim().isEmpty()) {
+			return -1;
+		}
+
+		String normalized = target.trim().toLowerCase(Locale.ROOT);
+		VoteStreakDefinition definition = byProgressGroup.get(normalized);
+		if (definition == null) {
+			definition = getDefinition(normalized);
+		}
+		if (definition == null) {
+			return -1;
+		}
+
+		return readState(user, definition).streakCount;
+	}
+
+	/**
 	 * Advances a configured vote streak and gives any crossed rewards.
 	 *
 	 * @param user     voting plugin user

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -275,6 +275,36 @@ class VoteStreakHandlerTest {
 	}
 
 	@Test
+	void getVoteStreakAmount_supportsStandaloneStreaks() {
+		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 1, 1, 7);
+		loadFromRoot(root);
+
+		VoteStreakDefinition definition = handler.getDefinition("DailyStreak");
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		backing.put(handler.getColumnName(definition), "2026-01-10|12|1|true||1");
+
+		assertEquals(12, handler.getVoteStreakAmount(user, "dailystreak"));
+		assertEquals(-1, handler.getVoteStreakAmount(user, "missing"));
+	}
+
+	@Test
+	void getVoteStreakAmount_supportsProgressGroupAndMilestoneIds() {
+		MemoryConfiguration root = new MemoryConfiguration();
+		ConfigurationSection voteStreaks = root.createSection("VoteStreaks");
+		ConfigurationSection group = addProgressGroup(voteStreaks, "continuousstreak", "DAILY", 1, 1, 7);
+		addProgressGroupMilestone(group, "Daily3", 3, true, false);
+		loadFromRoot(root);
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		backing.put("VoteStreakGroup_DAILY_continuousstreak", "2026-01-10|12|1|true||1");
+
+		assertEquals(12, handler.getVoteStreakAmount(user, "continuousstreak"));
+		assertEquals(12, handler.getVoteStreakAmount(user, "Daily3"));
+	}
+
+	@Test
 	void configLoader_skipsProgressGroupThatDuplicatesFlatStreakId() {
 		MemoryConfiguration root = new MemoryConfiguration();
 		ConfigurationSection voteStreaks = root.createSection("VoteStreaks");


### PR DESCRIPTION
This adds `%votingplugin_VoteStreakAmount_<streak>%`, which reads the amount from the newer VoteStreak system.

It supports streak IDs and progress groups, this lets you display the correct active streak when missed days are allowed since the legacy streak placeholder isn't reliable since it will reset on a missed way even if your streak is set to allow missed days. 

The existing legacy streak placeholders is unchanged.