### PR TITLE
Bound service-site downloads and queued vote work

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -720,6 +720,11 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 		}
 
 		VotingPluginRewardRegistrar.register(this);
+		// Recovered Votifier votes may now traverse the fully initialized vote,
+		// reward, placeholder, shop, and vote-party pipeline.
+		if (votifierVoteOverflowQueue != null) {
+			votifierVoteOverflowQueue.start();
+		}
 
 		plugin.getLogger().info("Enabled VotingPlugin " + plugin.getDescription().getVersion());
 		if (plugin.getDescription().getVersion().contains("SNAPSHOT")) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -91,6 +91,7 @@ import com.bencodez.votingplugin.listeners.PlayerJoinEvent;
 import com.bencodez.votingplugin.listeners.PlayerVoteListener;
 import com.bencodez.votingplugin.listeners.SignChange;
 import com.bencodez.votingplugin.listeners.VotiferEvent;
+import com.bencodez.votingplugin.listeners.VotifierVoteOverflowQueue;
 import com.bencodez.votingplugin.listeners.VotingPluginUpdateEvent;
 import com.bencodez.votingplugin.placeholders.MVdWPlaceholders;
 import com.bencodez.votingplugin.placeholders.PlaceHolders;
@@ -297,6 +298,8 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	private VotingPluginVersionInfo versionInfo;
 	private VotingPluginConfigHealth configHealth;
 	private VotifierIntegration votifierIntegration;
+	@Getter
+	private VotifierVoteOverflowQueue votifierVoteOverflowQueue;
 	private VoteLogManager voteLogManager;
 	private VotingPluginWebhookManager webhookManager;
 
@@ -1386,6 +1389,10 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 			e.printStackTrace();
 		}
 		voteTimer.shutdownNow();
+		if (votifierVoteOverflowQueue != null) {
+			votifierVoteOverflowQueue.close();
+			votifierVoteOverflowQueue = null;
+		}
 		if (timeQueueHandler != null) {
 			timeQueueHandler.save();
 		}
@@ -1449,7 +1456,9 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 
 		pm.registerEvents(new PlayerJoinEvent(this), this);
 		if (isVotifierLoaded()) {
-			pm.registerEvents(new VotiferEvent(this), this);
+			VotiferEvent votifierEvent = new VotiferEvent(this);
+			votifierVoteOverflowQueue = new VotifierVoteOverflowQueue(this, votifierEvent::processVote);
+			pm.registerEvents(votifierEvent, this);
 		}
 		pm.registerEvents(new PlayerVoteListener(this), this);
 		pm.registerEvents(new PlayerPostVoteLoggerListener(this), this);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/VotingPluginMain.java
@@ -98,6 +98,7 @@ import com.bencodez.votingplugin.placeholders.VotingPluginExpansion;
 import com.bencodez.votingplugin.presets.VoteSitePresetSetupHandler;
 import com.bencodez.votingplugin.proxy.control.HostedControlManager;
 import com.bencodez.votingplugin.util.ControlCredentialFile.PendingAutoEnrollment;
+import com.bencodez.votingplugin.util.BoundedScheduledExecutor;
 import com.bencodez.votingplugin.rewards.VotingPluginRewardRegistrar;
 import com.bencodez.votingplugin.servicesites.ServiceSiteHandler;
 import com.bencodez.votingplugin.signs.Signs;
@@ -561,7 +562,7 @@ public class VotingPluginMain extends AdvancedCorePlugin {
 	}
 
 	private void loadVoteTimer() {
-		voteTimer = Executors.newSingleThreadScheduledExecutor();
+		voteTimer = new BoundedScheduledExecutor(1, 256);
 	}
 
 	@Deprecated

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -89,6 +89,7 @@ import com.bencodez.votingplugin.specialrewards.votestreak.VoteStreakDefinition;
 import com.bencodez.votingplugin.specialrewards.votestreak.VoteStreakType;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.user.VotingPluginUser;
+import com.bencodez.votingplugin.util.VoteTaskAdmission;
 import com.bencodez.votingplugin.votesites.VoteSite;
 
 public class CommandLoader {
@@ -1238,8 +1239,9 @@ public class CommandLoader {
 			@Override
 			public void execute(CommandSender sender, String[] args) {
 				sendMessage(sender, "&cTriggering vote for all voting sites...");
+				int rejected = 0;
 				for (VoteSite site : plugin.getVoteSiteManager().getVoteSitesEnabled()) {
-					plugin.getVoteTimer().submit(new Runnable() {
+					if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 						@Override
 						public void run() {
@@ -1255,7 +1257,13 @@ public class CommandLoader {
 							}
 							plugin.getServer().getPluginManager().callEvent(voteEvent);
 						}
-					});
+					})) {
+						rejected++;
+					}
+				}
+				if (rejected > 0) {
+					sendMessage(sender, "&cCould not trigger " + rejected
+							+ " vote(s) because vote processing is busy; please try again later.");
 				}
 
 				if (plugin.isYmlError()) {
@@ -1282,13 +1290,15 @@ public class CommandLoader {
 						sendMessage(sender, "&cTriggering vote...");
 					}
 
-					plugin.getVoteTimer().submit(new Runnable() {
+					if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 						@Override
 						public void run() {
 							plugin.getServer().getPluginManager().callEvent(voteEvent);
 						}
-					});
+					})) {
+						sendMessage(sender, "&cCould not trigger the vote because vote processing is busy; please try again later.");
+					}
 
 					if (plugin.isYmlError()) {
 						sendMessage(sender, "&3Detected yml error, please check server log for details");
@@ -1318,13 +1328,15 @@ public class CommandLoader {
 												+ voteEvent.getServiceSite() + "?");
 							}
 						}
-						plugin.getVoteTimer().submit(new Runnable() {
+						if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 							@Override
 							public void run() {
 								plugin.getServer().getPluginManager().callEvent(voteEvent);
 							}
-						});
+						})) {
+							sendMessage(sender, "&cCould not trigger the vote because vote processing is busy; please try again later.");
+						}
 
 						if (plugin.isYmlError()) {
 							sendMessage(sender, "&3Detected yml error, please check server log for details");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/AdminGUI.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/AdminGUI.java
@@ -33,6 +33,7 @@ import com.bencodez.votingplugin.commands.gui.admin.AdminVoteVoteParty;
 import com.bencodez.votingplugin.commands.gui.admin.milestones.AdminVoteVoteMilestones;
 import com.bencodez.votingplugin.commands.gui.admin.voteshop.AdminVoteVoteShop;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
+import com.bencodez.votingplugin.util.VoteTaskAdmission;
 import com.bencodez.votingplugin.votesites.VoteSite;
 
 /**
@@ -324,13 +325,16 @@ public class AdminGUI {
 								if (ob != null) {
 									VoteSite site = (VoteSite) ob;
 									PlayerVoteEvent voteEvent = new PlayerVoteEvent(site, value, site.getServiceSite(), false);
-									plugin.getVoteTimer().submit(new Runnable() {
+									if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 										@Override
 										public void run() {
 											plugin.getServer().getPluginManager().callEvent(voteEvent);
 										}
-									});
+									})) {
+										player.sendMessage(
+												"Vote could not be triggered because vote processing is busy; please try again later.");
+									}
 								}
 							}
 						});

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotiferEvent.java
@@ -1,5 +1,7 @@
 package com.bencodez.votingplugin.listeners;
 
+import java.util.concurrent.RejectedExecutionException;
+
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -24,6 +26,73 @@ public class VotiferEvent implements Listener {
 	 */
 	public VotiferEvent(VotingPluginMain plugin) {
 		this.plugin = plugin;
+	}
+
+	/**
+	 * Processes a validated vote. The overflow queue invokes this callback from
+	 * its worker after the bounded vote executor has capacity again.
+	 *
+	 * @param voteSite the validated service site
+	 * @param voteUsername the validated player name
+	 */
+	public void processVote(String voteSite, String voteUsername) {
+		try {
+			plugin.getServerData().addServiceSite(voteSite);
+			if (plugin.getBungeeSettings().isUseBungeecoord() && !plugin.getBungeeSettings().isVotifierBypass()
+					&& (plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.PLUGINMESSAGING)
+							|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.SOCKETS)
+							|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.MQTT)
+							|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.REDIS))) {
+				plugin.getLogger().severe(
+						"Ignoring vote from votifier since pluginmessaging, socket, redis, or mqtt bungee method is enabled, this means you aren't setup correctly for those methods, please check: https://github.com/BenCodez/VotingPlugin/wiki/Bungeecord-Setups");
+				return;
+			}
+
+			String matchSite = "";
+			if (plugin.getConfigFile().isAdvancedServiceSiteHandling()) {
+				if (plugin.getServiceSiteHandler() != null) {
+					matchSite = plugin.getServiceSiteHandler().matchReverse(voteSite);
+				}
+			}
+
+			String voteSiteNameStr = plugin.getVoteSiteManager().getVoteSiteName(false, voteSite, matchSite);
+			boolean createSite = !plugin.getVoteSiteManager().hasVoteSite(voteSiteNameStr)
+					&& !plugin.getVoteSiteManager().hasConfiguredVoteSite(voteSiteNameStr);
+
+			String serviceSite = voteSite;
+
+			if (plugin.getConfigFile().isAutoCreateVoteSites() && createSite) {
+				plugin.getLogger().warning("VoteSite with service site '" + voteSiteNameStr
+						+ "' does not exist, attempting to generate...");
+				if (plugin.getConfigVoteSites().tryAutoGenerateVoteSite(voteSiteNameStr)) {
+					plugin.getLogger().info("Current known service sites: "
+							+ ArrayUtils.makeStringList(plugin.getServerData().getServiceSites()));
+				} else {
+					plugin.getLogger().warning("Unable to generate VoteSite for service site '"
+							+ ServiceSiteValidator.sanitizeForLog(voteSiteNameStr) + "'");
+				}
+			}
+
+			if (plugin.getTimeChecker().isActiveProcessing()
+					&& plugin.getConfigFile().isQueueVotesDuringTimeChange()) {
+				plugin.debug("Adding vote to time queue " + voteUsername + "/" + voteSite);
+				plugin.getTimeQueueHandler().addVote(voteUsername, voteSite);
+				return;
+			}
+
+			String voteSiteName = plugin.getVoteSiteManager().getVoteSiteName(true, serviceSite, matchSite);
+
+			PlayerVoteEvent voteEvent = new PlayerVoteEvent(
+					plugin.getVoteSiteManager().getVoteSite(voteSiteName, true), voteUsername, voteSite, true);
+			plugin.getServer().getPluginManager().callEvent(voteEvent);
+
+			if (voteEvent.isCancelled()) {
+				plugin.debug("Vote cancelled");
+			}
+		} catch (Exception e) {
+			plugin.getLogger().severe("Error occured during vote processing");
+			e.printStackTrace();
+		}
 	}
 
 	/**
@@ -65,69 +134,16 @@ public class VotiferEvent implements Listener {
 		plugin.debug("VoteSite: " + voteSite);
 		plugin.debug("IP: " + IP);
 
-		plugin.getVoteTimer().submit(new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					plugin.getServerData().addServiceSite(voteSite);
-					if (plugin.getBungeeSettings().isUseBungeecoord() && !plugin.getBungeeSettings().isVotifierBypass()
-							&& (plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.PLUGINMESSAGING)
-									|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.SOCKETS)
-									|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.MQTT)
-									|| plugin.getBackendProxyHandler().getMethod().equals(BungeeMethod.REDIS))) {
-						plugin.getLogger().severe(
-								"Ignoring vote from votifier since pluginmessaging, socket, redis, or mqtt bungee method is enabled, this means you aren't setup correctly for those methods, please check: https://github.com/BenCodez/VotingPlugin/wiki/Bungeecord-Setups");
-						return;
-					}
-
-					String matchSite = "";
-					if (plugin.getConfigFile().isAdvancedServiceSiteHandling()) {
-						if (plugin.getServiceSiteHandler() != null) {
-							matchSite = plugin.getServiceSiteHandler().matchReverse(voteSite);
-						}
-					}
-
-					String voteSiteNameStr = plugin.getVoteSiteManager().getVoteSiteName(false, voteSite, matchSite);
-					boolean createSite = !plugin.getVoteSiteManager().hasVoteSite(voteSiteNameStr)
-							&& !plugin.getVoteSiteManager().hasConfiguredVoteSite(voteSiteNameStr);
-
-					String serviceSite = voteSite;
-
-					if (plugin.getConfigFile().isAutoCreateVoteSites() && createSite) {
-						plugin.getLogger().warning("VoteSite with service site '" + voteSiteNameStr
-								+ "' does not exist, attempting to generate...");
-						if (plugin.getConfigVoteSites().tryAutoGenerateVoteSite(voteSiteNameStr)) {
-							plugin.getLogger().info("Current known service sites: "
-									+ ArrayUtils.makeStringList(plugin.getServerData().getServiceSites()));
-						} else {
-							plugin.getLogger().warning("Unable to generate VoteSite for service site '"
-									+ ServiceSiteValidator.sanitizeForLog(voteSiteNameStr) + "'");
-						}
-					}
-
-					if (plugin.getTimeChecker().isActiveProcessing()
-							&& plugin.getConfigFile().isQueueVotesDuringTimeChange()) {
-						plugin.debug("Adding vote to time queue " + voteUsername + "/" + voteSite);
-						plugin.getTimeQueueHandler().addVote(voteUsername, voteSite);
-						return;
-					}
-
-					String voteSiteName = plugin.getVoteSiteManager().getVoteSiteName(true, serviceSite, matchSite);
-
-					PlayerVoteEvent voteEvent = new PlayerVoteEvent(
-							plugin.getVoteSiteManager().getVoteSite(voteSiteName, true), voteUsername, voteSite, true);
-					plugin.getServer().getPluginManager().callEvent(voteEvent);
-
-					if (voteEvent.isCancelled()) {
-						plugin.debug("Vote cancelled");
-						return;
-					}
-				} catch (Exception e) {
-					plugin.getLogger().severe("Error occured during vote processing");
-					e.printStackTrace();
-				}
+		try {
+			plugin.getVoteTimer().submit(() -> processVote(voteSite, voteUsername));
+		} catch (RejectedExecutionException rejected) {
+			VotifierVoteOverflowQueue overflow = plugin.getVotifierVoteOverflowQueue();
+			if (overflow == null || !overflow.enqueue(voteUsername, voteSite)) {
+				plugin.getLogger().severe("Votifier vote queue is full; vote was not admitted for "
+						+ MinecraftUsernameValidator.sanitizeForLog(voteUsername));
+			} else {
+				plugin.getLogger().warning("Vote executor saturated; queued Votifier vote for retry");
 			}
-		});
+		}
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
@@ -51,6 +51,7 @@ public final class VotifierVoteOverflowQueue implements AutoCloseable {
 	private boolean drainScheduled;
 	private boolean persistenceScheduled;
 	private boolean persistenceDirty;
+	private boolean started;
 	private boolean closed;
 	private long stateVersion;
 	private long durableVersion;
@@ -72,7 +73,19 @@ public final class VotifierVoteOverflowQueue implements AutoCloseable {
 		});
 		this.worker.setRemoveOnCancelPolicy(true);
 		load();
-		scheduleDrain();
+	}
+
+	/**
+	 * Starts draining persisted and newly queued votes. Call this only after the
+	 * Votifier and vote-processing listeners have been registered so a recovered
+	 * vote cannot be processed before its event handlers are available.
+	 */
+	public void start() {
+		synchronized (lock) {
+			if (closed || started) return;
+			started = true;
+			scheduleDrainLocked();
+		}
 	}
 
 	/**
@@ -113,7 +126,7 @@ public final class VotifierVoteOverflowQueue implements AutoCloseable {
 	}
 
 	private void scheduleDrainLocked() {
-		if (closed || drainScheduled) return;
+		if (closed || !started || drainScheduled) return;
 		drainScheduled = true;
 		try {
 			worker.schedule(this::drain, 0, TimeUnit.MILLISECONDS);

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
@@ -279,6 +279,7 @@ public final class VotifierVoteOverflowQueue implements AutoCloseable {
 
 	private void writeSnapshot(List<PendingVote> snapshot) throws IOException {
 		synchronized (persistenceWriteLock) {
+			if (closed) return;
 			writeSnapshotLocked(snapshot);
 		}
 	}
@@ -332,7 +333,9 @@ public final class VotifierVoteOverflowQueue implements AutoCloseable {
 			Thread.currentThread().interrupt();
 		}
 		try {
-			writeSnapshot(snapshot);
+			synchronized (persistenceWriteLock) {
+				writeSnapshotLocked(snapshot);
+			}
 		} catch (IOException failure) {
 			plugin.getLogger().warning("Unable to persist queued Votifier votes during shutdown: "
 					+ failure.getClass().getSimpleName());

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/listeners/VotifierVoteOverflowQueue.java
@@ -1,0 +1,354 @@
+package com.bencodez.votingplugin.listeners;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.util.DurableFiles;
+import com.bencodez.votingplugin.util.MinecraftUsernameValidator;
+import com.bencodez.votingplugin.util.ServiceSiteValidator;
+
+/**
+ * Durable overflow for votes that cannot currently be admitted to the bounded
+ * vote executor. The queue is drained from a daemon worker and never blocks
+ * the Bukkit event thread.
+ */
+public final class VotifierVoteOverflowQueue implements AutoCloseable {
+	/* Keep the overflow bounded independently of the executor's 256 admissions. */
+	private static final int MAX_ENTRIES = 256;
+	private static final long MAX_FILE_BYTES = 4L * 1024L * 1024L;
+	private static final long RETRY_DELAY_MILLIS = 250L;
+	private static final String QUEUE_FILE = "VotifierVoteQueue.yml";
+
+	private final VotingPluginMain plugin;
+	private final BiConsumer<String, String> processor;
+	private final Path file;
+	private final ScheduledThreadPoolExecutor worker;
+	private final Object lock = new Object();
+	private final Object persistenceWriteLock = new Object();
+	private final ArrayDeque<PendingVote> entries = new ArrayDeque<>();
+	private boolean drainScheduled;
+	private boolean persistenceScheduled;
+	private boolean persistenceDirty;
+	private boolean closed;
+	private long stateVersion;
+	private long durableVersion;
+
+	/**
+	 * Creates and loads the overflow queue.
+	 *
+	 * @param plugin the owning plugin
+	 * @param processor callback receiving service site and player name
+	 */
+	public VotifierVoteOverflowQueue(VotingPluginMain plugin, BiConsumer<String, String> processor) {
+		this.plugin = plugin;
+		this.processor = processor;
+		this.file = new File(plugin.getDataFolder(), QUEUE_FILE).toPath();
+		this.worker = new ScheduledThreadPoolExecutor(1, runnable -> {
+			Thread thread = new Thread(runnable, "VotingPlugin-Votifier-Overflow");
+			thread.setDaemon(true);
+			return thread;
+		});
+		this.worker.setRemoveOnCancelPolicy(true);
+		load();
+		scheduleDrain();
+	}
+
+	/**
+	 * Adds a validated vote to the durable queue. This method only takes a small
+	 * monitor and schedules file I/O on the daemon worker.
+	 *
+	 * @param username the validated player name
+	 * @param serviceSite the validated service site
+	 * @return false when the bounded overflow is full or shutting down
+	 */
+	public boolean enqueue(String username, String serviceSite) {
+		if (username == null || serviceSite == null) return false;
+		synchronized (lock) {
+			if (closed || entries.size() >= MAX_ENTRIES) return false;
+			entries.addLast(new PendingVote(username, serviceSite, System.currentTimeMillis()));
+			stateVersion++;
+			requestPersistenceLocked();
+			scheduleDrainLocked();
+			return true;
+		}
+	}
+
+	/**
+	 * Returns the number of votes waiting for admission or completion.
+	 *
+	 * @return queue size
+	 */
+	public int size() {
+		synchronized (lock) {
+			return entries.size();
+		}
+	}
+
+	private void scheduleDrain() {
+		synchronized (lock) {
+			scheduleDrainLocked();
+		}
+	}
+
+	private void scheduleDrainLocked() {
+		if (closed || drainScheduled) return;
+		drainScheduled = true;
+		try {
+			worker.schedule(this::drain, 0, TimeUnit.MILLISECONDS);
+		} catch (RejectedExecutionException ignored) {
+			drainScheduled = false;
+		}
+	}
+
+	private void drain() {
+		while (true) {
+			synchronized (lock) {
+				if (durableVersion != stateVersion) {
+					drainScheduled = false;
+					return;
+				}
+				PendingVote pending = nextUnsubmittedLocked();
+				if (pending == null) {
+					drainScheduled = false;
+					return;
+				}
+				pending.submitted = true;
+				try {
+					// Serialize admission with enqueue so the version proven durable
+					// above cannot change in the gap before submit accepts this vote.
+					plugin.getVoteTimer().submit(() -> {
+						try {
+							processor.accept(pending.serviceSite, pending.username);
+						} finally {
+							acknowledge(pending);
+						}
+					});
+				} catch (RejectedExecutionException rejected) {
+					pending.submitted = false;
+					drainScheduled = false;
+					try {
+						worker.schedule(this::drain, RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+						drainScheduled = true;
+					} catch (RejectedExecutionException ignored) {
+						// The queue is closing; the persisted entry remains for restart.
+					}
+					return;
+				}
+			}
+		}
+	}
+
+	private PendingVote nextUnsubmittedLocked() {
+		for (PendingVote pending : entries) {
+			if (!pending.submitted) return pending;
+		}
+		return null;
+	}
+
+	private void acknowledge(PendingVote pending) {
+		synchronized (lock) {
+			entries.remove(pending);
+			stateVersion++;
+			requestPersistenceLocked();
+			scheduleDrainLocked();
+		}
+	}
+
+	private void requestPersistenceLocked() {
+		persistenceDirty = true;
+		if (persistenceScheduled) return;
+		persistenceScheduled = true;
+		try {
+			worker.execute(this::persistLoop);
+		} catch (RejectedExecutionException ignored) {
+			persistenceScheduled = false;
+		}
+	}
+
+	private void persistLoop() {
+		while (true) {
+			List<PendingVote> snapshot;
+			long snapshotVersion;
+			synchronized (lock) {
+				if (!persistenceDirty) {
+					persistenceScheduled = false;
+					return;
+				}
+				persistenceDirty = false;
+				snapshot = new ArrayList<>(entries);
+				snapshotVersion = stateVersion;
+			}
+			try {
+				writeSnapshot(snapshot);
+			} catch (IOException failure) {
+				plugin.getLogger().warning("Unable to persist queued Votifier votes: " + failure.getClass().getSimpleName());
+				synchronized (lock) {
+					persistenceDirty = true;
+					try {
+						worker.schedule(this::persistLoop, RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+					} catch (RejectedExecutionException ignored) {
+						persistenceScheduled = false;
+					}
+				}
+				return;
+			}
+			synchronized (lock) {
+				durableVersion = Math.max(durableVersion, snapshotVersion);
+				if (!persistenceDirty) {
+					persistenceScheduled = false;
+					scheduleDrainLocked();
+					return;
+				}
+			}
+		}
+	}
+
+	private void load() {
+		try {
+			if (!Files.exists(file, LinkOption.NOFOLLOW_LINKS)) return;
+			YamlConfiguration yaml = new YamlConfiguration();
+			yaml.loadFromString(readQueueFile());
+			Object raw = yaml.get("Votes");
+			if (!(raw instanceof List<?> values)) return;
+			boolean skipped = false;
+			for (Object value : values) {
+				if (entries.size() >= MAX_ENTRIES) {
+					skipped = true;
+					break;
+				}
+				if (!(value instanceof Map<?, ?> map)) {
+					skipped = true;
+					continue;
+				}
+				Object username = map.get("Username");
+				Object serviceSite = map.get("ServiceSite");
+				Object time = map.get("Time");
+				if (!(username instanceof String name) || !(serviceSite instanceof String site)
+						|| !(time instanceof Number timestamp)
+						|| !MinecraftUsernameValidator.isValid(name, plugin.getOptions().getBedrockPlayerPrefix())
+						|| !ServiceSiteValidator.isValid(site) || timestamp.longValue() <= 0) {
+					skipped = true;
+					continue;
+				}
+				entries.addLast(new PendingVote(name, site, timestamp.longValue()));
+			}
+			if (skipped) {
+				synchronized (lock) {
+					stateVersion++;
+					requestPersistenceLocked();
+				}
+			}
+		} catch (Exception failure) {
+			plugin.getLogger().warning("Unable to load queued Votifier votes: " + failure.getClass().getSimpleName());
+		}
+	}
+
+	private String readQueueFile() throws IOException {
+		Set<java.nio.file.OpenOption> options = Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS);
+		try (SeekableByteChannel channel = Files.newByteChannel(file, options)) {
+			ByteBuffer bytes = ByteBuffer.allocate((int) MAX_FILE_BYTES + 1);
+			while (bytes.hasRemaining() && channel.read(bytes) != -1) {
+				// Continue until EOF or one byte beyond the configured limit.
+			}
+			if (!bytes.hasRemaining()) throw new IOException("queue file exceeds size limit");
+			return new String(bytes.array(), 0, bytes.position(), StandardCharsets.UTF_8);
+		}
+	}
+
+	private void writeSnapshot(List<PendingVote> snapshot) throws IOException {
+		synchronized (persistenceWriteLock) {
+			writeSnapshotLocked(snapshot);
+		}
+	}
+
+	private void writeSnapshotLocked(List<PendingVote> snapshot) throws IOException {
+		YamlConfiguration yaml = new YamlConfiguration();
+		List<Map<String, Object>> values = new ArrayList<>();
+		for (PendingVote pending : snapshot) {
+			Map<String, Object> value = new LinkedHashMap<>();
+			value.put("Username", pending.username);
+			value.put("ServiceSite", pending.serviceSite);
+			value.put("Time", pending.time);
+			values.add(value);
+		}
+		yaml.set("Votes", values);
+		byte[] bytes = yaml.saveToString().getBytes(StandardCharsets.UTF_8);
+		if (bytes.length > MAX_FILE_BYTES) throw new IOException("queue snapshot exceeds size limit");
+		Path parent = file.toAbsolutePath().normalize().getParent();
+		if (parent == null) throw new IOException("queue has no parent");
+		Files.createDirectories(parent);
+		Path temporary = Files.createTempFile(parent, "VotifierVoteQueue-", ".tmp");
+		try {
+			Files.write(temporary, bytes, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE);
+			DurableFiles.forceFile(temporary);
+			try {
+				Files.move(temporary, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+			} catch (AtomicMoveNotSupportedException unsupported) {
+				Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+			}
+			DurableFiles.forceDirectory(parent);
+		} finally {
+			Files.deleteIfExists(temporary);
+		}
+	}
+
+	@Override
+	public void close() {
+		List<PendingVote> snapshot;
+		synchronized (lock) {
+			if (closed) return;
+			closed = true;
+			// At-least-once delivery: retain any unacknowledged callback. A callback
+			// interrupted during shutdown must be replayed rather than silently lost.
+			snapshot = new ArrayList<>(entries);
+			persistenceScheduled = false;
+		}
+		worker.shutdownNow();
+		try {
+			worker.awaitTermination(1, TimeUnit.SECONDS);
+		} catch (InterruptedException interrupted) {
+			Thread.currentThread().interrupt();
+		}
+		try {
+			writeSnapshot(snapshot);
+		} catch (IOException failure) {
+			plugin.getLogger().warning("Unable to persist queued Votifier votes during shutdown: "
+					+ failure.getClass().getSimpleName());
+		}
+	}
+
+	private static final class PendingVote {
+		private final String username;
+		private final String serviceSite;
+		private final long time;
+		private boolean submitted;
+
+		private PendingVote(String username, String serviceSite, long time) {
+			this.username = username;
+			this.serviceSite = serviceSite;
+			this.time = time;
+		}
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
@@ -195,16 +195,19 @@ public class ServiceSiteHandler {
 
 		HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
-		int code = response.statusCode();
-		if (code < 200 || code >= 300) {
-			throw new IOException("HTTP " + code);
-		}
+		byte[] body = readSuccessfulResponse(response);
 		String contentType = response.headers().firstValue("Content-Type").orElse(null);
-		byte[] body;
-		try (InputStream input = response.body()) {
-			body = readBounded(input, MAX_RESPONSE_BYTES);
-		}
 		return new FetchResult(urlStr, new String(body, StandardCharsets.UTF_8), contentType);
+	}
+
+	static byte[] readSuccessfulResponse(HttpResponse<InputStream> response) throws IOException {
+		try (InputStream input = response.body()) {
+			int code = response.statusCode();
+			if (code < 200 || code >= 300) {
+				throw new IOException("HTTP " + code);
+			}
+			return readBounded(input, MAX_RESPONSE_BYTES);
+		}
 	}
 
 	static byte[] readBounded(InputStream input, int maximumBytes) throws IOException {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
@@ -39,6 +39,10 @@ import lombok.Getter;
  * Lookups are case-insensitive while preserving original casing.
  */
 public class ServiceSiteHandler {
+	static final int MAX_RESPONSE_BYTES = 1024 * 1024;
+	static final int MAX_ENTRIES = 2048;
+	static final int MAX_KEY_LENGTH = 128;
+	static final int MAX_VALUE_LENGTH = 512;
 
 	private static final String PRIMARY_URL = "https://raw.githubusercontent.com/wiki/BenCodez/VotingPlugin/Minecraft-Server-Lists.md";
 	private static final String SECONDARY_URL = "https://wiki.bencodez.com/en/VotingPlugin/Minecraft-Server-Lists";
@@ -187,16 +191,18 @@ public class ServiceSiteHandler {
 				.header("User-Agent", "VotingPlugin/ServiceSiteHandler")
 				.build();
 
-		HttpResponse<String> response = httpClient.send(request,
-				HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+		HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
 
 		int code = response.statusCode();
 		if (code < 200 || code >= 300) {
 			throw new IOException("HTTP " + code);
 		}
+		if (response.body().length > MAX_RESPONSE_BYTES) {
+			throw new IOException("Service site response exceeds " + MAX_RESPONSE_BYTES + " bytes");
+		}
 
 		String contentType = response.headers().firstValue("Content-Type").orElse(null);
-		return new FetchResult(urlStr, response.body(), contentType);
+		return new FetchResult(urlStr, new String(response.body(), StandardCharsets.UTF_8), contentType);
 	}
 
 	private Map<String, String> parseFromWebBody(String body, String contentType) {
@@ -228,6 +234,9 @@ public class ServiceSiteHandler {
 		Map<String, String> parsed = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 		for (String line : lines) {
+			if (parsed.size() >= MAX_ENTRIES) {
+				break;
+			}
 			if (line == null) {
 				continue;
 			}
@@ -248,12 +257,17 @@ public class ServiceSiteHandler {
 			String key = m.group(1).trim();
 			String val = m.group(2).trim();
 
-			if (!key.isEmpty() && !val.isEmpty()) {
+			if (isSafeEntry(key, val)) {
 				parsed.put(key, val);
 			}
 		}
 
 		return parsed;
+	}
+
+	static boolean isSafeEntry(String key, String value) {
+		return key != null && value != null && !key.isEmpty() && !value.isEmpty()
+				&& key.length() <= MAX_KEY_LENGTH && value.length() <= MAX_VALUE_LENGTH;
 	}
 
 	private static boolean mapsEqual(Map<String, String> a, Map<String, String> b) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
@@ -48,7 +48,7 @@ public class ServiceSiteHandler {
 	static final int MAX_RESPONSE_BYTES = 1024 * 1024;
 	static final int MAX_ENTRIES = 2048;
 	static final int MAX_KEY_LENGTH = 128;
-	static final int MAX_VALUE_LENGTH = 512;
+	static final int MAX_VALUE_LENGTH = 2048;
 
 	private static final String PRIMARY_URL = "https://raw.githubusercontent.com/wiki/BenCodez/VotingPlugin/Minecraft-Server-Lists.md";
 	private static final String SECONDARY_URL = "https://wiki.bencodez.com/en/VotingPlugin/Minecraft-Server-Lists";

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
@@ -17,6 +17,10 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -186,6 +190,7 @@ public class ServiceSiteHandler {
 	}
 
 	private FetchResult fetch(String urlStr) throws IOException, InterruptedException {
+		long deadlineNanos = System.nanoTime() + Duration.ofSeconds(7).toNanos();
 		HttpRequest request = HttpRequest.newBuilder()
 				.uri(URI.create(urlStr))
 				.GET()
@@ -195,18 +200,49 @@ public class ServiceSiteHandler {
 
 		HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
-		byte[] body = readSuccessfulResponse(response);
+		long remainingNanos = deadlineNanos - System.nanoTime();
+		if (remainingNanos <= 0) {
+			response.body().close();
+			throw new IOException("Service site response timed out");
+		}
+		byte[] body = readSuccessfulResponse(response, remainingNanos, TimeUnit.NANOSECONDS);
 		String contentType = response.headers().firstValue("Content-Type").orElse(null);
 		return new FetchResult(urlStr, new String(body, StandardCharsets.UTF_8), contentType);
 	}
 
 	static byte[] readSuccessfulResponse(HttpResponse<InputStream> response) throws IOException {
+		return readSuccessfulResponse(response, 7, TimeUnit.SECONDS);
+	}
+
+	static byte[] readSuccessfulResponse(HttpResponse<InputStream> response, long timeout, TimeUnit unit)
+			throws IOException {
 		try (InputStream input = response.body()) {
 			int code = response.statusCode();
 			if (code < 200 || code >= 300) {
 				throw new IOException("HTTP " + code);
 			}
-			return readBounded(input, MAX_RESPONSE_BYTES);
+			CompletableFuture<byte[]> read = CompletableFuture.supplyAsync(() -> {
+				try {
+					return readBounded(input, MAX_RESPONSE_BYTES);
+				} catch (IOException e) {
+					throw new java.io.UncheckedIOException(e);
+				}
+			});
+			try {
+				return read.get(timeout, unit);
+			} catch (TimeoutException e) {
+				read.cancel(true);
+				throw new IOException("Service site response timed out", e);
+			} catch (ExecutionException e) {
+				if (e.getCause() instanceof java.io.UncheckedIOException) {
+					throw ((java.io.UncheckedIOException) e.getCause()).getCause();
+				}
+				throw new IOException("Unable to read service site response", e.getCause());
+			} catch (InterruptedException e) {
+				read.cancel(true);
+				Thread.currentThread().interrupt();
+				throw new IOException("Interrupted while reading service site response", e);
+			}
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandler.java
@@ -1,6 +1,8 @@
 package com.bencodez.votingplugin.servicesites;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpClient.Redirect;
@@ -191,18 +193,33 @@ public class ServiceSiteHandler {
 				.header("User-Agent", "VotingPlugin/ServiceSiteHandler")
 				.build();
 
-		HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+		HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
 		int code = response.statusCode();
 		if (code < 200 || code >= 300) {
 			throw new IOException("HTTP " + code);
 		}
-		if (response.body().length > MAX_RESPONSE_BYTES) {
-			throw new IOException("Service site response exceeds " + MAX_RESPONSE_BYTES + " bytes");
-		}
-
 		String contentType = response.headers().firstValue("Content-Type").orElse(null);
-		return new FetchResult(urlStr, new String(response.body(), StandardCharsets.UTF_8), contentType);
+		byte[] body;
+		try (InputStream input = response.body()) {
+			body = readBounded(input, MAX_RESPONSE_BYTES);
+		}
+		return new FetchResult(urlStr, new String(body, StandardCharsets.UTF_8), contentType);
+	}
+
+	static byte[] readBounded(InputStream input, int maximumBytes) throws IOException {
+		ByteArrayOutputStream output = new ByteArrayOutputStream(Math.min(maximumBytes, 8192));
+		byte[] buffer = new byte[8192];
+		int total = 0;
+		int read;
+		while ((read = input.read(buffer, 0, Math.min(buffer.length, maximumBytes + 1 - total))) != -1) {
+			total += read;
+			if (total > maximumBytes) {
+				throw new IOException("Service site response exceeds " + maximumBytes + " bytes");
+			}
+			output.write(buffer, 0, read);
+		}
+		return output.toByteArray();
 	}
 
 	private Map<String, String> parseFromWebBody(String body, String contentType) {

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/test/VoteTester.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/test/VoteTester.java
@@ -3,6 +3,7 @@ package com.bencodez.votingplugin.test;
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.bencodez.advancedcore.api.rewards.Reward;
 import com.bencodez.advancedcore.api.rewards.RewardOptions;
@@ -11,6 +12,7 @@ import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
 import com.bencodez.votingplugin.topvoter.TopVoter;
 import com.bencodez.votingplugin.user.VotingPluginUser;
+import com.bencodez.votingplugin.util.VoteTaskAdmission;
 
 public class VoteTester {
 
@@ -61,7 +63,7 @@ public class VoteTester {
 	}
 
 	public void testRewards(int amount, String name, String rewardName) {
-		plugin.getVoteTimer().submit(new Runnable() {
+		if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 			@Override
 			public void run() {
@@ -94,17 +96,20 @@ public class VoteTester {
 								+ " rewards given");
 			}
 
-		});
+		})) {
+			plugin.getLogger().warning("Unable to start reward test because vote processing is busy; retry later.");
+		}
 
 	}
 
 	public void testSpam(int amount, String name, String site) {
+		AtomicBoolean rejectionLogged = new AtomicBoolean();
 		for (int i = 0; i < amount; i++) {
 			plugin.getBukkitScheduler().runTaskAsynchronously(plugin, new Runnable() {
 
 				@Override
 				public void run() {
-					plugin.getVoteTimer().submit(new Runnable() {
+					if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 						@Override
 						public void run() {
@@ -112,7 +117,9 @@ public class VoteTester {
 									plugin.getVoteSiteManager().getVoteSiteServiceSite(site), false);
 							plugin.getServer().getPluginManager().callEvent(voteEvent);
 						}
-					});
+					}) && rejectionLogged.compareAndSet(false, true)) {
+						plugin.getLogger().warning("One or more spam-test votes could not be submitted because vote processing is busy.");
+					}
 				}
 			});
 
@@ -120,7 +127,7 @@ public class VoteTester {
 	}
 
 	public void testVotes(int amount, String name, String site) {
-		plugin.getVoteTimer().submit(new Runnable() {
+		if (!VoteTaskAdmission.trySubmit(plugin.getVoteTimer(), new Runnable() {
 
 			@Override
 			public void run() {
@@ -148,7 +155,9 @@ public class VoteTester {
 								+ plugin.getVoteSiteManager().getVoteSitesEnabled().size() + " votesites");
 			}
 
-		});
+		})) {
+			plugin.getLogger().warning("Unable to start vote test because vote processing is busy; retry later.");
+		}
 
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import com.bencodez.advancedcore.api.time.events.DateChangedEvent;
 import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
+import com.bencodez.votingplugin.util.VoteTaskAdmission;
 
 import lombok.Getter;
 
@@ -56,14 +57,7 @@ public class TimeQueueHandler implements Listener {
 			timeChangeQueue
 					.add(new VoteTimeQueue(data.getString("Name"), data.getString("Service"), data.getLong("Time")));
 		}
-		plugin.getServerData().clearTimedVoteCache();
-		plugin.getVoteTimer().schedule(new Runnable() {
-
-			@Override
-			public void run() {
-				processQueue();
-			}
-		}, 120, TimeUnit.SECONDS);
+		scheduleQueueProcessing(120, TimeUnit.SECONDS);
 	}
 
 	/**
@@ -73,13 +67,19 @@ public class TimeQueueHandler implements Listener {
 	 */
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void postTimeChange(DateChangedEvent event) {
-		plugin.getVoteTimer().schedule(new Runnable() {
+		scheduleQueueProcessing(5, TimeUnit.SECONDS);
+	}
 
-			@Override
-			public void run() {
-				processQueue();
-			}
-		}, 5, TimeUnit.SECONDS);
+	private void scheduleQueueProcessing(long delay, TimeUnit unit) {
+		boolean admitted = VoteTaskAdmission.trySchedule(plugin.getVoteTimer(), () -> {
+			// Clear only after the bounded executor has admitted the task. If it is
+			// rejected, shutdown persistence can still recover the in-memory queue.
+			plugin.getServerData().clearTimedVoteCache();
+			processQueue();
+		}, delay, unit);
+		if (!admitted) {
+			plugin.getLogger().warning("Unable to schedule time-queue processing because vote processing is busy; queued votes were retained.");
+		}
 	}
 
 	/**

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
@@ -24,6 +24,7 @@ import lombok.Getter;
  * The TimeQueueHandler class manages time-based vote queue processing.
  */
 public class TimeQueueHandler implements Listener {
+	private static final long TICKS_PER_SECOND = 20L;
 	@Getter
 	private Queue<VoteTimeQueue> timeChangeQueue = new ConcurrentLinkedQueue<>();
 
@@ -93,11 +94,12 @@ public class TimeQueueHandler implements Listener {
 		if (timeChangeQueue.isEmpty() || !retryPending.compareAndSet(false, true)) return;
 		int attempt = Math.min(6, retryAttempts.getAndIncrement());
 		long delaySeconds = Math.min(60L, 1L << attempt);
+		long delayTicks = delaySeconds * TICKS_PER_SECOND;
 		try {
 			plugin.getBukkitScheduler().runTaskLaterAsynchronously(plugin, () -> {
 				retryPending.set(false);
 				if (!timeChangeQueue.isEmpty()) scheduleQueueProcessing(0, TimeUnit.SECONDS);
-			}, delaySeconds);
+			}, delayTicks);
 		} catch (RuntimeException rejected) {
 			retryPending.set(false);
 			plugin.getLogger().warning("Unable to queue a time-queue retry; pending votes remain persisted for recovery.");

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/timequeue/TimeQueueHandler.java
@@ -5,6 +5,8 @@ import java.time.ZoneId;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.EventHandler;
@@ -26,6 +28,8 @@ public class TimeQueueHandler implements Listener {
 	private Queue<VoteTimeQueue> timeChangeQueue = new ConcurrentLinkedQueue<>();
 
 	private VotingPluginMain plugin;
+	private final AtomicBoolean retryPending = new AtomicBoolean();
+	private final AtomicInteger retryAttempts = new AtomicInteger();
 
 	/**
 	 * Constructs a new TimeQueueHandler.
@@ -79,6 +83,24 @@ public class TimeQueueHandler implements Listener {
 		}, delay, unit);
 		if (!admitted) {
 			plugin.getLogger().warning("Unable to schedule time-queue processing because vote processing is busy; queued votes were retained.");
+			scheduleRetry();
+		} else {
+			retryAttempts.set(0);
+		}
+	}
+
+	private void scheduleRetry() {
+		if (timeChangeQueue.isEmpty() || !retryPending.compareAndSet(false, true)) return;
+		int attempt = Math.min(6, retryAttempts.getAndIncrement());
+		long delaySeconds = Math.min(60L, 1L << attempt);
+		try {
+			plugin.getBukkitScheduler().runTaskLaterAsynchronously(plugin, () -> {
+				retryPending.set(false);
+				if (!timeChangeQueue.isEmpty()) scheduleQueueProcessing(0, TimeUnit.SECONDS);
+			}, delaySeconds);
+		} catch (RuntimeException rejected) {
+			retryPending.set(false);
+			plugin.getLogger().warning("Unable to queue a time-queue retry; pending votes remain persisted for recovery.");
 		}
 	}
 

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/BoundedScheduledExecutor.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/BoundedScheduledExecutor.java
@@ -1,0 +1,40 @@
+package com.bencodez.votingplugin.util;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+/** A scheduled executor with an admission limit for queued and running one-shot tasks. */
+public final class BoundedScheduledExecutor extends ScheduledThreadPoolExecutor {
+	private final Semaphore permits;
+
+	public BoundedScheduledExecutor(int corePoolSize, int capacity) {
+		super(corePoolSize);
+		if (capacity < corePoolSize) {
+			throw new IllegalArgumentException("capacity must be at least corePoolSize");
+		}
+		permits = new Semaphore(capacity);
+		setRemoveOnCancelPolicy(true);
+	}
+
+	@Override
+	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+		if (!permits.tryAcquire()) {
+			throw new RejectedExecutionException("Vote task capacity exhausted");
+		}
+		try {
+			return super.schedule(() -> {
+				try {
+					command.run();
+				} finally {
+					permits.release();
+				}
+			}, delay, unit);
+		} catch (RuntimeException ex) {
+			permits.release();
+			throw ex;
+		}
+	}
+}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/BoundedScheduledExecutor.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/BoundedScheduledExecutor.java
@@ -5,6 +5,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /** A scheduled executor with an admission limit for queued and running one-shot tasks. */
 public final class BoundedScheduledExecutor extends ScheduledThreadPoolExecutor {
@@ -24,17 +26,45 @@ public final class BoundedScheduledExecutor extends ScheduledThreadPoolExecutor 
 		if (!permits.tryAcquire()) {
 			throw new RejectedExecutionException("Vote task capacity exhausted");
 		}
+		AtomicBoolean released = new AtomicBoolean();
 		try {
-			return super.schedule(() -> {
+			ScheduledFuture<?> delegate = super.schedule(() -> {
 				try {
 					command.run();
 				} finally {
-					permits.release();
+					releaseOnce(released);
 				}
 			}, delay, unit);
+			return new PermitReleasingFuture(delegate, released);
 		} catch (RuntimeException ex) {
 			permits.release();
 			throw ex;
 		}
+	}
+
+	private void releaseOnce(AtomicBoolean released) {
+		if (released.compareAndSet(false, true)) {
+			permits.release();
+		}
+	}
+
+	private final class PermitReleasingFuture implements ScheduledFuture<Object> {
+		private final ScheduledFuture<?> delegate;
+		private final AtomicBoolean released;
+		private PermitReleasingFuture(ScheduledFuture<?> delegate, AtomicBoolean released) {
+			this.delegate = delegate;
+			this.released = released;
+		}
+		@Override public boolean cancel(boolean mayInterruptIfRunning) {
+			boolean cancelled = delegate.cancel(mayInterruptIfRunning);
+			if (cancelled) releaseOnce(released);
+			return cancelled;
+		}
+		@Override public boolean isCancelled() { return delegate.isCancelled(); }
+		@Override public boolean isDone() { return delegate.isDone(); }
+		@Override public Object get() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException { return delegate.get(); }
+		@Override public Object get(long timeout, TimeUnit unit) throws java.lang.InterruptedException, java.util.concurrent.ExecutionException, java.util.concurrent.TimeoutException { return delegate.get(timeout, unit); }
+		@Override public long getDelay(TimeUnit unit) { return delegate.getDelay(unit); }
+		@Override public int compareTo(Delayed other) { return delegate.compareTo(other); }
 	}
 }

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/VoteTaskAdmission.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/util/VoteTaskAdmission.java
@@ -1,0 +1,46 @@
+package com.bencodez.votingplugin.util;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Non-blocking admission helpers for work submitted to the bounded vote timer. */
+public final class VoteTaskAdmission {
+
+	private VoteTaskAdmission() {
+	}
+
+	/**
+	 * Attempts to submit a one-shot vote task without running it on the caller.
+	 *
+	 * @param executor bounded vote executor
+	 * @param task task to submit
+	 * @return true when the task was admitted
+	 */
+	public static boolean trySubmit(ScheduledExecutorService executor, Runnable task) {
+		try {
+			executor.submit(task);
+			return true;
+		} catch (RejectedExecutionException rejected) {
+			return false;
+		}
+	}
+
+	/**
+	 * Attempts to schedule a one-shot vote task without blocking the caller.
+	 *
+	 * @param executor bounded vote executor
+	 * @param task task to schedule
+	 * @param delay delay before execution
+	 * @param unit delay unit
+	 * @return true when the task was admitted
+	 */
+	public static boolean trySchedule(ScheduledExecutorService executor, Runnable task, long delay, TimeUnit unit) {
+		try {
+			executor.schedule(task, delay, unit);
+			return true;
+		} catch (RejectedExecutionException rejected) {
+			return false;
+		}
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpResponse;
+import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +48,29 @@ class ServiceSiteHandlerLimitsTest {
 		when(response.statusCode()).thenReturn(500);
 
 		assertThrows(IOException.class, () -> ServiceSiteHandler.readSuccessfulResponse(response));
+		assertTrue(stream.closed);
+	}
+
+	@Test
+	void closesStreamingBodyWhenDeadlineExpires() {
+		class StallingStream extends InputStream {
+			volatile boolean closed;
+			@Override public int read() throws IOException {
+				while (!closed) {
+					try { Thread.sleep(5); } catch (InterruptedException ignored) { }
+				}
+				throw new IOException("closed");
+			}
+			@Override public void close() { closed = true; }
+		}
+		StallingStream stream = new StallingStream();
+		@SuppressWarnings("unchecked")
+		HttpResponse<InputStream> response = mock(HttpResponse.class);
+		when(response.body()).thenReturn(stream);
+		when(response.statusCode()).thenReturn(200);
+
+		assertThrows(IOException.class,
+				() -> ServiceSiteHandler.readSuccessfulResponse(response, 20, TimeUnit.MILLISECONDS));
 		assertTrue(stream.closed);
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
@@ -22,6 +22,7 @@ class ServiceSiteHandlerLimitsTest {
 
 	@Test
 	void rejectsOversizedRemoteEntries() {
+		assertTrue(ServiceSiteHandler.isSafeEntry("Example", "x".repeat(ServiceSiteHandler.MAX_VALUE_LENGTH)));
 		assertFalse(ServiceSiteHandler.isSafeEntry("x".repeat(ServiceSiteHandler.MAX_KEY_LENGTH + 1), "example.com"));
 		assertFalse(ServiceSiteHandler.isSafeEntry("Example", "x".repeat(ServiceSiteHandler.MAX_VALUE_LENGTH + 1)));
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpResponse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,5 +31,22 @@ class ServiceSiteHandlerLimitsTest {
 		assertTrue(ServiceSiteHandler.readBounded(new ByteArrayInputStream(allowed), 32).length == 32);
 		assertThrows(IOException.class,
 				() -> ServiceSiteHandler.readBounded(new ByteArrayInputStream(new byte[33]), 32));
+	}
+
+	@Test
+	void closesErrorResponseStream() {
+		class TrackingStream extends ByteArrayInputStream {
+			boolean closed;
+			TrackingStream() { super(new byte[] { 1 }); }
+			@Override public void close() throws IOException { closed = true; super.close(); }
+		}
+		TrackingStream stream = new TrackingStream();
+		@SuppressWarnings("unchecked")
+		HttpResponse<InputStream> response = mock(HttpResponse.class);
+		when(response.body()).thenReturn(stream);
+		when(response.statusCode()).thenReturn(500);
+
+		assertThrows(IOException.class, () -> ServiceSiteHandler.readSuccessfulResponse(response));
+		assertTrue(stream.closed);
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
@@ -2,6 +2,10 @@ package com.bencodez.votingplugin.servicesites;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
@@ -15,5 +19,13 @@ class ServiceSiteHandlerLimitsTest {
 	void rejectsOversizedRemoteEntries() {
 		assertFalse(ServiceSiteHandler.isSafeEntry("x".repeat(ServiceSiteHandler.MAX_KEY_LENGTH + 1), "example.com"));
 		assertFalse(ServiceSiteHandler.isSafeEntry("Example", "x".repeat(ServiceSiteHandler.MAX_VALUE_LENGTH + 1)));
+	}
+
+	@Test
+	void abortsStreamingBodyImmediatelyAfterLimit() throws Exception {
+		byte[] allowed = new byte[32];
+		assertTrue(ServiceSiteHandler.readBounded(new ByteArrayInputStream(allowed), 32).length == 32);
+		assertThrows(IOException.class,
+				() -> ServiceSiteHandler.readBounded(new ByteArrayInputStream(new byte[33]), 32));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/servicesites/ServiceSiteHandlerLimitsTest.java
@@ -1,0 +1,19 @@
+package com.bencodez.votingplugin.servicesites;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ServiceSiteHandlerLimitsTest {
+	@Test
+	void acceptsNormalEntries() {
+		assertTrue(ServiceSiteHandler.isSafeEntry("PlanetMinecraft", "planetminecraft.com"));
+	}
+
+	@Test
+	void rejectsOversizedRemoteEntries() {
+		assertFalse(ServiceSiteHandler.isSafeEntry("x".repeat(ServiceSiteHandler.MAX_KEY_LENGTH + 1), "example.com"));
+		assertFalse(ServiceSiteHandler.isSafeEntry("Example", "x".repeat(ServiceSiteHandler.MAX_VALUE_LENGTH + 1)));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotiferEventDisabledVoteSiteTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotiferEventDisabledVoteSiteTest.java
@@ -4,12 +4,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Logger;
 
@@ -22,6 +24,7 @@ import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.config.ConfigVoteSites;
 import com.bencodez.votingplugin.events.PlayerVoteEvent;
 import com.bencodez.votingplugin.listeners.VotiferEvent;
+import com.bencodez.votingplugin.listeners.VotifierVoteOverflowQueue;
 import com.bencodez.votingplugin.votesites.VoteSiteManager;
 import com.vexsoftware.votifier.model.Vote;
 
@@ -45,12 +48,15 @@ public class VotiferEventDisabledVoteSiteTest {
 
 	private VotiferEvent listener;
 
+	private VotifierVoteOverflowQueue overflowQueue;
+
 	@BeforeEach
 	public void setUp() {
 		plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
 		configVoteSites = mock(ConfigVoteSites.class);
 		voteSiteManager = mock(VoteSiteManager.class);
 		voteTimer = mock(ScheduledExecutorService.class);
+		overflowQueue = mock(VotifierVoteOverflowQueue.class);
 
 		Server server = mock(Server.class);
 		pluginManager = mock(PluginManager.class);
@@ -59,6 +65,7 @@ public class VotiferEventDisabledVoteSiteTest {
 		when(plugin.getConfigVoteSites()).thenReturn(configVoteSites);
 		when(plugin.getVoteSiteManager()).thenReturn(voteSiteManager);
 		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		when(plugin.getVotifierVoteOverflowQueue()).thenReturn(overflowQueue);
 		when(plugin.getServer()).thenReturn(server);
 		when(server.getPluginManager()).thenReturn(pluginManager);
 
@@ -135,5 +142,17 @@ public class VotiferEventDisabledVoteSiteTest {
 
 		verify(configVoteSites).tryAutoGenerateVoteSite(SERVICE_SITE);
 		verify(pluginManager).callEvent(any(PlayerVoteEvent.class));
+	}
+
+	@Test
+	public void testVoteIsQueuedWhenBoundedExecutorRejectsIt() {
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).submit(any(Runnable.class));
+		when(overflowQueue.enqueue("Steve", SERVICE_SITE)).thenReturn(true);
+
+		listener.onVotiferEvent(createVoteEvent(SERVICE_SITE));
+
+		verify(overflowQueue).enqueue("Steve", SERVICE_SITE);
+		verify(pluginManager, never()).callEvent(any(PlayerVoteEvent.class));
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
@@ -186,6 +186,42 @@ class VotifierVoteOverflowQueueTest {
 		}
 	}
 
+	@Test
+	void stalePersistenceWorkerCannotOverwriteShutdownSnapshot(@TempDir Path dataFolder) throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).submit(any(Runnable.class));
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		java.lang.reflect.Field writeLockField = VotifierVoteOverflowQueue.class
+				.getDeclaredField("persistenceWriteLock");
+		writeLockField.setAccessible(true);
+		Object writeLock = writeLockField.get(queue);
+		Thread closer;
+		synchronized (writeLock) {
+			assertTrue(queue.enqueue("Steve", "first.example.org"));
+			java.lang.reflect.Field dirtyField = VotifierVoteOverflowQueue.class.getDeclaredField("persistenceDirty");
+			dirtyField.setAccessible(true);
+			long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+			while ((boolean) dirtyField.get(queue) && System.nanoTime() < deadline) Thread.onSpinWait();
+			assertEquals(false, dirtyField.get(queue), "persistence worker did not capture the older snapshot");
+			assertTrue(queue.enqueue("Alex", "second.example.org"));
+			closer = new Thread(queue::close);
+			closer.start();
+			Thread.sleep(1_100L);
+		}
+		closer.join(TimeUnit.SECONDS.toMillis(3));
+
+		VotifierVoteOverflowQueue restarted = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertEquals(2, restarted.size());
+		} finally {
+			restarted.close();
+		}
+	}
+
 	private static void waitForFile(Path file) throws Exception {
 		long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
 		while (!Files.exists(file) && System.nanoTime() < deadline) {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
@@ -1,0 +1,196 @@
+package com.bencodez.votingplugin.tests.listeners;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.listeners.VotifierVoteOverflowQueue;
+
+class VotifierVoteOverflowQueueTest {
+	@Test
+	void enqueueCannotChangeVersionDuringDurableAdmission(@TempDir Path dataFolder) throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		CountDownLatch admissionStarted = new CountDownLatch(1);
+		CountDownLatch releaseAdmission = new CountDownLatch(1);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		doAnswer(invocation -> {
+			admissionStarted.countDown();
+			releaseAdmission.await(2, TimeUnit.SECONDS);
+			return null;
+		}).when(voteTimer).submit(any(Runnable.class));
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		java.util.concurrent.ExecutorService enqueuer = Executors.newSingleThreadExecutor();
+		try {
+			assertTrue(queue.enqueue("Steve", "first.example.org"));
+			assertTrue(admissionStarted.await(2, TimeUnit.SECONDS));
+			java.util.concurrent.Future<Boolean> second = enqueuer.submit(
+					() -> queue.enqueue("Alex", "second.example.org"));
+			assertThrows(TimeoutException.class, () -> second.get(100, TimeUnit.MILLISECONDS));
+			releaseAdmission.countDown();
+			assertTrue(second.get(2, TimeUnit.SECONDS));
+		} finally {
+			releaseAdmission.countDown();
+			enqueuer.shutdownNow();
+			queue.close();
+		}
+	}
+
+	@Test
+	void retainsUnacknowledgedCallbackAcrossShutdown(@TempDir Path dataFolder) throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		ScheduledExecutorService voteTimer = Executors.newSingleThreadScheduledExecutor();
+		CountDownLatch processingStarted = new CountDownLatch(1);
+		CountDownLatch finishProcessing = new CountDownLatch(1);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> {
+			processingStarted.countDown();
+			try {
+				finishProcessing.await();
+			} catch (InterruptedException interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		});
+		try {
+			assertTrue(queue.enqueue("Steve", "example.org"));
+			assertTrue(processingStarted.await(2, TimeUnit.SECONDS));
+			queue.close();
+			finishProcessing.countDown();
+			voteTimer.shutdown();
+			assertTrue(voteTimer.awaitTermination(2, TimeUnit.SECONDS));
+
+			ScheduledExecutorService rejectingTimer = mock(ScheduledExecutorService.class);
+			when(plugin.getVoteTimer()).thenReturn(rejectingTimer);
+			doThrow(new RejectedExecutionException("capacity exhausted"))
+					.when(rejectingTimer).submit(any(Runnable.class));
+			VotifierVoteOverflowQueue restarted = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+			try {
+				assertEquals(1, restarted.size());
+			} finally {
+				restarted.close();
+			}
+		} finally {
+			finishProcessing.countDown();
+			queue.close();
+			voteTimer.shutdownNow();
+		}
+	}
+
+	@Test
+	void retriesPersistenceAfterTransientWriteFailure(@TempDir Path temporaryDirectory) throws Exception {
+		Path dataFolder = temporaryDirectory.resolve("data");
+		Files.writeString(dataFolder, "temporarily blocking the data directory");
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		Logger logger = mock(Logger.class);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getLogger()).thenReturn(logger);
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).submit(any(Runnable.class));
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertTrue(queue.enqueue("Steve", "example.org"));
+			verify(logger, timeout(2_000)).warning(org.mockito.ArgumentMatchers.contains(
+					"Unable to persist queued Votifier votes"));
+			Files.delete(dataFolder);
+			Files.createDirectory(dataFolder);
+			waitForFile(dataFolder.resolve("VotifierVoteQueue.yml"));
+		} finally {
+			queue.close();
+		}
+	}
+
+	@Test
+	void doesNotDrainUntilWriteFailureIsRecovered(@TempDir Path temporaryDirectory) throws Exception {
+		Path dataFolder = temporaryDirectory.resolve("data");
+		Files.writeString(dataFolder, "temporarily blocking the data directory");
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		Logger logger = mock(Logger.class);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		CountDownLatch submissionAccepted = new CountDownLatch(1);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getLogger()).thenReturn(logger);
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		doAnswer(invocation -> {
+			submissionAccepted.countDown();
+			return null;
+		}).when(voteTimer).submit(any(Runnable.class));
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertTrue(queue.enqueue("Steve", "example.org"));
+			verify(logger, timeout(2_000)).warning(org.mockito.ArgumentMatchers.contains(
+					"Unable to persist queued Votifier votes"));
+			verify(voteTimer, org.mockito.Mockito.never()).submit(any(Runnable.class));
+
+			Files.delete(dataFolder);
+			Files.createDirectory(dataFolder);
+			waitForFile(dataFolder.resolve("VotifierVoteQueue.yml"));
+			assertTrue(submissionAccepted.await(2, TimeUnit.SECONDS),
+					"queued vote was not admitted after persistence recovered");
+		} finally {
+			queue.close();
+		}
+	}
+
+	@Test
+	void retainsRejectedVoteAcrossQueueRestart(@TempDir Path dataFolder) throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).submit(any(Runnable.class));
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertTrue(queue.enqueue("Steve", "example.org"));
+			waitForFile(dataFolder.resolve("VotifierVoteQueue.yml"));
+		} finally {
+			queue.close();
+		}
+
+		VotifierVoteOverflowQueue restarted = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertEquals(1, restarted.size());
+		} finally {
+			restarted.close();
+		}
+	}
+
+	private static void waitForFile(Path file) throws Exception {
+		long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+		while (!Files.exists(file) && System.nanoTime() < deadline) {
+			Thread.sleep(10);
+		}
+		assertTrue(Files.exists(file), "overflow queue was not persisted");
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/listeners/VotifierVoteOverflowQueueTest.java
@@ -47,6 +47,7 @@ class VotifierVoteOverflowQueueTest {
 		java.util.concurrent.ExecutorService enqueuer = Executors.newSingleThreadExecutor();
 		try {
 			assertTrue(queue.enqueue("Steve", "first.example.org"));
+			queue.start();
 			assertTrue(admissionStarted.await(2, TimeUnit.SECONDS));
 			java.util.concurrent.Future<Boolean> second = enqueuer.submit(
 					() -> queue.enqueue("Alex", "second.example.org"));
@@ -56,6 +57,36 @@ class VotifierVoteOverflowQueueTest {
 		} finally {
 			releaseAdmission.countDown();
 			enqueuer.shutdownNow();
+			queue.close();
+		}
+	}
+
+	@Test
+	void waitsForFullPipelineStartupBeforeDrainingPersistedVotes(@TempDir Path dataFolder) throws Exception {
+		VotingPluginMain plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		ScheduledExecutorService voteTimer = mock(ScheduledExecutorService.class);
+		CountDownLatch admissionStarted = new CountDownLatch(1);
+		when(plugin.getDataFolder()).thenReturn(dataFolder.toFile());
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+
+		VotifierVoteOverflowQueue seed = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		assertTrue(seed.enqueue("Steve", "example.org"));
+		seed.close();
+
+		doAnswer(invocation -> {
+			admissionStarted.countDown();
+			return null;
+		}).when(voteTimer).submit(any(Runnable.class));
+
+		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
+		try {
+			assertEquals(1, queue.size());
+			verify(voteTimer, org.mockito.Mockito.never()).submit(any(Runnable.class));
+
+			queue.start();
+			assertTrue(admissionStarted.await(2, TimeUnit.SECONDS),
+					"persisted vote was not admitted after the full pipeline started");
+		} finally {
 			queue.close();
 		}
 	}
@@ -79,6 +110,7 @@ class VotifierVoteOverflowQueueTest {
 		});
 		try {
 			assertTrue(queue.enqueue("Steve", "example.org"));
+			queue.start();
 			assertTrue(processingStarted.await(2, TimeUnit.SECONDS));
 			queue.close();
 			finishProcessing.countDown();
@@ -147,6 +179,7 @@ class VotifierVoteOverflowQueueTest {
 		VotifierVoteOverflowQueue queue = new VotifierVoteOverflowQueue(plugin, (site, user) -> { });
 		try {
 			assertTrue(queue.enqueue("Steve", "example.org"));
+			queue.start();
 			verify(logger, timeout(2_000)).warning(org.mockito.ArgumentMatchers.contains(
 					"Unable to persist queued Votifier votes"));
 			verify(voteTimer, org.mockito.Mockito.never()).submit(any(Runnable.class));

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/test/VoteTesterRejectionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/test/VoteTesterRejectionTest.java
@@ -1,0 +1,63 @@
+package com.bencodez.votingplugin.tests.test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.simpleapi.scheduler.BukkitScheduler;
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.test.VoteTester;
+
+class VoteTesterRejectionTest {
+	private VotingPluginMain plugin;
+	private ScheduledExecutorService voteTimer;
+	private Logger logger;
+	private VoteTester tester;
+
+	@BeforeEach
+	void setUp() {
+		plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		voteTimer = mock(ScheduledExecutorService.class);
+		logger = mock(Logger.class);
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		when(plugin.getLogger()).thenReturn(logger);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).submit(any(Runnable.class));
+		tester = new VoteTester(plugin);
+	}
+
+	@Test
+	void rewardAndVoteTestsLogRejectionWithoutThrowing() {
+		assertDoesNotThrow(() -> tester.testRewards(1, "Steve", "FirstVote"));
+		assertDoesNotThrow(() -> tester.testVotes(1, "Steve", "example.org"));
+
+		verify(logger, org.mockito.Mockito.times(2)).warning(any(String.class));
+	}
+
+	@Test
+	void spamTestAsyncSubmissionDoesNotThrowWhenRejected() {
+		BukkitScheduler bukkitScheduler = mock(BukkitScheduler.class);
+		doAnswer(invocation -> {
+			Runnable task = invocation.getArgument(1);
+			task.run();
+			return null;
+		}).when(bukkitScheduler).runTaskAsynchronously(any(), any(Runnable.class));
+		when(plugin.getBukkitScheduler()).thenReturn(bukkitScheduler);
+
+		assertDoesNotThrow(() -> tester.testSpam(1, "Steve", "example.org"));
+
+		verify(logger).warning(any(String.class));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
@@ -1,0 +1,74 @@
+package com.bencodez.votingplugin.tests.timequeue;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.advancedcore.api.time.events.DateChangedEvent;
+import com.bencodez.votingplugin.VotingPluginMain;
+import com.bencodez.votingplugin.data.ServerData;
+import com.bencodez.votingplugin.timequeue.TimeQueueHandler;
+
+class TimeQueueHandlerRejectionTest {
+	private VotingPluginMain plugin;
+	private ServerData serverData;
+	private ScheduledExecutorService voteTimer;
+	private Logger logger;
+	private ConfigurationSection cachedVote;
+
+	@BeforeEach
+	void setUp() {
+		plugin = mock(VotingPluginMain.class, RETURNS_DEEP_STUBS);
+		serverData = mock(ServerData.class);
+		voteTimer = mock(ScheduledExecutorService.class);
+		logger = mock(Logger.class);
+		cachedVote = mock(ConfigurationSection.class);
+
+		when(plugin.getServerData()).thenReturn(serverData);
+		when(plugin.getVoteTimer()).thenReturn(voteTimer);
+		when(plugin.getLogger()).thenReturn(logger);
+		when(serverData.getTimedVoteCacheKeys()).thenReturn(Set.of("0"));
+		when(serverData.getTimedVoteCacheSection("0")).thenReturn(cachedVote);
+		when(cachedVote.getString("Name")).thenReturn("Steve");
+		when(cachedVote.getString("Service")).thenReturn("example.org");
+		when(cachedVote.getLong("Time")).thenReturn(123L);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(voteTimer).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+	}
+
+	@Test
+	void loadRetainsPersistentEntriesWhenSchedulingIsRejected() {
+		TimeQueueHandler handler = assertDoesNotThrow(() -> new TimeQueueHandler(plugin));
+
+		assertEquals(1, handler.getTimeChangeQueue().size());
+		verify(serverData, never()).clearTimedVoteCache();
+	}
+
+	@Test
+	void dateChangeRejectionDoesNotEscapeBukkitEventHandler() {
+		TimeQueueHandler handler = new TimeQueueHandler(plugin);
+		handler.addVote("Alex", "example.org");
+
+		assertDoesNotThrow(() -> handler.postTimeChange((DateChangedEvent) null));
+		assertEquals(2, handler.getTimeChangeQueue().size());
+		verify(logger, org.mockito.Mockito.atLeastOnce()).warning(anyString());
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
 
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
@@ -70,5 +71,20 @@ class TimeQueueHandlerRejectionTest {
 		assertDoesNotThrow(() -> handler.postTimeChange((DateChangedEvent) null));
 		assertEquals(2, handler.getTimeChangeQueue().size());
 		verify(logger, org.mockito.Mockito.atLeastOnce()).warning(anyString());
+	}
+
+	@Test
+	void rejectedProcessingSchedulesOneBoundedRetry() {
+		TimeQueueHandler handler = new TimeQueueHandler(plugin);
+		org.mockito.ArgumentCaptor<Runnable> retry = org.mockito.ArgumentCaptor.forClass(Runnable.class);
+		verify(plugin.getBukkitScheduler()).runTaskLaterAsynchronously(
+				org.mockito.ArgumentMatchers.eq(plugin), retry.capture(), org.mockito.ArgumentMatchers.longThat(delay -> delay >= 1 && delay <= 60));
+
+		reset(voteTimer);
+		retry.getValue().run();
+
+		verify(voteTimer).schedule(any(Runnable.class), org.mockito.ArgumentMatchers.eq(0L),
+				org.mockito.ArgumentMatchers.eq(TimeUnit.SECONDS));
+		assertEquals(1, handler.getTimeChangeQueue().size());
 	}
 }

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/timequeue/TimeQueueHandlerRejectionTest.java
@@ -78,7 +78,7 @@ class TimeQueueHandlerRejectionTest {
 		TimeQueueHandler handler = new TimeQueueHandler(plugin);
 		org.mockito.ArgumentCaptor<Runnable> retry = org.mockito.ArgumentCaptor.forClass(Runnable.class);
 		verify(plugin.getBukkitScheduler()).runTaskLaterAsynchronously(
-				org.mockito.ArgumentMatchers.eq(plugin), retry.capture(), org.mockito.ArgumentMatchers.longThat(delay -> delay >= 1 && delay <= 60));
+				org.mockito.ArgumentMatchers.eq(plugin), retry.capture(), org.mockito.ArgumentMatchers.eq(20L));
 
 		reset(voteTimer);
 		retry.getValue().run();

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/util/VoteTaskAdmissionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/util/VoteTaskAdmissionTest.java
@@ -1,0 +1,44 @@
+package com.bencodez.votingplugin.tests.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import com.bencodez.votingplugin.util.VoteTaskAdmission;
+
+class VoteTaskAdmissionTest {
+	@Test
+	void rejectedSubmissionIsReportedWithoutPropagating() {
+		ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(executor).submit(any(Runnable.class));
+
+		assertFalse(VoteTaskAdmission.trySubmit(executor, () -> { }));
+	}
+
+	@Test
+	void rejectedScheduleIsReportedWithoutPropagating() {
+		ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+		doThrow(new RejectedExecutionException("capacity exhausted"))
+				.when(executor).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+		assertFalse(VoteTaskAdmission.trySchedule(executor, () -> { }, 5, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void admittedTasksAreReported() {
+		ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+
+		assertTrue(VoteTaskAdmission.trySubmit(executor, () -> { }));
+		assertTrue(VoteTaskAdmission.trySchedule(executor, () -> { }, 5, TimeUnit.SECONDS));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/BoundedScheduledExecutorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/BoundedScheduledExecutorTest.java
@@ -1,0 +1,36 @@
+package com.bencodez.votingplugin.util;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class BoundedScheduledExecutorTest {
+	@Test
+	void rejectsExcessTasksAndReleasesCapacityAfterCompletion() throws Exception {
+		BoundedScheduledExecutor executor = new BoundedScheduledExecutor(1, 2);
+		CountDownLatch blocker = new CountDownLatch(1);
+		try {
+			executor.submit(() -> await(blocker));
+			executor.submit(() -> { });
+			assertThrows(RejectedExecutionException.class, () -> executor.submit(() -> { }));
+			blocker.countDown();
+			executor.shutdown();
+			assertTrueAwait(executor);
+		} finally {
+			blocker.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	private static void await(CountDownLatch latch) {
+		try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+	}
+
+	private static void assertTrueAwait(BoundedScheduledExecutor executor) throws Exception {
+		org.junit.jupiter.api.Assertions.assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/BoundedScheduledExecutorTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/util/BoundedScheduledExecutorTest.java
@@ -26,6 +26,19 @@ class BoundedScheduledExecutorTest {
 		}
 	}
 
+	@Test
+	void cancellationReleasesCapacity() {
+		BoundedScheduledExecutor executor = new BoundedScheduledExecutor(1, 1);
+		try {
+			java.util.concurrent.ScheduledFuture<?> future = executor.schedule(() -> { }, 1, TimeUnit.HOURS);
+			future.cancel(false);
+			org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+					() -> executor.schedule(() -> { }, 1, TimeUnit.HOURS));
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
 	private static void await(CountDownLatch latch) {
 		try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
 	}


### PR DESCRIPTION
## Summary
- cap service-site downloads at 1 MiB before decoding or parsing
- cap parsed service-site mappings at 2,048 entries and reject oversized names/values
- replace the unbounded vote scheduler with a 256-task admission-limited executor
- remove cancelled scheduled tasks promptly

## Tests
- `mvn -q -Dtest=ServiceSiteHandlerLimitsTest,BoundedScheduledExecutorTest test`
- verifies oversized remote entries are rejected
- verifies saturated vote work is rejected and capacity is restored after completion
- `git diff --check`