### PR TITLE
Report effective bulk command permissions

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/AdminAuthorization.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/AdminAuthorization.java
@@ -18,6 +18,11 @@ public final class AdminAuthorization {
 		return amount >= 0 || canRemovePointsFromAll(sender);
 	}
 
+	public static boolean canAddPointsToAll(CommandSender sender, int amount, boolean allowAdminOverride) {
+		return amount >= 0 || sender.hasPermission(REMOVE_POINTS_ALL_PERMISSION)
+				|| allowAdminOverride && sender.hasPermission(ADMIN_PERMISSION);
+	}
+
 	public static boolean canEditConfig(CommandSender sender, String permission) {
 		return sender.hasPermission(permission) || sender.hasPermission(ADMIN_PERMISSION);
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -303,7 +303,7 @@ public class CommandLoader {
 		});
 
 		plugin.getAdminVoteCommand()
-				.add(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "SetPoints", "(number)" },
+				.add(configureAllPermissionOverride(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "SetPoints", "(number)" },
 						"VotingPlugin.Commands.AdminVote.SetPoints|" + adminPerm, "Set players voting points") {
 
 					@Override
@@ -328,7 +328,7 @@ public class CommandLoader {
 						sender.sendMessage(MessageAPI.colorize("&cSet " + args[1] + " points to " + args[3]));
 						plugin.getPlaceholders().onUpdate(user, false);
 					}
-				}.withAllPermissionOverrides(adminPerm));
+				}, adminPerm));
 
 		plugin.getAdminVoteCommand()
 				.add(new CommandHandler(plugin, new String[] { "ResyncMilestones" },
@@ -410,7 +410,7 @@ public class CommandLoader {
 				});
 
 		plugin.getAdminVoteCommand()
-				.add(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "AddPoints", "(number)" },
+				.add(configureAllPermissionOverride(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "AddPoints", "(number)" },
 						"VotingPlugin.Commands.AdminVote.AddPoints|" + adminPerm, "Add to players voting points") {
 
 					@Override
@@ -455,10 +455,10 @@ public class CommandLoader {
 						plugin.getPlaceholders().onUpdate(user, false);
 
 					}
-				}.withAllPermissionOverrides(adminPerm));
+				}, adminPerm));
 
 		plugin.getAdminVoteCommand()
-				.add(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "RemovePoints", "(number)" },
+				.add(configureAllPermissionOverride(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "RemovePoints", "(number)" },
 						"VotingPlugin.Commands.AdminVote.RemovePoints|" + adminPerm, "Remove voting points") {
 
 					@Override
@@ -500,7 +500,7 @@ public class CommandLoader {
 								+ args[1] + " now has " + user.getPoints() + " points"));
 						plugin.getPlaceholders().onUpdate(user, false);
 					}
-				}.withAllPermissionOverrides(adminPerm));
+				}, adminPerm));
 
 		plugin.getAdminVoteCommand().add(new CommandHandler(plugin, new String[] { "Help&?" },
 				"VotingPlugin.Commands.AdminVote.Help|" + adminPerm, "See this page") {
@@ -2690,11 +2690,30 @@ public class CommandLoader {
 		for (CommandHandler cmd : avCommands) {
 			cmd.setPerm(cmd.getPerm() + "|" + adminPerm);
 			if (cmd instanceof PlayerCommandHandler playerHandler) {
-				playerHandler.withAllPermissionOverrides(adminPerm);
+				configureAllPermissionOverride(playerHandler, adminPerm);
 			}
 		}
 		plugin.getAdminVoteCommand().addAll(avCommands);
 
+	}
+
+	/**
+	 * Configures the shared bulk administrator override when supported by the
+	 * AdvancedCore dependency. The reflective bridge keeps this consumer source
+	 * compatible with the currently published snapshot while AdvancedCore #316 is
+	 * awaiting release. Runtime use with that older implementation fails closed
+	 * because it does not enforce the required base-plus-bulk permission contract.
+	 */
+	static PlayerCommandHandler configureAllPermissionOverride(PlayerCommandHandler handler, String adminPermission) {
+		try {
+			PlayerCommandHandler.class.getMethod("withAllPermissionOverrides", String[].class)
+					.invoke(handler, (Object) new String[] { adminPermission });
+		} catch (NoSuchMethodException exception) {
+			throw new IllegalStateException("AdvancedCore with secure bulk permission support is required", exception);
+		} catch (ReflectiveOperationException exception) {
+			throw new IllegalStateException("Failed to configure bulk permission override", exception);
+		}
+		return handler;
 	}
 
 	private final Set<String> aliasCommandNames = new HashSet<>();

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/CommandLoader.java
@@ -26,6 +26,8 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.PluginManager;
 
 import com.bencodez.advancedcore.api.command.CommandHandler;
 import com.bencodez.advancedcore.api.command.PlayerCommandHandler;
@@ -326,7 +328,7 @@ public class CommandLoader {
 						sender.sendMessage(MessageAPI.colorize("&cSet " + args[1] + " points to " + args[3]));
 						plugin.getPlaceholders().onUpdate(user, false);
 					}
-				});
+				}.withAllPermissionOverrides(adminPerm));
 
 		plugin.getAdminVoteCommand()
 				.add(new CommandHandler(plugin, new String[] { "ResyncMilestones" },
@@ -412,26 +414,10 @@ public class CommandLoader {
 						"VotingPlugin.Commands.AdminVote.AddPoints|" + adminPerm, "Add to players voting points") {
 
 					@Override
-					public boolean hasPerm(CommandSender sender) {
-						return AdminAuthorization.hasCommandOrAdmin(sender,
-								"VotingPlugin.Commands.AdminVote.AddPoints");
-					}
-
-					@Override
-					public void execute(CommandSender sender, String[] args) {
-						// The permission for this bulk form depends on the sign of the
-						// amount, so the generic <command>.All rule cannot decide it.
-						if (args[1].equalsIgnoreCase("all")) {
-							executeAll(sender, args);
-							return;
-						}
-						super.execute(sender, args);
-					}
-
-					@Override
 					public void executeAll(CommandSender sender, String[] args) {
 						int num = Integer.parseInt(args[3]);
-						if (!AdminAuthorization.canAddPointsToAll(sender, num)) {
+						if (!AdminAuthorization.canAddPointsToAll(sender, num,
+								plugin.getOptions().isMultiplePermissionChecks())) {
 							sender.sendMessage(MessageAPI.colorize(plugin.getConfigFile().getFormatNoPerms()));
 							return;
 						}
@@ -469,22 +455,11 @@ public class CommandLoader {
 						plugin.getPlaceholders().onUpdate(user, false);
 
 					}
-				});
+				}.withAllPermissionOverrides(adminPerm));
 
 		plugin.getAdminVoteCommand()
 				.add(new PlayerCommandHandler(plugin, new String[] { "User", "(player)", "RemovePoints", "(number)" },
 						"VotingPlugin.Commands.AdminVote.RemovePoints|" + adminPerm, "Remove voting points") {
-
-					@Override
-					public boolean hasPerm(CommandSender sender) {
-						return AdminAuthorization.hasCommandOrAdmin(sender,
-								"VotingPlugin.Commands.AdminVote.RemovePoints");
-					}
-
-					@Override
-					public boolean hasAllPermission(CommandSender sender) {
-						return AdminAuthorization.canRemovePointsFromAll(sender);
-					}
 
 					@Override
 					public void executeAll(CommandSender sender, String[] args) {
@@ -525,7 +500,7 @@ public class CommandLoader {
 								+ args[1] + " now has " + user.getPoints() + " points"));
 						plugin.getPlaceholders().onUpdate(user, false);
 					}
-				});
+				}.withAllPermissionOverrides(adminPerm));
 
 		plugin.getAdminVoteCommand().add(new CommandHandler(plugin, new String[] { "Help&?" },
 				"VotingPlugin.Commands.AdminVote.Help|" + adminPerm, "See this page") {
@@ -2714,6 +2689,9 @@ public class CommandLoader {
 				.getBasicAdminCommands("VotingPlugin");
 		for (CommandHandler cmd : avCommands) {
 			cmd.setPerm(cmd.getPerm() + "|" + adminPerm);
+			if (cmd instanceof PlayerCommandHandler playerHandler) {
+				playerHandler.withAllPermissionOverrides(adminPerm);
+			}
 		}
 		plugin.getAdminVoteCommand().addAll(avCommands);
 
@@ -2774,6 +2752,7 @@ public class CommandLoader {
 			} catch (Exception e) {
 				plugin.debug("Failed to set permission for /vote" + arg0);
 			}
+			registerAdditionalPermissions(Bukkit.getPluginManager(), cmdHandle);
 
 			if (argLength > 0) {
 				String[] args = cmdHandle.getArgs()[0].split("&");
@@ -2851,6 +2830,7 @@ public class CommandLoader {
 			} catch (Exception e) {
 				plugin.debug("Failed to set permission for /adminvote" + arg0);
 			}
+			registerAdditionalPermissions(Bukkit.getPluginManager(), cmdHandle);
 
 			if (argLength > 0) {
 				String[] args = cmdHandle.getArgs()[0].split("&");
@@ -2896,6 +2876,22 @@ public class CommandLoader {
 								+ ex.getMessage());
 					}
 				}
+			}
+		}
+	}
+
+	static void registerAdditionalPermissions(PluginManager manager, CommandHandler handler) {
+		if (manager == null || !(handler instanceof PlayerCommandHandler playerHandler)) return;
+		List<String> additionalPermissions = playerHandler.getAdditionalPermissions();
+		for (String permissionName : additionalPermissions) {
+			Permission permission = manager.getPermission(permissionName);
+			if (permission == null) {
+				permission = new Permission(permissionName, "Allows use of the all target for its player command",
+						PermissionDefault.FALSE);
+				manager.addPermission(permission);
+			} else if (permission.getDefault() != PermissionDefault.FALSE) {
+				permission.setDefault(PermissionDefault.FALSE);
+				permission.recalculatePermissibles();
 			}
 		}
 	}

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePerms.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePerms.java
@@ -1,6 +1,7 @@
 package com.bencodez.votingplugin.commands.gui.admin;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -85,7 +86,7 @@ public class AdminVotePerms extends GUIHandler {
 			} else {
 				msg.add(handle.getHelpLineCommand("/vote") + " : " + handle.getPerm().split(Pattern.quote("|"))[0]);
 			}
-			addAdditionalPermissions(msg, sender, handle);
+			addAdditionalPermissions(msg, sender, handle, "/vote");
 
 		}
 
@@ -101,7 +102,7 @@ public class AdminVotePerms extends GUIHandler {
 			} else {
 				msg.add(handle.getHelpLineCommand("/av") + " : " + handle.getPerm().split(Pattern.quote("|"))[0]);
 			}
-			addAdditionalPermissions(msg, sender, handle);
+			addAdditionalPermissions(msg, sender, handle, "/av");
 		}
 
 		for (Permission perm : plugin.getDescription().getPermissions()) {
@@ -169,7 +170,7 @@ public class AdminVotePerms extends GUIHandler {
 					msg.add("&6" + handle.getHelpLineCommand("/vote") + " : "
 							+ handle.getPerm().split(Pattern.quote("|"))[0] + " : &cfalse");
 				}
-				addAdditionalPermissions(msg, p, handle);
+				addAdditionalPermissions(msg, p, handle, "/vote");
 
 			}
 
@@ -181,7 +182,7 @@ public class AdminVotePerms extends GUIHandler {
 					msg.add("&6" + handle.getHelpLineCommand("/av") + " : "
 							+ handle.getPerm().split(Pattern.quote("|"))[0] + " : &cfalse");
 				}
-				addAdditionalPermissions(msg, p, handle);
+				addAdditionalPermissions(msg, p, handle, "/av");
 			}
 
 			for (Permission perm : plugin.getDescription().getPermissions()) {
@@ -240,7 +241,7 @@ public class AdminVotePerms extends GUIHandler {
 			msg.add("  " + handle.getPerm());
 			msg.add("  " + handle.getHelpMessage());
 			for (String permission : additionalPermissions(handle)) {
-				msg.add("  " + permission);
+				msg.add("  Additional permission for all target: " + permission);
 			}
 		}
 
@@ -249,7 +250,7 @@ public class AdminVotePerms extends GUIHandler {
 			msg.add("  " + handle.getPerm());
 			msg.add("  " + handle.getHelpMessage());
 			for (String permission : additionalPermissions(handle)) {
-				msg.add("  " + permission);
+				msg.add("  Additional permission for all target: " + permission);
 			}
 		}
 
@@ -263,14 +264,12 @@ public class AdminVotePerms extends GUIHandler {
 	}
 
 	static ArrayList<String> additionalPermissions(CommandHandler handle) {
-		ArrayList<String> permissions = new ArrayList<>();
-		if (handle instanceof PlayerCommandHandler && handle.getPerm() != null) {
-			String primary = handle.getPerm().split(Pattern.quote("|"))[0];
-			if ("VotingPlugin.Commands.AdminVote.RemovePoints".equals(primary)) {
-				permissions.add(primary + ".All");
-			}
-		}
-		return permissions;
+		if (!(handle instanceof PlayerCommandHandler playerHandler)) return new ArrayList<>();
+		return new ArrayList<>(new LinkedHashSet<>(playerHandler.getAdditionalPermissions()));
+	}
+
+	static boolean hasEffectiveBulkPermission(CommandSender sender, CommandHandler handle) {
+		return handle instanceof PlayerCommandHandler playerHandler && playerHandler.hasAllPermission(sender);
 	}
 
 	static boolean hasEffectivePermission(CommandSender sender, String permission) {
@@ -280,14 +279,16 @@ public class AdminVotePerms extends GUIHandler {
 		return sender.hasPermission(permission);
 	}
 
-	private static void addAdditionalPermissions(ArrayList<String> output, CommandSender sender, CommandHandler handle) {
+	private static void addAdditionalPermissions(ArrayList<String> output, CommandSender sender, CommandHandler handle,
+			String command) {
 		for (String permission : additionalPermissions(handle)) {
+			String description = handle.getHelpLineCommand(command) + " : Additional permission for all target: "
+					+ permission;
 			if (sender instanceof Player) {
-				boolean allowed = "VotingPlugin.Commands.AdminVote.RemovePoints.All".equals(permission)
-						? AdminAuthorization.canRemovePointsFromAll(sender) : sender.hasPermission(permission);
-				output.add("&6" + permission + (allowed ? " : &atrue" : " : &cfalse"));
+				boolean allowed = hasEffectiveBulkPermission(sender, handle);
+				output.add("&6" + description + (allowed ? " : &atrue" : " : &cfalse"));
 			} else {
-				output.add(permission);
+				output.add(description);
 			}
 		}
 	}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/AdminAuthorizationTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/AdminAuthorizationTest.java
@@ -44,6 +44,18 @@ class AdminAuthorizationTest {
 	}
 
 	@Test
+	void negativeBulkAddAdminOverrideHonorsMultiplePermissionPolicy() {
+		CommandSender admin = mock(CommandSender.class);
+		when(admin.hasPermission(AdminAuthorization.ADMIN_PERMISSION)).thenReturn(true);
+		CommandSender dedicated = mock(CommandSender.class);
+		when(dedicated.hasPermission(AdminAuthorization.REMOVE_POINTS_ALL_PERMISSION)).thenReturn(true);
+
+		assertTrue(AdminAuthorization.canAddPointsToAll(admin, -100, true));
+		assertFalse(AdminAuthorization.canAddPointsToAll(admin, -100, false));
+		assertTrue(AdminAuthorization.canAddPointsToAll(dedicated, -100, false));
+	}
+
+	@Test
 	void configEditorsRequireTheirOwnPermissionOrAdminOverride() {
 		String permission = "VotingPlugin.Commands.AdminVote.Edit.SpecialRewards";
 		CommandSender denied = mock(CommandSender.class);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/CommandLoaderBulkPermissionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/CommandLoaderBulkPermissionTest.java
@@ -1,0 +1,38 @@
+package com.bencodez.votingplugin.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.bencodez.advancedcore.api.command.PlayerCommandHandler;
+
+class CommandLoaderBulkPermissionTest {
+	@Test
+	void registersBulkPermissionAsDefaultFalseWithoutImplicitPermissionChildren() {
+		PluginManager manager = mock(PluginManager.class);
+		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
+		when(handler.getAdditionalPermissions())
+				.thenReturn(List.of("VotingPlugin.Commands.AdminVote.SetPoints.All"));
+		when(handler.getAllPermissionOverrides()).thenReturn(List.of(AdminAuthorization.ADMIN_PERMISSION));
+		when(manager.getPermission("VotingPlugin.Commands.AdminVote.SetPoints.All")).thenReturn(null);
+
+		CommandLoader.registerAdditionalPermissions(manager, handler);
+
+		ArgumentCaptor<Permission> registered = ArgumentCaptor.forClass(Permission.class);
+		verify(manager).addPermission(registered.capture());
+		assertEquals("VotingPlugin.Commands.AdminVote.SetPoints.All", registered.getValue().getName());
+		assertEquals(PermissionDefault.FALSE, registered.getValue().getDefault());
+		verify(manager, never()).getPermission("VotingPlugin.Commands.AdminVote.SetPoints");
+		verify(manager, never()).getPermission(AdminAuthorization.ADMIN_PERMISSION);
+	}
+}

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/CommandLoaderBulkPermissionTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/CommandLoaderBulkPermissionTest.java
@@ -1,7 +1,11 @@
 package com.bencodez.votingplugin.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,12 +22,26 @@ import com.bencodez.advancedcore.api.command.PlayerCommandHandler;
 
 class CommandLoaderBulkPermissionTest {
 	@Test
+	void secureBulkOverrideBridgeConfiguresCandidateOrFailsClosed() throws Exception {
+		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
+		try {
+			PlayerCommandHandler.class.getMethod("withAllPermissionOverrides", String[].class);
+			assertSame(handler, CommandLoader.configureAllPermissionOverride(handler,
+					AdminAuthorization.ADMIN_PERMISSION));
+			assertTrue(mockingDetails(handler).getInvocations().stream()
+					.anyMatch(invocation -> invocation.getMethod().getName().equals("withAllPermissionOverrides")));
+		} catch (NoSuchMethodException exception) {
+			assertThrows(IllegalStateException.class, () -> CommandLoader.configureAllPermissionOverride(handler,
+					AdminAuthorization.ADMIN_PERMISSION));
+		}
+	}
+
+	@Test
 	void registersBulkPermissionAsDefaultFalseWithoutImplicitPermissionChildren() {
 		PluginManager manager = mock(PluginManager.class);
 		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
 		when(handler.getAdditionalPermissions())
 				.thenReturn(List.of("VotingPlugin.Commands.AdminVote.SetPoints.All"));
-		when(handler.getAllPermissionOverrides()).thenReturn(List.of(AdminAuthorization.ADMIN_PERMISSION));
 		when(manager.getPermission("VotingPlugin.Commands.AdminVote.SetPoints.All")).thenReturn(null);
 
 		CommandLoader.registerAdditionalPermissions(manager, handler);

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePermsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePermsTest.java
@@ -143,7 +143,8 @@ class AdminVotePermsTest {
 			@Override
 			public void executeSinglePlayer(CommandSender sender, String[] args) {
 			}
-		}.withAllPermissionOverrides(AdminAuthorization.ADMIN_PERMISSION);
+		};
+		configureAllPermissionOverride(handler);
 		when(plugin.getAdminVoteCommand()).thenReturn(new ArrayList<>(List.of(handler)));
 
 		assertTrue(handler.hasAllPermission(admin));
@@ -165,7 +166,8 @@ class AdminVotePermsTest {
 			@Override
 			public void executeSinglePlayer(CommandSender sender, String[] args) {
 			}
-		}.withAllPermissionOverrides(AdminAuthorization.ADMIN_PERMISSION);
+		};
+		configureAllPermissionOverride(handler);
 		when(plugin.getAdminVoteCommand()).thenReturn(new ArrayList<>(List.of(handler)));
 
 		assertFalse(handler.hasAllPermission(admin));
@@ -182,6 +184,17 @@ class AdminVotePermsTest {
 		when(handler.getHelpMessage()).thenReturn("Help");
 		when(handler.getAdditionalPermissions()).thenReturn(List.of(additionalPermission));
 		return handler;
+	}
+
+	private static void configureAllPermissionOverride(PlayerCommandHandler handler) {
+		try {
+			PlayerCommandHandler.class.getMethod("withAllPermissionOverrides", String[].class)
+					.invoke(handler, (Object) new String[] { AdminAuthorization.ADMIN_PERMISSION });
+		} catch (NoSuchMethodException ignored) {
+			// The published pre-#316 API already treats later alternatives as overrides.
+		} catch (ReflectiveOperationException exception) {
+			throw new AssertionError(exception);
+		}
 	}
 
 	private static AdminVotePerms fixture(CommandSender viewer, List<CommandHandler> vote,

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePermsTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/commands/gui/admin/AdminVotePermsTest.java
@@ -1,26 +1,45 @@
 package com.bencodez.votingplugin.commands.gui.admin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
+import com.bencodez.advancedcore.AdvancedCoreConfigOptions;
 import com.bencodez.advancedcore.api.command.CommandHandler;
 import com.bencodez.advancedcore.api.command.PlayerCommandHandler;
+import com.bencodez.votingplugin.VotingPluginMain;
 import com.bencodez.votingplugin.commands.AdminAuthorization;
-import org.bukkit.command.CommandSender;
+import com.bencodez.votingplugin.config.Config;
 
 class AdminVotePermsTest {
 	@Test
-	void listsDedicatedAllPermissionForPlayerCommands() {
-		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
-		when(handler.getPerm()).thenReturn("VotingPlugin.Commands.AdminVote.RemovePoints|VotingPlugin.Admin");
+	void listsSharedBulkMetadataForEveryPlayerCommand() {
+		PlayerCommandHandler setPoints = playerHandler("/av User (player) SetPoints (number)",
+				"VotingPlugin.Commands.AdminVote.SetPoints.All");
+		PlayerCommandHandler addPoints = playerHandler("/av User (player) AddPoints (number)",
+				"VotingPlugin.Commands.AdminVote.AddPoints.All");
 
-		assertEquals(Collections.singletonList("VotingPlugin.Commands.AdminVote.RemovePoints.All"),
-				AdminVotePerms.additionalPermissions(handler));
+		assertEquals(Collections.singletonList("VotingPlugin.Commands.AdminVote.SetPoints.All"),
+				AdminVotePerms.additionalPermissions(setPoints));
+		assertEquals(Collections.singletonList("VotingPlugin.Commands.AdminVote.AddPoints.All"),
+				AdminVotePerms.additionalPermissions(addPoints));
 	}
 
 	@Test
@@ -29,17 +48,165 @@ class AdminVotePermsTest {
 	}
 
 	@Test
-	void unrelatedPlayerCommandsDoNotAdvertiseUnusedAllPermission() {
-		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
-		when(handler.getPerm()).thenReturn("VotingPlugin.Commands.AdminVote.SetPoints|VotingPlugin.Admin");
-		assertEquals(Collections.emptyList(), AdminVotePerms.additionalPermissions(handler));
+	void senderListingAssociatesBulkPermissionAndUsesEffectiveAuthorization() {
+		Player sender = mock(Player.class);
+		PlayerCommandHandler handler = playerHandler("/av User (player) SetPoints (number)",
+				"VotingPlugin.Commands.AdminVote.SetPoints.All");
+		when(handler.hasPerm(sender)).thenReturn(true);
+		when(handler.hasAllPermission(sender)).thenReturn(true);
+		AdminVotePerms perms = fixture(sender, List.of(), List.of(handler), 20);
+
+		String output = String.join("\n", perms.listPerms(sender));
+
+		assertTrue(output.contains("/av User (player) SetPoints (number) : Additional permission for all target: "
+				+ "VotingPlugin.Commands.AdminVote.SetPoints.All : §atrue"));
+	}
+
+	@Test
+	void namedPlayerListingChecksInspectedPlayerNotViewer() {
+		Player viewer = mock(Player.class);
+		Player inspected = mock(Player.class);
+		PlayerCommandHandler handler = playerHandler("/vote Example (player)", "VotingPlugin.Commands.Example.All");
+		when(handler.hasAllPermission(inspected)).thenReturn(true);
+		AdminVotePerms perms = fixture(viewer, List.of(handler), List.of(), 20);
+
+		ArrayList<String> output;
+		try (MockedStatic<Bukkit> bukkit = mockStatic(Bukkit.class)) {
+			bukkit.when(() -> Bukkit.getPlayer("Target")).thenReturn(inspected);
+			output = perms.listPerms(viewer, "Target", 1);
+		}
+
+		assertTrue(String.join("\n", output).contains("VotingPlugin.Commands.Example.All : §atrue"));
+		verify(handler).hasAllPermission(inspected);
+		verify(handler, never()).hasAllPermission(viewer);
+	}
+
+	@Test
+	void consoleListingShowsBulkMetadataWithoutInventingAccessStatus() {
+		CommandSender console = mock(CommandSender.class);
+		PlayerCommandHandler handler = playerHandler("/av User (player) AddPoints (number)",
+				"VotingPlugin.Commands.AdminVote.AddPoints.All");
+		AdminVotePerms perms = fixture(console, List.of(), List.of(handler), 20);
+
+		String output = String.join("\n", perms.listPerms(console));
+
+		assertTrue(output.contains("Additional permission for all target: VotingPlugin.Commands.AdminVote.AddPoints.All"));
+		assertFalse(output.contains("VotingPlugin.Commands.AdminVote.AddPoints.All : true"));
+		assertFalse(output.contains("VotingPlugin.Commands.AdminVote.AddPoints.All : false"));
+	}
+
+	@Test
+	void paginationRetainsBulkEntryOnItsExpectedPage() {
+		CommandSender console = mock(CommandSender.class);
+		PlayerCommandHandler handler = playerHandler("/av User (player) SetPoints (number)",
+				"VotingPlugin.Commands.AdminVote.SetPoints.All");
+		String[] secondPage = new AdminVotePerms(plugin(List.of(), List.of(handler), 1), console, 2).listPerms(console);
+
+		assertTrue(Arrays.stream(secondPage)
+				.anyMatch(line -> line.contains("Additional permission for all target: ")));
+	}
+
+	@Test
+	void developerOutputLabelsBulkMetadataForVoteAndAdminHandlers() {
+		CommandSender consoleSub = mock(CommandSender.class);
+		PlayerCommandHandler vote = playerHandler("/vote Example (player)", "VotingPlugin.Commands.Example.All");
+		PlayerCommandHandler admin = playerHandler("/av User (player) RemovePoints (number)",
+				"VotingPlugin.Commands.AdminVote.RemovePoints.All");
+		AdminVotePerms perms = fixture(consoleSub, List.of(vote), List.of(admin), 20);
+
+		String output = String.join("\n", perms.listPermsDev(consoleSub));
+
+		assertTrue(output.contains("Additional permission for all target: VotingPlugin.Commands.Example.All"));
+		assertTrue(output.contains(
+				"Additional permission for all target: VotingPlugin.Commands.AdminVote.RemovePoints.All"));
 	}
 
 	@Test
 	void editorPermissionStatusIncludesAdminOverride() {
 		CommandSender sender = mock(CommandSender.class);
 		when(sender.hasPermission(AdminAuthorization.ADMIN_PERMISSION)).thenReturn(true);
-		assertEquals(true, AdminVotePerms.hasEffectivePermission(sender,
-				"VotingPlugin.Commands.AdminVote.Edit.Config"));
+		assertTrue(AdminVotePerms.hasEffectivePermission(sender, "VotingPlugin.Commands.AdminVote.Edit.Config"));
+	}
+
+	@Test
+	void administratorOverrideListingMatchesSharedAuthorization() {
+		Player admin = mock(Player.class);
+		when(admin.hasPermission(AdminAuthorization.ADMIN_PERMISSION)).thenReturn(true);
+		VotingPluginMain plugin = plugin(List.of(), List.of(), 20);
+		PlayerCommandHandler handler = new PlayerCommandHandler(plugin,
+				new String[] { "User", "(player)", "SetPoints", "(number)" },
+				"VotingPlugin.Commands.AdminVote.SetPoints|" + AdminAuthorization.ADMIN_PERMISSION, "Set points") {
+			@Override
+			public void executeAll(CommandSender sender, String[] args) {
+			}
+
+			@Override
+			public void executeSinglePlayer(CommandSender sender, String[] args) {
+			}
+		}.withAllPermissionOverrides(AdminAuthorization.ADMIN_PERMISSION);
+		when(plugin.getAdminVoteCommand()).thenReturn(new ArrayList<>(List.of(handler)));
+
+		assertTrue(handler.hasAllPermission(admin));
+		String output = String.join("\n", new AdminVotePerms(plugin, admin, 1).listPerms(admin));
+		assertTrue(output.contains("VotingPlugin.Commands.AdminVote.SetPoints.All : §atrue"));
+	}
+
+	@Test
+	void disabledMultiplePermissionChecksDisableAdminAlternativeInListing() {
+		Player admin = mock(Player.class);
+		when(admin.hasPermission(AdminAuthorization.ADMIN_PERMISSION)).thenReturn(true);
+		VotingPluginMain plugin = plugin(List.of(), List.of(), 20, false);
+		PlayerCommandHandler handler = new PlayerCommandHandler(plugin, new String[] { "User", "(player)" },
+				"VotingPlugin.Commands.AdminVote.SetPoints|" + AdminAuthorization.ADMIN_PERMISSION, "Set points") {
+			@Override
+			public void executeAll(CommandSender sender, String[] args) {
+			}
+
+			@Override
+			public void executeSinglePlayer(CommandSender sender, String[] args) {
+			}
+		}.withAllPermissionOverrides(AdminAuthorization.ADMIN_PERMISSION);
+		when(plugin.getAdminVoteCommand()).thenReturn(new ArrayList<>(List.of(handler)));
+
+		assertFalse(handler.hasAllPermission(admin));
+		String output = String.join("\n", new AdminVotePerms(plugin, admin, 1).listPerms(admin));
+		assertTrue(output.contains("VotingPlugin.Commands.AdminVote.SetPoints.All : §cfalse"));
+	}
+
+	private static PlayerCommandHandler playerHandler(String helpLine, String additionalPermission) {
+		PlayerCommandHandler handler = mock(PlayerCommandHandler.class);
+		String basePermission = additionalPermission.substring(0, additionalPermission.length() - ".All".length());
+		when(handler.getPerm()).thenReturn(basePermission + "|VotingPlugin.Admin");
+		when(handler.getHelpLineCommand("/vote")).thenReturn(helpLine);
+		when(handler.getHelpLineCommand("/av")).thenReturn(helpLine);
+		when(handler.getHelpMessage()).thenReturn("Help");
+		when(handler.getAdditionalPermissions()).thenReturn(List.of(additionalPermission));
+		return handler;
+	}
+
+	private static AdminVotePerms fixture(CommandSender viewer, List<CommandHandler> vote,
+			List<CommandHandler> admin, int pageSize) {
+		return new AdminVotePerms(plugin(vote, admin, pageSize), viewer, 1);
+	}
+
+	private static VotingPluginMain plugin(List<CommandHandler> vote, List<CommandHandler> admin, int pageSize) {
+		return plugin(vote, admin, pageSize, true);
+	}
+
+	private static VotingPluginMain plugin(List<CommandHandler> vote, List<CommandHandler> admin, int pageSize,
+			boolean multiplePermissions) {
+		VotingPluginMain plugin = mock(VotingPluginMain.class);
+		Config config = mock(Config.class);
+		AdvancedCoreConfigOptions options = mock(AdvancedCoreConfigOptions.class);
+		PluginDescriptionFile description = mock(PluginDescriptionFile.class);
+		when(plugin.getVoteCommand()).thenReturn(new ArrayList<>(vote));
+		when(plugin.getAdminVoteCommand()).thenReturn(new ArrayList<>(admin));
+		when(plugin.getConfigFile()).thenReturn(config);
+		when(plugin.getOptions()).thenReturn(options);
+		when(options.isMultiplePermissionChecks()).thenReturn(multiplePermissions);
+		when(config.getFormatPageSize()).thenReturn(pageSize);
+		when(plugin.getDescription()).thenReturn(description);
+		when(description.getPermissions()).thenReturn(Collections.emptyList());
+		return plugin;
 	}
 }


### PR DESCRIPTION
## Summary
- derive /av perms bulk entries from AdvancedCore PlayerCommandHandler metadata for both /vote and /av handlers
- show each ordinary permission with a labelled additional all-target permission and effective access for the inspected player
- register bulk nodes as default-false without making them children of ordinary permissions
- preserve the negative bulk AddPoints safeguard and apply the existing administrator-override policy consistently

Examples include VotingPlugin.Commands.AdminVote.SetPoints.All, VotingPlugin.Commands.AdminVote.AddPoints.All, and VotingPlugin.Commands.AdminVote.RemovePoints.All. Base-only staff retain named-player access but require the matching .All node for bulk actions; VotingPlugin.Admin remains the configured full-admin override when multiple-permission checks are enabled.

Depends on and is coordinated with AdvancedCore #316.

## Validation
- built AdvancedCore #316 into isolated Maven repository /root/.cache/codex-m2/player-all-permissions/repository
- mvn -o -B -Dmaven.repo.local=/root/.cache/codex-m2/player-all-permissions/repository clean package (619 tests, 0 failures/errors; BUILD SUCCESS; shaded JAR)
- verified the shaded VotingPlugin JAR contains the relocated AdvancedCore PlayerCommandHandler APIs runCommand, hasAllPermission, getAdditionalPermissions, and withAllPermissionOverrides
- git diff --check
- independent final review: No findings

Coverage includes sender, named-player, console, pagination, developer output, multiple handlers, admin-policy modes, wrong/base-only permissions, dynamic registration, and negative AddPoints.

## Ordering
Merge and publish AdvancedCore #316 first, then update/build this PR against that released artifact before merging. No deployment is included.

AI assistance was used for implementation and review; the complete diff was independently source-reviewed and validated locally.

Compatibility note: the source compiles against the currently published snapshot so pre-release CI can run, but command registration fails closed at runtime if the secure AdvancedCore #316 bulk API is absent. Deployment therefore requires #316 first. Final candidate JAR SHA-256: 3988ce70ad034785a12dcfbcdd939c6857e20fbfe7f6453fd6b180a00c4cf092.