### PR TITLE
Own the optional SimpleAPI dependency

### DIFF
--- a/VotingPlugin/pom.xml
+++ b/VotingPlugin/pom.xml
@@ -427,6 +427,38 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- AdvancedCore embeds the SimpleAPI subset it uses and intentionally
+             publishes SimpleAPI as optional. VotingPlugin uses additional
+             SimpleAPI APIs, so own that input explicitly and filter its
+             self-contained optional payload during shading. -->
+        <dependency>
+            <groupId>com.bencodez</groupId>
+            <artifactId>simpleapi</artifactId>
+            <version>1.0.2-SNAPSHOT</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcutil-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.paho</groupId>
+                    <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>redis.clients</groupId>
+                    <artifactId>jedis</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/docs/jar-packaging.md
+++ b/docs/jar-packaging.md
@@ -1,10 +1,14 @@
 # JAR packaging contract
 
-VotingPlugin consumes AdvancedCore's normal artifact and applies a narrow
-artifact-specific filter so both the currently published SNAPSHOT and the
-coordinated slimmer successor produce the same dependency ownership. VotingPlugin
-directly declares the Jedis and Paho libraries used by its Redis and MQTT
-transports. Gson is platform-supplied and is therefore `provided`.
+VotingPlugin consumes AdvancedCore's normal artifact and directly declares
+SimpleAPI because it uses APIs outside the subset embedded by AdvancedCore.
+AdvancedCore publishes that embedded input as optional so downstream shaders do
+not pull the unfiltered self-contained SimpleAPI JAR back into their output.
+VotingPlugin applies narrow artifact-specific filters so both the currently
+published SNAPSHOT and the coordinated slimmer successor produce the same
+dependency ownership. It directly declares the Jedis and Paho libraries used by
+its Redis and MQTT transports. Gson is platform-supplied and is therefore
+`provided`.
 
 AdvancedCore already contains the relocated Rhino implementation needed by its
 JavaScript support, so VotingPlugin excludes the second unrelocated Rhino


### PR DESCRIPTION
## Summary

- declare SimpleAPI directly because AdvancedCore now embeds only its required subset and publishes the original dependency as optional
- retain VotingPlugin's existing artifact filters and explicit Redis/MQTT dependency ownership
- document the corrected downstream packaging contract

This is the focused publication follow-up to merged VotingPlugin #1606 and AdvancedCore #323.

## Validation

- AdvancedCore candidate `clean install`: 332 tests plus packaged-artifact test passed
- VotingPlugin candidate `clean package`: 623 tests plus packaged-artifact test passed against the exact installed AdvancedCore POM
- minimal AdvancedCore-only consumer dependency tree contains AdvancedCore but not SimpleAPI
- VotingPlugin dependency tree contains explicit AdvancedCore and SimpleAPI inputs
- downloadable JAR opens successfully: 8,577,110 bytes, SHA-256 `83ca8a51c4b5f1faaa438f5ad3459e68b93bf54a723277ad9f49d0036af0fd81`
- packaged contract confirms duplicate Rhino and unused HTTP crypto remain absent
- `git diff --check`
- fresh independent frozen-diff review: `No findings.`

No artifact was published and no deployment was performed.
