### PR TITLE
Improve agent and code review guidance

### DIFF
--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -272,7 +272,8 @@ Coverage: <complete, static-only, partial, or stale; material limitations>
 
 Determine review completeness independently from findings and publishing readiness:
 
-- Complete review with findings: report the verified findings in priority order and record the review as complete. Keep `Coverage: static-only` for an explicitly scoped static-only review; otherwise mark coverage complete.
+- Coverage describes the review scope, not finding completeness. Preserve `Coverage: partial` for an explicitly scoped, focused review (including bounded security or reliability reviews), even when every finding within that scope is verified; findings do not upgrade partial coverage to complete.
+- Complete review with findings: report the verified findings in priority order and record the review as complete. Keep `Coverage: static-only` for an explicitly scoped static-only review; otherwise mark coverage complete only when the requested scope was fully covered.
 - Complete review without findings: the findings section is exactly `No findings.`
 - Incomplete review: only when required coverage or validation is missing, unresolved, or stale, use `Review incomplete.` with the actual limitations while still reporting verified findings.
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -270,11 +270,13 @@ Coverage: <complete, static-only, partial, or stale; material limitations>
 <prioritized findings, or the applicable zero-finding result below>
 ```
 
-When required coverage and validation are complete with no findings, the findings
-section is exactly `No findings.` Otherwise use `Review incomplete.` with specific
-limitations, while still reporting verified findings. An explicitly scoped
-static-only review can be complete within that scope but does not pass a gate
-requiring builds. Do not add praise, scores, generic advice, or merge approval.
+Determine review completeness independently from findings and publishing readiness:
+
+- Complete review with findings: report the verified findings in priority order and keep coverage marked complete.
+- Complete review without findings: the findings section is exactly `No findings.`
+- Incomplete review: only when required coverage or validation is missing, unresolved, or stale, use `Review incomplete.` with the actual limitations while still reporting verified findings.
+
+An explicitly scoped static-only review can be complete within that scope but does not pass a gate requiring builds. A demonstrated defect is validation evidence, not by itself a coverage gap. Do not add praise, scores, generic advice, or merge approval.
 
 For a pre-publish gate, the implementation coordinator, not the reviewer, fixes
 accepted findings, reruns required checks, and obtains a fresh independent review

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -272,7 +272,7 @@ Coverage: <complete, static-only, partial, or stale; material limitations>
 
 Determine review completeness independently from findings and publishing readiness:
 
-- Complete review with findings: report the verified findings in priority order and keep coverage marked complete.
+- Complete review with findings: report the verified findings in priority order and record the review as complete. Keep `Coverage: static-only` for an explicitly scoped static-only review; otherwise mark coverage complete.
 - Complete review without findings: the findings section is exactly `No findings.`
 - Incomplete review: only when required coverage or validation is missing, unresolved, or stale, use `Review incomplete.` with the actual limitations while still reporting verified findings.
 

--- a/.github/skills/code-review/tests/coverage-contract.sh
+++ b/.github/skills/code-review/tests/coverage-contract.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skill=${1:-"$(cd "$(dirname "$0")/.." && pwd)/SKILL.md"}
+
+grep -Fq 'Coverage describes the review scope, not finding completeness.' "$skill"
+grep -Fq 'Preserve `Coverage: partial` for an explicitly scoped, focused review' "$skill"
+grep -Fq 'findings do not upgrade partial coverage' "$skill"
+if grep -Fq 'otherwise mark coverage complete.' "$skill"; then
+	echo 'stale unconditional complete-coverage guidance remains' >&2
+	exit 1
+fi
+
+echo 'coverage contract: ok'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,10 @@ credentials, generated JARs, dependency caches, IDE output, or unrelated formatt
 ## Safe change checklist
 
 - Trace whether the code runs on the connector worker, proxy thread, Bukkit primary thread, or a SQL executor.
+- Preserve queued votes across saturation, shutdown, and restart; overflow handling must be bounded, durable when promised, and observable rather than silently dropping work.
+- Treat scheduler units explicitly. Verify whether each delay is in ticks, milliseconds, or seconds, especially across Bukkit, Folia, BungeeCord, and Velocity adapters.
+- Register listeners and lifecycle wakeups before producers can publish work; startup/reload ordering must not strand already-persisted or newly-arriving operations.
+- Protocol-mode changes must not silently broaden legacy v1/RSA acceptance when token-only operation is configured or intended; cover downgrade behavior with tests.
 - Add strict type/field/range/count validation before calling plugin services.
 - Snapshot synchronized live collections before iterating; do not return mutable collections across threads.
 - Distinguish “not configured/unavailable”, “not found”, and a genuine empty result.


### PR DESCRIPTION
## Summary
- strengthen runtime review invariants for durable queue handling, scheduler units, lifecycle ordering, and protocol downgrade behavior
- correct the code-review skill so completed reviews with findings are not mislabeled as incomplete
- preserve the independent, source-read-only pre-publish review workflow

## Validation
- fetched and validated both branch files
- verified code-review frontmatter, P0-P3 priorities, read-only boundaries, build guidance, and clean/incomplete result semantics
- checked for trailing whitespace

Documentation and review-instruction changes only; no runtime source changed.