### PR TITLE
Reduce bundled dependency duplication

### DIFF
--- a/VotingPlugin/pom.xml
+++ b/VotingPlugin/pom.xml
@@ -70,11 +70,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.4</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
@@ -215,6 +210,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/PackagedArtifactTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>packaged-artifact-test</id>
+                        <phase>package</phase>
+                        <goals><goal>test</goal></goals>
+                        <configuration>
+                            <includes><include>**/PackagedArtifactTest.java</include></includes>
+                            <reportsDirectory>${project.build.directory}/packaged-artifact-reports</reportsDirectory>
+                            <systemPropertyVariables>
+                                <votingplugin.packagedJar>${project.build.directory}/${project.name}.jar</votingplugin.packagedJar>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -292,6 +314,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
             <version>1.21-R0.4</version>
@@ -328,6 +356,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>7.5.3</version>
+        </dependency>
+        <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.12.2</version>
@@ -338,6 +376,13 @@
             <artifactId>advancedcore</artifactId>
             <version>3.8.2-SNAPSHOT</version>
             <scope>compile</scope>
+            <!-- AdvancedCore already embeds its relocated Rhino implementation. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mozilla</groupId>
+                    <artifactId>rhino</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/VotingPlugin/pom.xml
+++ b/VotingPlugin/pom.xml
@@ -11,6 +11,7 @@
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <build.number>NOTSET</build.number>
+        <packaged.jar.name>${project.name}</packaged.jar.name>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>
@@ -192,6 +193,28 @@
                             <minimizeJar>false</minimizeJar>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
+                                <!-- Keep this PR buildable against both the current published
+                                     AdvancedCore SNAPSHOT and its coordinated slimmer successor. -->
+                                <filter>
+                                    <artifact>com.bencodez:advancedcore</artifact>
+                                    <excludes>
+                                        <exclude>org/bouncycastle/**</exclude>
+                                        <exclude>com/bencodez/simpleapi/servercomm/http/**</exclude>
+                                        <exclude>redis/clients/**</exclude>
+                                        <exclude>org/eclipse/paho/**</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.bencodez:simpleapi</artifact>
+                                    <excludes>
+                                        <exclude>org/bouncycastle/**</exclude>
+                                        <exclude>com/bencodez/simpleapi/servercomm/http/**</exclude>
+                                        <exclude>redis/clients/**</exclude>
+                                        <exclude>org/eclipse/paho/**</exclude>
+                                        <exclude>META-INF/versions/**</exclude>
+                                    </excludes>
+                                </filter>
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
@@ -231,7 +254,7 @@
                             <includes><include>**/PackagedArtifactTest.java</include></includes>
                             <reportsDirectory>${project.build.directory}/packaged-artifact-reports</reportsDirectory>
                             <systemPropertyVariables>
-                                <votingplugin.packagedJar>${project.build.directory}/${project.name}.jar</votingplugin.packagedJar>
+                                <votingplugin.packagedJar>${project.build.directory}/${packaged.jar.name}.jar</votingplugin.packagedJar>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -382,6 +405,26 @@
                     <groupId>org.mozilla</groupId>
                     <artifactId>rhino</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcutil-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.paho</groupId>
+                    <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>redis.clients</groupId>
+                    <artifactId>jedis</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -461,6 +504,7 @@
             <id>deploy-snapshot</id>
             <properties>
                 <build.profile.id>dev-snapshot</build.profile.id>
+                <packaged.jar.name>${project.name}-${build.number}</packaged.jar.name>
             </properties>
             <distributionManagement>
                 <snapshotRepository>

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/packaging/PackagedArtifactTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/packaging/PackagedArtifactTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,7 +40,7 @@ public class PackagedArtifactTest {
 
     private static Path packagedJar() {
         String configured = System.getProperty("votingplugin.packagedJar");
-        assertNotNull(configured, "Run this test through the Maven package lifecycle");
+        assumeTrue(configured != null, "Packaged artifact is available only in the package lifecycle");
         Path artifact = Path.of(configured).toAbsolutePath().normalize();
         assertTrue(Files.isRegularFile(artifact), "Missing packaged artifact: " + artifact);
         return artifact;

--- a/VotingPlugin/src/test/java/com/bencodez/votingplugin/packaging/PackagedArtifactTest.java
+++ b/VotingPlugin/src/test/java/com/bencodez/votingplugin/packaging/PackagedArtifactTest.java
@@ -1,0 +1,47 @@
+package com.bencodez.votingplugin.packaging;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+
+import org.junit.jupiter.api.Test;
+
+/** Package-phase checks for the actual downloadable plugin artifact. */
+public class PackagedArtifactTest {
+
+    @Test
+    void containsOneRelocatedRuntimeWithoutUnusedHttpCrypto() throws Exception {
+        Path artifactPath = packagedJar();
+        try (JarFile artifact = new JarFile(artifactPath.toFile())) {
+            assertNotNull(artifact.getEntry("com/bencodez/votingplugin/VotingPluginMain.class"));
+            assertNotNull(artifact.getEntry("plugin.yml"));
+            assertNotNull(artifact.getEntry(
+                    "com/bencodez/votingplugin/advancedcore/rhino/Context.class"));
+            assertNotNull(artifact.getEntry(
+                    "com/bencodez/votingplugin/simpleapi/scheduler/BukkitScheduler.class"));
+            assertNotNull(artifact.getEntry(
+                    "com/bencodez/votingplugin/simpleapi/hikari/HikariDataSource.class"));
+
+            assertNull(artifact.getEntry("org/mozilla/javascript/Context.class"));
+            assertNull(artifact.getEntry("com/zaxxer/hikari/HikariDataSource.class"));
+            assertNull(artifact.getEntry("com/tcoded/folialib/FoliaLib.class"));
+            assertFalse(artifact.stream().anyMatch(entry -> entry.getName().startsWith("org/bouncycastle/")));
+            assertFalse(artifact.stream().anyMatch(entry -> entry.getName().startsWith("META-INF/versions/25/")));
+        }
+        System.out.printf("VotingPlugin downloadable artifact: %,d bytes; duplicate Rhino and unused HTTP crypto absent%n",
+                Files.size(artifactPath));
+    }
+
+    private static Path packagedJar() {
+        String configured = System.getProperty("votingplugin.packagedJar");
+        assertNotNull(configured, "Run this test through the Maven package lifecycle");
+        Path artifact = Path.of(configured).toAbsolutePath().normalize();
+        assertTrue(Files.isRegularFile(artifact), "Missing packaged artifact: " + artifact);
+        return artifact;
+    }
+}

--- a/docs/jar-packaging.md
+++ b/docs/jar-packaging.md
@@ -1,0 +1,19 @@
+# JAR packaging contract
+
+VotingPlugin consumes the coordinated AdvancedCore artifact, whose SimpleAPI
+dependency uses the `thin` classifier. VotingPlugin directly declares the
+Jedis and Paho libraries used by its Redis and MQTT transports instead of
+receiving them accidentally through SimpleAPI. Gson is platform-supplied and is
+therefore `provided`.
+
+AdvancedCore already contains the relocated Rhino implementation needed by its
+JavaScript support, so VotingPlugin excludes the second unrelocated Rhino
+dependency. The default branch has no HTTP transport and therefore does not
+bundle Bouncy Castle. Adding HTTP transport support must explicitly own its TLS
+implementation and crypto dependencies; it must not rely on the non-HTTP
+AdvancedCore artifact to provide them.
+
+The package phase runs `PackagedArtifactTest` after shading. It opens the actual
+downloadable JAR, checks plugin resources and required relocated classes, and
+rejects duplicate Rhino, raw Hikari/Folia, unused Bouncy Castle, and unsupported
+Java 25 versioned payload. Release/deployment profiles reuse this Shade setup.

--- a/docs/jar-packaging.md
+++ b/docs/jar-packaging.md
@@ -1,10 +1,10 @@
 # JAR packaging contract
 
-VotingPlugin consumes the coordinated AdvancedCore artifact, whose SimpleAPI
-dependency uses the `thin` classifier. VotingPlugin directly declares the
-Jedis and Paho libraries used by its Redis and MQTT transports instead of
-receiving them accidentally through SimpleAPI. Gson is platform-supplied and is
-therefore `provided`.
+VotingPlugin consumes AdvancedCore's normal artifact and applies a narrow
+artifact-specific filter so both the currently published SNAPSHOT and the
+coordinated slimmer successor produce the same dependency ownership. VotingPlugin
+directly declares the Jedis and Paho libraries used by its Redis and MQTT
+transports. Gson is platform-supplied and is therefore `provided`.
 
 AdvancedCore already contains the relocated Rhino implementation needed by its
 JavaScript support, so VotingPlugin excludes the second unrelocated Rhino
@@ -16,4 +16,5 @@ AdvancedCore artifact to provide them.
 The package phase runs `PackagedArtifactTest` after shading. It opens the actual
 downloadable JAR, checks plugin resources and required relocated classes, and
 rejects duplicate Rhino, raw Hikari/Folia, unused Bouncy Castle, and unsupported
-Java 25 versioned payload. Release/deployment profiles reuse this Shade setup.
+Java 25 versioned payload. Release/deployment profiles reuse this Shade setup;
+the artifact check follows their configured JAR name.


### PR DESCRIPTION
## Summary

- make VotingPlugin explicitly own its Jedis and MQTT dependencies
- exclude the redundant raw Rhino dependency already embedded/relocated by AdvancedCore
- add a package-phase contract test against the actual downloadable JAR
- document dependency ownership and the HTTP transport boundary

## Size

- baseline: 21,823,436 bytes (20.81 MiB)
- candidate against current published upstreams: 8,575,695 bytes (8.18 MiB)
- reduction: 13,247,741 bytes (60.70%)

## Validation

- focused proxy lifecycle and Redis transport tests — 16/16 passed
- `mvn -B -Dmaven.repo.local=... -f VotingPlugin/pom.xml clean package`
  - 623 ordinary tests passed
  - packaged-artifact test passed
- candidate JAR opens successfully and contains expected plugin/resources and relocated scheduler/Hikari/Rhino classes, without a duplicate Rhino or unused BC payload
- installed upstream POMs, dependency trees, and resolved artifact hashes were inspected
- `git diff --check`
- fresh independent frozen-diff review: `No findings.`

The exact GitHub CI command passed locally from a fresh Maven repository against
the currently published AdvancedCore and SimpleAPI SNAPSHOTs. The coordinated
candidate chain also passed, so this PR is compatible before and after the
upstream size PRs merge.

The `deploy-snapshot` package profile was separately validated with a non-default
build number; its profile-specific JAR name is inspected successfully.

## HTTP dependency evaluation

The active HTTP transport branch was also built against this coordinated chain: 854/854 tests passed and its evaluated artifact fell from 22,610,080 to 19,096,202 bytes. Bouncy Castle still accounts for roughly 10.38 MB of that HTTP-enabled ZIP. A safe on-demand loader requires a separate JDK-only SPI/implementation boundary and lifecycle-safe verified cache; a child URLClassLoader cannot safely satisfy the current parent-linked types. That security/class-loading redesign is deliberately not mixed into this focused packaging PR.

No artifact was published and no deployment was performed.
