### PR TITLE
Add new vote streak best amount placeholder

### DIFF
--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/placeholders/PlaceHolders.java
@@ -434,6 +434,16 @@ public class PlaceHolders {
 			}
 		}.withDescription("Current amount for a VoteStreak ID or progress group").useStartsWith());
 
+		placeholders.add(new PlaceHolder<VotingPluginUser>("VoteStreakBestAmount_") {
+
+			@Override
+			public String placeholderRequest(VotingPluginUser user, String identifier) {
+				String target = identifier.substring("VoteStreakBestAmount_".length());
+				int amount = plugin.getVoteStreakHandler().getVoteStreakBestAmount(user, target);
+				return amount >= 0 ? Integer.toString(amount) : "invalid";
+			}
+		}.withDescription("Best amount for a VoteStreak ID or progress group").useStartsWith());
+
 		placeholders.add(new PlaceHolder<VotingPluginUser>("BestDailyVoteStreak") {
 
 			@Override

--- a/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
+++ b/VotingPlugin/src/main/java/com/bencodez/votingplugin/specialrewards/votestreak/VoteStreakHandler.java
@@ -132,9 +132,31 @@ public class VoteStreakHandler {
 		}
 	}
 
+	private int getLegacyBestStreakProgress(VotingPluginUser user, VoteStreakType type) {
+		switch (type) {
+		case DAILY:
+			return Math.max(0, user.getBestDayVoteStreak());
+		case WEEKLY:
+			return Math.max(0, user.getBestWeekVoteStreak());
+		case MONTHLY:
+			return Math.max(0, user.getBestMonthVoteStreak());
+		default:
+			return 0;
+		}
+	}
+
+	private void migrateLegacyBestProgressIfNeeded(VotingPluginUser user, VoteStreakDefinition def,
+			StreakState state) {
+		if (state.hasBestStreakCount) {
+			return;
+		}
+		state.bestStreakCount = Math.max(state.streakCount, getLegacyBestStreakProgress(user, def.getType()));
+		state.hasBestStreakCount = true;
+	}
+
 	private void migrateLegacyProgressIfNeeded(VotingPluginUser user, VoteStreakDefinition def, StreakState state,
 			String currentPeriodKey) {
-		if (state.periodKey != null && !state.periodKey.isEmpty()) {
+		if (state.hasBestStreakCount || state.periodKey != null && !state.periodKey.isEmpty()) {
 			return;
 		}
 		int legacyProgress = getLegacyStreakProgress(user, def.getType());
@@ -173,6 +195,7 @@ public class VoteStreakHandler {
 
 		final String currentPeriodKey = periodKey(progressDef.getType(), voteTimeMillis);
 		migrateLegacyProgressIfNeeded(user, progressDef, state, currentPeriodKey);
+		migrateLegacyBestProgressIfNeeded(user, progressDef, state);
 
 		plugin.extraDebug("[VoteStreak] def=" + progressDef.getId() + " idKey=" + progressDef.getId() + " type="
 				+ progressDef.getType() + " col=" + col + " progressGroup=" + progressDef.getProgressGroup()
@@ -211,6 +234,7 @@ public class VoteStreakHandler {
 			if (state.votesThisPeriod >= votesRequired) {
 				state.countedThisPeriod = true;
 				state.streakCount++;
+				state.recordBestStreakCount();
 
 				for (VoteStreakDefinition def : defs) {
 					int interval = Math.max(1, def.getRequiredAmount());
@@ -548,6 +572,16 @@ public class VoteStreakHandler {
 		return definition;
 	}
 
+	private VoteStreakDefinition getReadableStateDefinition(String target) {
+		if (target == null || target.trim().isEmpty()) {
+			return null;
+		}
+
+		String normalized = target.trim().toLowerCase(Locale.ROOT);
+		VoteStreakDefinition definition = byProgressGroup.get(normalized);
+		return definition == null ? getDefinition(normalized) : definition;
+	}
+
 	/**
 	 * Gets every definition sharing the state identified by a vote streak ID or
 	 * progress group.
@@ -581,20 +615,30 @@ public class VoteStreakHandler {
 	 * @return current streak amount, or -1 when the user or target is invalid
 	 */
 	public int getVoteStreakAmount(VotingPluginUser user, String target) {
-		if (user == null || target == null || target.trim().isEmpty()) {
-			return -1;
-		}
-
-		String normalized = target.trim().toLowerCase(Locale.ROOT);
-		VoteStreakDefinition definition = byProgressGroup.get(normalized);
-		if (definition == null) {
-			definition = getDefinition(normalized);
-		}
-		if (definition == null) {
+		VoteStreakDefinition definition = getReadableStateDefinition(target);
+		if (user == null || definition == null) {
 			return -1;
 		}
 
 		return readState(user, definition).streakCount;
+	}
+
+	/**
+	 * Gets the highest amount reached for a configured vote streak or progress
+	 * group. Milestone IDs belonging to a progress group return that group's shared
+	 * best amount.
+	 *
+	 * @param user   voting plugin user
+	 * @param target standalone streak ID, milestone ID, or progress group ID
+	 * @return best streak amount, or -1 when the user or target is invalid
+	 */
+	public int getVoteStreakBestAmount(VotingPluginUser user, String target) {
+		VoteStreakDefinition definition = getReadableStateDefinition(target);
+		if (user == null || definition == null) {
+			return -1;
+		}
+
+		return readState(user, definition).bestStreakCount;
 	}
 
 	/**
@@ -627,6 +671,7 @@ public class VoteStreakHandler {
 
 		for (int i = 0; i < amount; i++) {
 			state.streakCount++;
+			state.recordBestStreakCount();
 			for (VoteStreakDefinition definition : definitions) {
 				if (!definition.isEnabled() || !shouldReward(definition, state, sharedProgress)) {
 					continue;
@@ -658,6 +703,7 @@ public class VoteStreakHandler {
 
 		StreakState state = readState(user, definition);
 		state.streakCount = Math.max(0, amount);
+		state.recordBestStreakCount();
 		writeState(user, definition, state);
 		return true;
 	}
@@ -678,6 +724,7 @@ public class VoteStreakHandler {
 
 		StreakState state = readState(user, definition);
 		state.streakCount = Math.max(0, state.streakCount + amount);
+		state.recordBestStreakCount();
 		writeState(user, definition, state);
 		return state.streakCount;
 	}
@@ -802,6 +849,7 @@ public class VoteStreakHandler {
 				+ (definition.getProgressGroup().isEmpty() ? "none" : definition.getProgressGroup()));
 		status.add("Period: " + (state.periodKey.isEmpty() ? "not initialized" : state.periodKey));
 		status.add("Streak amount: " + state.streakCount);
+		status.add("Best streak amount: " + state.bestStreakCount);
 		status.add("Votes this period: " + state.votesThisPeriod + "/" + definition.getVotesRequired());
 		status.add("Period satisfied: " + state.countedThisPeriod);
 		status.add("Misses used: " + state.missesUsed);
@@ -846,7 +894,7 @@ public class VoteStreakHandler {
 		Set<String> resetColumns = new LinkedHashSet<>();
 		for (VoteStreakDefinition def : ordered) {
 			if (resetColumns.add(getColumnName(def))) {
-				writeStateString(user, getColumnName(def), "");
+				writeStateString(user, getColumnName(def), new StreakState().serialize());
 				reset++;
 			}
 		}
@@ -862,7 +910,7 @@ public class VoteStreakHandler {
 		Set<String> resetColumns = new LinkedHashSet<>();
 		for (VoteStreakDefinition def : ordered) {
 			if (def.getType() == type && resetColumns.add(getColumnName(def))) {
-				writeStateString(user, getColumnName(def), "");
+				writeStateString(user, getColumnName(def), new StreakState().serialize());
 				reset++;
 			}
 		}
@@ -877,7 +925,7 @@ public class VoteStreakHandler {
 		String target = id.trim().toLowerCase(Locale.ROOT);
 		VoteStreakDefinition progressGroup = byProgressGroup.get(target);
 		if (progressGroup != null) {
-			writeStateString(user, getColumnName(progressGroup), "");
+			writeStateString(user, getColumnName(progressGroup), new StreakState().serialize());
 			return true;
 		}
 
@@ -889,7 +937,7 @@ public class VoteStreakHandler {
 			return false;
 		}
 
-		writeStateString(user, getColumnName(def), "");
+		writeStateString(user, getColumnName(def), new StreakState().serialize());
 		return true;
 	}
 
@@ -937,7 +985,9 @@ public class VoteStreakHandler {
 
 	public StreakState readState(VotingPluginUser user, VoteStreakDefinition def) {
 		String raw = readStateString(user, getColumnName(def));
-		return StreakState.deserialize(raw);
+		StreakState state = StreakState.deserialize(raw);
+		migrateLegacyBestProgressIfNeeded(user, def, state);
+		return state;
 	}
 
 	public void writeState(VotingPluginUser user, VoteStreakDefinition def, StreakState state) {
@@ -976,12 +1026,15 @@ public class VoteStreakHandler {
 		String missWindowStartKey = "";
 		int missesUsed = 0;
 		Set<String> rewardedDefinitions = new LinkedHashSet<>();
+		int bestStreakCount = 0;
+		boolean hasBestStreakCount = false;
 
 		String serialize() {
+			recordBestStreakCount();
 			String base = safe(periodKey) + "|" + streakCount + "|" + votesThisPeriod + "|" + countedThisPeriod + "|"
 					+ safe(missWindowStartKey) + "|" + missesUsed;
 			String rewarded = serializeRewardedDefinitions();
-			return rewarded.isEmpty() ? base : base + "|" + rewarded;
+			return base + "|" + rewarded + "|" + bestStreakCount;
 		}
 
 		static StreakState deserialize(String raw) {
@@ -1028,6 +1081,11 @@ public class VoteStreakHandler {
 				}
 			}
 
+			if (p.length > 7) {
+				s.bestStreakCount = parseInt(p[7], 0);
+				s.hasBestStreakCount = true;
+			}
+
 			if (s.periodKey == null)
 				s.periodKey = "";
 			if (s.missWindowStartKey == null)
@@ -1038,6 +1096,8 @@ public class VoteStreakHandler {
 				s.votesThisPeriod = 0;
 			if (s.missesUsed < 0)
 				s.missesUsed = 0;
+			if (s.bestStreakCount < 0)
+				s.bestStreakCount = 0;
 
 			return s;
 		}
@@ -1048,6 +1108,11 @@ public class VoteStreakHandler {
 
 		void markRewarded(VoteStreakDefinition def) {
 			rewardedDefinitions.add(def.getId().toLowerCase(Locale.ROOT));
+		}
+
+		void recordBestStreakCount() {
+			bestStreakCount = Math.max(bestStreakCount, streakCount);
+			hasBestStreakCount = true;
 		}
 
 		private String serializeRewardedDefinitions() {

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/tests/votestreak/VoteStreakHandlerTest.java
@@ -197,7 +197,7 @@ class VoteStreakHandlerTest {
 	}
 
 	/**
-	 * periodKey|streakCount|votesThisPeriod|countedThisPeriod|missWindowStartKey|missesUsed
+	 * periodKey|streakCount|votesThisPeriod|countedThisPeriod|missWindowStartKey|missesUsed|rewardedDefinitions|bestStreakCount
 	 *
 	 * @param raw raw streak state
 	 * @return parsed state fields
@@ -210,6 +210,18 @@ class VoteStreakHandlerTest {
 		assertTrue(p.length >= 6, "expected >= 6 fields, got " + p.length + " raw=" + raw);
 
 		return p;
+	}
+
+	private static void assertResetState(String raw) {
+		String[] p = parseState(raw);
+		assertEquals("", p[0]);
+		assertEquals("0", p[1]);
+		assertEquals("0", p[2]);
+		assertEquals("false", p[3]);
+		assertEquals("", p[4]);
+		assertEquals("0", p[5]);
+		assertEquals("", p[6]);
+		assertEquals("0", p[7]);
 	}
 
 	private void loadFromRoot(ConfigurationSection root) {
@@ -302,6 +314,61 @@ class VoteStreakHandlerTest {
 
 		assertEquals(12, handler.getVoteStreakAmount(user, "continuousstreak"));
 		assertEquals(12, handler.getVoteStreakAmount(user, "Daily3"));
+	}
+
+	@Test
+	void getVoteStreakBestAmount_migratesLegacyBestWithoutLosingNewerProgress() {
+		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 1, 1, 7);
+		loadFromRoot(root);
+
+		VoteStreakDefinition definition = handler.getDefinition("DailyStreak");
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		when(user.getBestDayVoteStreak()).thenReturn(15);
+		backing.put(handler.getColumnName(definition), "2026-01-10|12|1|true||1");
+
+		assertEquals(15, handler.getVoteStreakBestAmount(user, "dailystreak"));
+		assertEquals(-1, handler.getVoteStreakBestAmount(user, "missing"));
+
+		when(user.getBestDayVoteStreak()).thenReturn(10);
+		backing.put(handler.getColumnName(definition), "2026-01-10|12|1|true||1");
+		assertEquals(12, handler.getVoteStreakBestAmount(user, "dailystreak"));
+	}
+
+	@Test
+	void getVoteStreakBestAmount_supportsProgressGroupAndMilestoneIds() {
+		MemoryConfiguration root = new MemoryConfiguration();
+		ConfigurationSection voteStreaks = root.createSection("VoteStreaks");
+		ConfigurationSection group = addProgressGroup(voteStreaks, "continuousstreak", "DAILY", 1, 1, 7);
+		addProgressGroupMilestone(group, "Daily3", 3, true, false);
+		loadFromRoot(root);
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		backing.put("VoteStreakGroup_DAILY_continuousstreak", "2026-01-10|12|1|true||1||19");
+
+		assertEquals(19, handler.getVoteStreakBestAmount(user, "continuousstreak"));
+		assertEquals(19, handler.getVoteStreakBestAmount(user, "Daily3"));
+	}
+
+	@Test
+	void setVoteStreakAmount_preservesAndRaisesBestAmount() {
+		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 1, 1, 7);
+		loadFromRoot(root);
+
+		VoteStreakDefinition definition = handler.getDefinition("DailyStreak");
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		String column = handler.getColumnName(definition);
+		backing.put(column, "2026-01-10|12|1|true||1||15");
+
+		assertTrue(handler.setVoteStreakAmount(user, "dailystreak", 5));
+		assertEquals("5", parseState(backing.get(column))[1]);
+		assertEquals("15", parseState(backing.get(column))[7]);
+
+		assertTrue(handler.setVoteStreakAmount(user, "dailystreak", 20));
+		assertEquals("20", parseState(backing.get(column))[1]);
+		assertEquals("20", parseState(backing.get(column))[7]);
 	}
 
 	@Test
@@ -561,7 +628,7 @@ class VoteStreakHandlerTest {
 
 		assertEquals(3, reset);
 		for (VoteStreakDefinition def : handler.getDefinitions()) {
-			assertEquals("", backing.get(handler.getColumnName(def)));
+			assertResetState(backing.get(handler.getColumnName(def)));
 		}
 	}
 
@@ -582,8 +649,8 @@ class VoteStreakHandlerTest {
 		int reset = handler.resetVoteStreaks(user, VoteStreakType.DAILY);
 
 		assertEquals(2, reset);
-		assertEquals("", backing.get(handler.getColumnName(daily3)));
-		assertEquals("", backing.get(handler.getColumnName(daily7)));
+		assertResetState(backing.get(handler.getColumnName(daily3)));
+		assertResetState(backing.get(handler.getColumnName(daily7)));
 		assertEquals("2026-W02|2|1|true||0", backing.get(handler.getColumnName(weekly2)));
 	}
 
@@ -600,7 +667,7 @@ class VoteStreakHandlerTest {
 		backing.put(handler.getColumnName(weekly2), "2026-W02|2|1|true||0");
 
 		assertTrue(handler.resetVoteStreak(user, "daily3"));
-		assertEquals("", backing.get(handler.getColumnName(daily3)));
+		assertResetState(backing.get(handler.getColumnName(daily3)));
 		assertEquals("2026-W02|2|1|true||0", backing.get(handler.getColumnName(weekly2)));
 	}
 
@@ -623,8 +690,22 @@ class VoteStreakHandlerTest {
 
 		assertTrue(handler.resetVoteStreak(user, "continuousstreak"));
 
-		assertEquals("", backing.get(groupCol));
+		assertResetState(backing.get(groupCol));
 		assertEquals("2026-01-10|1|1|true||0", backing.get(controlCol));
+	}
+
+	@Test
+	void resetVoteStreak_doesNotReimportLegacyBest() {
+		MemoryConfiguration root = rootWithOneStreak("DailyStreak", "DAILY", true, 5, 1, 1, 7);
+		loadFromRoot(root);
+
+		Map<String, String> backing = new HashMap<>();
+		VotingPluginUser user = mapBackedUser(UUID.randomUUID(), "Ben", backing);
+		when(user.getBestDayVoteStreak()).thenReturn(15);
+
+		assertTrue(handler.resetVoteStreak(user, "dailystreak"));
+		assertEquals(0, handler.getVoteStreakAmount(user, "dailystreak"));
+		assertEquals(0, handler.getVoteStreakBestAmount(user, "dailystreak"));
 	}
 
 	@Test


### PR DESCRIPTION
This is just more placeholder updates similar to https://github.com/BenCodez/VotingPlugin/pull/1597 but for the *best* streak amounts as the legacy placeholders are unaware of the new missed day options. While there is currently a placeholder for the current configured streak amount, there is no placeholder for the highest amount a player has reached.

This adds `%VotingPlugin_VoteStreakBestAmount_<id>%` for a streak ID or progress group. The saved best amount continues increasing with the configured streak and does not drop when the current streak resets.

For existing player data, it starts with the greater of the current configured streak or the matching legacy best streak so existing records are not lost.

Tests were added for tracking the best amount, preserving it through resets, and using existing streak values.